### PR TITLE
Adding missed changes for empty symbol support

### DIFF
--- a/src/software/amazon/ion/impl/IonWriterSystem.java
+++ b/src/software/amazon/ion/impl/IonWriterSystem.java
@@ -342,7 +342,7 @@ abstract class IonWriterSystem
         if (_field_name_type != null) {
             switch (_field_name_type) {
             case STRING:
-                return _field_name != null && _field_name.length() > 0;
+                return _field_name != null;
             case INT:
                 return _field_name_sid > 0;
             default:

--- a/test/software/amazon/ion/SystemProcessingTestCase.java
+++ b/test/software/amazon/ion/SystemProcessingTestCase.java
@@ -1163,7 +1163,6 @@ public abstract class SystemProcessingTestCase
         checkLocalSymtabWithMalformedSymbolEntry("0.123");                      // decimal
         checkLocalSymtabWithMalformedSymbolEntry("-0.12e4");                    // float
         checkLocalSymtabWithMalformedSymbolEntry("2013-05-09");                 // timestamp
-        checkLocalSymtabWithMalformedSymbolEntry("\"\"");                       // empty string
         checkLocalSymtabWithMalformedSymbolEntry("a_symbol");                   // symbol
         checkLocalSymtabWithMalformedSymbolEntry("{{MTIz}}");                   // blob
         checkLocalSymtabWithMalformedSymbolEntry("{{'''clob_content'''}}");     // clob


### PR DESCRIPTION
One is an ignored for malformed symbols, "" is valid so should not be
there

Another is part of the writer. Since it was not caught by any UT it
could be dead code, will investigate marking it as deprecated and
potentially removing as a separate task

https://github.com/amzn/ion-java/issues/42