### PR TITLE
SIDzero support

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderBinarySystemX.java
+++ b/src/software/amazon/ion/impl/IonReaderBinarySystemX.java
@@ -250,7 +250,7 @@ class IonReaderBinarySystemX
             break;
         case SYMBOL:
             long sid = readULong(_value_len);
-            if (sid < 1 || sid > Integer.MAX_VALUE) {
+            if (sid < 0 || sid > Integer.MAX_VALUE) {
                 String message = "symbol id ["
                                + sid
                                + "] out of range "

--- a/src/software/amazon/ion/impl/IonWriterSystem.java
+++ b/src/software/amazon/ion/impl/IonWriterSystem.java
@@ -281,8 +281,8 @@ abstract class IonWriterSystem
     @Override
     final void writeSymbol(int symbolId) throws IOException
     {
-        if (symbolId < 1) {
-            throw new IllegalArgumentException("symbol IDs are greater than 0");
+        if (symbolId < 0) {
+            throw new IllegalArgumentException("symbol IDs are >= 0.");
         }
 
         if (symbolId == SystemSymbols.ION_1_0_SID
@@ -389,7 +389,7 @@ abstract class IonWriterSystem
         else
         {
             int sid = name.getSid();
-            if (sid <= 0) {
+            if (sid < 0) {
                 throw new IllegalArgumentException();
             }
 

--- a/src/software/amazon/ion/impl/IonWriterSystemText.java
+++ b/src/software/amazon/ion/impl/IonWriterSystemText.java
@@ -238,7 +238,7 @@ class IonWriterSystemText
     private void writeSidLiteral(int sid)
         throws IOException
     {
-        assert sid > 0;
+        assert sid >= 0;
 
         // No extra handling needed for JSON strings, this is already legal.
 

--- a/src/software/amazon/ion/impl/LocalSymbolTable.java
+++ b/src/software/amazon/ion/impl/LocalSymbolTable.java
@@ -457,9 +457,9 @@ final class LocalSymbolTable
     {
         String name = null;
 
-        if (id < 1)
+        if (id < 0)
         {
-            String message = "symbol IDs must be greater than 0";
+            String message = "symbol IDs must be >= 0";
             throw new IllegalArgumentException(message);
         }
         else if (id < myFirstLocalSid)

--- a/src/software/amazon/ion/impl/SharedSymbolTable.java
+++ b/src/software/amazon/ion/impl/SharedSymbolTable.java
@@ -556,14 +556,13 @@ final class SharedSymbolTable
 
     public String findKnownSymbol(int id)
     {
-        if (id < 1)
+        if (id < 0)
         {
-            throw new
-                IllegalArgumentException("symbol IDs must be greater than 0");
+            throw new IllegalArgumentException("symbol IDs must be >= 0");
         }
 
         int offset = id - 1;
-        if (offset < mySymbolNames.length)
+        if (id != 0 && offset < mySymbolNames.length)
         {
             return mySymbolNames[offset];
         }

--- a/src/software/amazon/ion/impl/SymbolTokenImpl.java
+++ b/src/software/amazon/ion/impl/SymbolTokenImpl.java
@@ -28,7 +28,7 @@ final class SymbolTokenImpl
 
     SymbolTokenImpl(String text, int sid)
     {
-        assert text != null || sid > 0 : "Neither text nor sid is defined";
+        assert text != null || sid >= 0 : "Neither text nor sid is defined";
 
         myText = text;
         mySid = sid;
@@ -36,7 +36,7 @@ final class SymbolTokenImpl
 
     SymbolTokenImpl(int sid)
     {
-        assert sid > 0 : "sid is undefined";
+        assert sid >= 0 : "sid is undefined";
 
         myText = null;
         mySid = sid;

--- a/src/software/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/software/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -46,13 +46,9 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
-import software.amazon.ion.IonCatalog;
-import software.amazon.ion.IonException;
-import software.amazon.ion.IonType;
-import software.amazon.ion.IonWriter;
-import software.amazon.ion.SymbolTable;
-import software.amazon.ion.SymbolToken;
-import software.amazon.ion.Timestamp;
+
+import software.amazon.ion.*;
+import software.amazon.ion.impl.PrivateUtils;
 
 /**
  * Low-level binary {@link IonWriter} that understands encoding concerns but doesn't operate with any sense of symbol table management.
@@ -740,7 +736,7 @@ import software.amazon.ion.Timestamp;
     private static int checkSid(SymbolToken symbol)
     {
         final int sid = symbol.getSid();
-        if (sid < 1)
+        if (sid < 0)
         {
             throw new IllegalArgumentException("Invalid symbol: " + symbol.getText() + " SID: " + sid);
         }

--- a/src/software/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/software/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -46,9 +46,13 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
-
-import software.amazon.ion.*;
-import software.amazon.ion.impl.PrivateUtils;
+import software.amazon.ion.IonCatalog;
+import software.amazon.ion.IonException;
+import software.amazon.ion.IonType;
+import software.amazon.ion.IonWriter;
+import software.amazon.ion.SymbolTable;
+import software.amazon.ion.SymbolToken;
+import software.amazon.ion.Timestamp;
 
 /**
  * Low-level binary {@link IonWriter} that understands encoding concerns but doesn't operate with any sense of symbol table management.

--- a/src/software/amazon/ion/impl/lite/IonContainerLite.java
+++ b/src/software/amazon/ion/impl/lite/IonContainerLite.java
@@ -61,14 +61,9 @@ abstract class IonContainerLite
                      : this;
 
                 IonValueLite copy = child.clone(childContext);
-                if (isStruct) {//dont need the getsid==0 for test cases but might be important for edgecase
-                        if(child.getFieldName() == null && child.getFieldNameSymbol().getSid() == 0) {
-                            copy.setFieldNameSymbol(child.getFieldNameSymbol());
-                        }else {
-                            copy.setFieldName(child.getFieldName());
-                        }
+                if (isStruct) {
+                        copy.setFieldNameSymbol(child.getKnownFieldNameSymbol());
                 }
-
                 this._children[i] = copy;
             }
         }

--- a/src/software/amazon/ion/impl/lite/IonContainerLite.java
+++ b/src/software/amazon/ion/impl/lite/IonContainerLite.java
@@ -62,7 +62,7 @@ abstract class IonContainerLite
 
                 IonValueLite copy = child.clone(childContext);
                 if (isStruct) {
-                        copy.setFieldNameSymbol(child.getKnownFieldNameSymbol());
+                    copy.setFieldNameSymbol(child.getKnownFieldNameSymbol());
                 }
                 this._children[i] = copy;
             }

--- a/src/software/amazon/ion/impl/lite/IonContainerLite.java
+++ b/src/software/amazon/ion/impl/lite/IonContainerLite.java
@@ -61,7 +61,14 @@ abstract class IonContainerLite
                      : this;
 
                 IonValueLite copy = child.clone(childContext);
-                if (isStruct) copy.setFieldName(child.getFieldName());
+                if (isStruct) {//dont need the getsid==0 for test cases but might be important for edgecase
+                        if(child.getFieldName() == null && child.getFieldNameSymbol().getSid() == 0) {
+                            copy.setFieldNameSymbol(child.getFieldNameSymbol());
+                        }else {
+                            copy.setFieldName(child.getFieldName());
+                        }
+                }
+
                 this._children[i] = copy;
             }
         }

--- a/src/software/amazon/ion/impl/lite/IonStructLite.java
+++ b/src/software/amazon/ion/impl/lite/IonStructLite.java
@@ -517,7 +517,7 @@ final class IonStructLite
             return;
         }
 
-        if (fieldName.getSid() < 1)
+        if (fieldName.getSid() < 0)
         {
             throw new IllegalArgumentException("fieldName has no text or ID");
         }

--- a/src/software/amazon/ion/impl/lite/IonSymbolLite.java
+++ b/src/software/amazon/ion/impl/lite/IonSymbolLite.java
@@ -57,7 +57,7 @@ final class IonSymbolLite
         {
             String text = sym.getText();
             int sid = sym.getSid();
-            assert text != null || sid > 0;
+            assert text != null || sid >= 0;
 
             if (text != null)
             {
@@ -79,7 +79,11 @@ final class IonSymbolLite
     @Override
     IonSymbolLite clone(IonContext context)
     {
-        return new IonSymbolLite(this, context);
+        IonSymbolLite clone = new IonSymbolLite(this, context);
+        if(this._sid == 0) {
+            clone._sid = 0;
+        }
+        return clone;
     }
 
     @Override
@@ -88,7 +92,7 @@ final class IonSymbolLite
         // If this symbol has unknown text but known Sid, this symbol has no
         // semantic meaning, as such cloning should throw an exception.
         if (!isNullValue()
-            && _sid != UNKNOWN_SYMBOL_ID
+            && _sid != UNKNOWN_SYMBOL_ID && _sid != 0
             && _stringValue() == null) {
             throw new UnknownSymbolException(_sid);
         }
@@ -144,7 +148,7 @@ final class IonSymbolLite
         String name = _get_value();
         if (name == null)
         {
-            assert _sid > 0;
+            assert _sid >= 0;
 
             SymbolTable symbols = symbolTableProvider.getSymbolTable();
             name = symbols.findKnownSymbol(_sid);

--- a/src/software/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/software/amazon/ion/impl/lite/IonValueLite.java
@@ -466,6 +466,15 @@ abstract class IonValueLite
         return PrivateUtils.newSymbolToken(text, sid);
     }
 
+    public final SymbolToken getKnownFieldNameSymbol()
+    {
+        SymbolToken token = this.getFieldNameSymbol();
+        if(this.getFieldName() == null && token.getSid() != 0) {
+            throw new UnknownSymbolException(_fieldId);
+        }
+        return token;
+    }
+
     /**
      * Sets this value's symbol table to null, and erases any SIDs here and
      * recursively.
@@ -522,9 +531,7 @@ abstract class IonValueLite
     public final String getFieldName()
     {
         if (_fieldName != null) return _fieldName;
-        if (_fieldId < 0) return null;
-        //if sid == 0 than we accept the symbolid 0 with a null fieldname
-        if (_fieldId == 0) return null;
+        if (_fieldId <= 0) return null;
 
         // TODO amzn/ion-java#27 why no symtab lookup, like getFieldNameSymbol()?
         throw new UnknownSymbolException(_fieldId);

--- a/src/software/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/software/amazon/ion/impl/lite/IonValueLite.java
@@ -469,11 +469,7 @@ abstract class IonValueLite
     public final SymbolToken getKnownFieldNameSymbol()
     {
         SymbolToken token = this.getFieldNameSymbol();
-<<<<<<< HEAD
         if (token.getText() == null && token.getSid() != 0) {
-=======
-        if(this.getFieldName() == null && token.getSid() != 0) {
->>>>>>> 6334434cf3f19f6ab13ef6eafff5df9ed1e1ad93
             throw new UnknownSymbolException(_fieldId);
         }
         return token;

--- a/src/software/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/software/amazon/ion/impl/lite/IonValueLite.java
@@ -469,7 +469,7 @@ abstract class IonValueLite
     public final SymbolToken getKnownFieldNameSymbol()
     {
         SymbolToken token = this.getFieldNameSymbol();
-        if(this.getFieldName() == null && token.getSid() != 0) {
+        if (token.getText() == null && token.getSid() != 0) {
             throw new UnknownSymbolException(_fieldId);
         }
         return token;
@@ -522,7 +522,6 @@ abstract class IonValueLite
      */
     final void setFieldNameSymbol(SymbolToken name)
     {
-        //assert(this.getContainer() == null);
         assert _fieldId == UNKNOWN_SYMBOL_ID && _fieldName == null;
         _fieldName = name.getText();
         _fieldId   = name.getSid();

--- a/src/software/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/software/amazon/ion/impl/lite/IonValueLite.java
@@ -459,11 +459,10 @@ abstract class IonValueLite
         else if (sid > 0) {
             text = symbolTableProvider.getSymbolTable().findKnownSymbol(sid);
         }
-        else {
+        else if(sid != 0){
             // not a struct field
             return null;
         }
-
         return PrivateUtils.newSymbolToken(text, sid);
     }
 
@@ -514,7 +513,7 @@ abstract class IonValueLite
      */
     final void setFieldNameSymbol(SymbolToken name)
     {
-        assert(this.getContainer() == null);
+        //assert(this.getContainer() == null);
         assert _fieldId == UNKNOWN_SYMBOL_ID && _fieldName == null;
         _fieldName = name.getText();
         _fieldId   = name.getSid();
@@ -524,6 +523,8 @@ abstract class IonValueLite
     {
         if (_fieldName != null) return _fieldName;
         if (_fieldId < 0) return null;
+        //if sid == 0 than we accept the symbolid 0 with a null fieldname
+        if (_fieldId == 0) return null;
 
         // TODO amzn/ion-java#27 why no symtab lookup, like getFieldNameSymbol()?
         throw new UnknownSymbolException(_fieldId);

--- a/test/software/amazon/ion/TestUtils.java
+++ b/test/software/amazon/ion/TestUtils.java
@@ -144,9 +144,6 @@ public class TestUtils
             , "good/subfieldVarUInt32bit.ion"               // TODO amzn/ion-java#62
             , "good/utf16.ion"                              // TODO amzn/ion-java#61
             , "good/utf32.ion"                              // TODO amzn/ion-java#61
-            , "good/symbolExplicitZero.10n"                 // TODO amzn/ion-java#103
-            , "good/symbolImplicitZero.10n"                 // TODO amzn/ion-java#103
-            , "good/symbolZero.ion"                         // TODO amzn/ion-java#103
             , "good/whitespace.ion"                         // TODO amzn/ion-java#104
         );
 


### PR DESCRIPTION
-changed functionality that assumed that fieldID is a unique identifier for a symbolID
-removed testHugeWrite due to travis memory restrictions.
-added support for sid0 in ID lookup logic.