### PR TITLE
Roundtrip equivalence

### DIFF
--- a/test/software/amazon/ion/EquivTimelineTest.java
+++ b/test/software/amazon/ion/EquivTimelineTest.java
@@ -19,6 +19,8 @@ import static software.amazon.ion.TestUtils.GLOBAL_SKIP_LIST;
 import static software.amazon.ion.TestUtils.testdataFiles;
 
 import java.io.File;
+import java.io.IOException;
+
 import software.amazon.ion.IonTimestamp;
 import software.amazon.ion.IonValue;
 import software.amazon.ion.Timestamp;
@@ -50,5 +52,20 @@ public class EquivTimelineTest
         assertEquals("millis", lTime.getMillis(), rTime.getMillis());
         assertEquals("calendar", lTime.calendarValue(), rTime.calendarValue());
         assertEquals("date", lTime.dateValue(), rTime.dateValue());
+    }
+
+    @Override
+    public void roundTripEquivalence(IonDatagram input, boolean myExpectedEquality) throws IOException {
+        IonDatagram[] data = roundTripDatagram(input);
+        for(int i = 0; i < data.length - 1; i++){
+            runEquivalenceChecks(data[i], myExpectedEquality);
+            for(int j = i + 1; j < data.length; j++) {
+                for(int sexpIndice = 0; sexpIndice < data[i].size(); sexpIndice++) {
+                    for(int timestampIndice = 0; timestampIndice < ((IonSexp)data[i].get(sexpIndice)).size(); timestampIndice++) {
+                        checkEquivalence(((IonSexp)(data[i].get(sexpIndice))).get(timestampIndice), ((IonSexp)(data[j].get(sexpIndice))).get(timestampIndice), true);
+                    }
+                }
+            }
+        }
     }
 }

--- a/test/software/amazon/ion/EquivTimelineTest.java
+++ b/test/software/amazon/ion/EquivTimelineTest.java
@@ -60,11 +60,11 @@ public class EquivTimelineTest
         for(int i = 0; i < data.length; i++) {
             runEquivalenceChecks(data[i], myExpectedEquality);
             for(int j = i + 1; j < data.length; j++) {
-                for(int sexpIndice = 0; sexpIndice < data[i].size(); sexpIndice++) {
-                    int maxTimeStampIndice = ((IonSexp)data[i].get(sexpIndice)).size();
+                for(int seqIndice = 0; seqIndice < data[i].size(); seqIndice++) {
+                    int maxTimeStampIndice = ((IonSequence)data[i].get(seqIndice)).size();
                     for(int timeStampIndice = 0; timeStampIndice < maxTimeStampIndice; timeStampIndice++) {
-                        IonValue timeStamp1 = ((IonSexp)(data[i].get(sexpIndice))).get(timeStampIndice);
-                        IonValue timeStamp2 = ((IonSexp)(data[j].get(sexpIndice))).get(timeStampIndice);
+                        IonValue timeStamp1 = ((IonSequence)(data[i].get(seqIndice))).get(timeStampIndice);
+                        IonValue timeStamp2 = ((IonSequence)(data[j].get(seqIndice))).get(timeStampIndice);
                         checkEquivalence(timeStamp1, timeStamp2, true);
                     }
                 }

--- a/test/software/amazon/ion/EquivTimelineTest.java
+++ b/test/software/amazon/ion/EquivTimelineTest.java
@@ -57,12 +57,15 @@ public class EquivTimelineTest
     @Override
     public void roundTripEquivalence(IonDatagram input, boolean myExpectedEquality) throws IOException {
         IonDatagram[] data = roundTripDatagram(input);
-        for(int i = 0; i < data.length - 1; i++){
+        for(int i = 0; i < data.length; i++) {
             runEquivalenceChecks(data[i], myExpectedEquality);
             for(int j = i + 1; j < data.length; j++) {
                 for(int sexpIndice = 0; sexpIndice < data[i].size(); sexpIndice++) {
-                    for(int timestampIndice = 0; timestampIndice < ((IonSexp)data[i].get(sexpIndice)).size(); timestampIndice++) {
-                        checkEquivalence(((IonSexp)(data[i].get(sexpIndice))).get(timestampIndice), ((IonSexp)(data[j].get(sexpIndice))).get(timestampIndice), true);
+                    int maxTimeStampIndice = ((IonSexp)data[i].get(sexpIndice)).size();
+                    for(int timeStampIndice = 0; timeStampIndice < maxTimeStampIndice; timeStampIndice++) {
+                        IonValue timeStamp1 = ((IonSexp)(data[i].get(sexpIndice))).get(timeStampIndice);
+                        IonValue timeStamp2 = ((IonSexp)(data[j].get(sexpIndice))).get(timeStampIndice);
+                        checkEquivalence(timeStamp1, timeStamp2, true);
                     }
                 }
             }

--- a/test/software/amazon/ion/EquivsTestCase.java
+++ b/test/software/amazon/ion/EquivsTestCase.java
@@ -192,23 +192,27 @@ public class EquivsTestCase
     }
 
     public static IonDatagram[] roundTripDatagram(IonDatagram input) throws IOException{
-        IonSystem system = IonSystemBuilder.standard().build();
-        IonLoader loader = system.getLoader();
-        ByteArrayOutputStream textOutputStream = new ByteArrayOutputStream();
-        ByteArrayOutputStream binaryOutputStream = new ByteArrayOutputStream();
-        IonWriter textWriter = IonTextWriterBuilder.standard().build(textOutputStream);
-        IonWriter binaryWriter = IonBinaryWriterBuilder.standard().build(binaryOutputStream);
-        IonReader reader = system.newReader(input);
-        textWriter.writeValues(reader);
-        textWriter.close();
-        reader = system.newReader(input);
-        binaryWriter.writeValues(reader);
-        binaryWriter.close();
-        IonDatagram[] data = new IonDatagram[3];
-        data[0] = input;
-        data[1] = loader.load(new ByteArrayInputStream(textOutputStream.toByteArray()));
-        data[2] = loader.load(new ByteArrayInputStream(binaryOutputStream.toByteArray()));
-        return data;
+
+            IonSystem system = IonSystemBuilder.standard().build();
+            IonLoader loader = system.getLoader();
+            ByteArrayOutputStream textOutputStream = new ByteArrayOutputStream();
+            ByteArrayOutputStream binaryOutputStream = new ByteArrayOutputStream();
+            IonWriter textWriter = IonTextWriterBuilder.standard().build(textOutputStream);
+            IonWriter binaryWriter = IonBinaryWriterBuilder.standard().build(binaryOutputStream);
+            try {
+                IonReader reader = system.newReader(input);
+                textWriter.writeValues(reader);
+                reader = system.newReader(input);
+                binaryWriter.writeValues(reader);
+                IonDatagram[] data = new IonDatagram[3];
+                data[0] = input;
+                data[1] = loader.load(new ByteArrayInputStream(textOutputStream.toByteArray()));
+                data[2] = loader.load(new ByteArrayInputStream(binaryOutputStream.toByteArray()));
+                return data;
+            } finally {
+                textWriter.close();
+                binaryWriter.close();
+            }
     }
 
     public void roundTripEquivalence(IonDatagram input, boolean myExpectedEquality) throws IOException {

--- a/test/software/amazon/ion/EquivsTestCase.java
+++ b/test/software/amazon/ion/EquivsTestCase.java
@@ -108,7 +108,6 @@ public class EquivsTestCase
             {
                 for (int i = 0; i < sequenceSize; i++)
                 {
-
                     IonValue thisValue = sequence.get(i);
                     if (embeddedDocuments)
                     {
@@ -180,8 +179,7 @@ public class EquivsTestCase
             IonAssert.assertIonEquals(right, left);
 
             // IonDatagram's hashCode() is unsupported
-            if (left.getType() != DATAGRAM &&
-                    right.getType() != DATAGRAM)
+            if (left.getType() != DATAGRAM && right.getType() != DATAGRAM)
                 assertEquals("Equal values have unequal hashes",
                         left.hashCode(), right.hashCode());
         }
@@ -225,9 +223,9 @@ public class EquivsTestCase
 
     public void roundTripEquivalence(IonDatagram input, boolean myExpectedEquality) throws IOException {
         IonDatagram[] data = roundTripDatagram(input);
-        for(int i = 0; i < data.length - 1; i++){
+        for(int i = 0; i < data.length; i++){
             runEquivalenceChecks(data[i], myExpectedEquality);
-            checkEquivalence(data[i], data[i + 1], true);
+            checkEquivalence(data[i], data[((i + 1) % data.length)], true);
         }
     }
 

--- a/test/software/amazon/ion/EquivsTestCase.java
+++ b/test/software/amazon/ion/EquivsTestCase.java
@@ -172,8 +172,10 @@ public class EquivsTestCase
      */
     protected void checkEquivalence(final IonValue left,
                                     final IonValue right,
-                                    boolean expectedEquality) {
-        if (expectedEquality) {
+                                    boolean expectedEquality)
+    {
+        if (expectedEquality)
+        {
             IonAssert.assertIonEquals(left, right);
             IonAssert.assertIonEquals(right, left);
 
@@ -182,7 +184,9 @@ public class EquivsTestCase
                     right.getType() != DATAGRAM)
                 assertEquals("Equal values have unequal hashes",
                         left.hashCode(), right.hashCode());
-        } else {
+        }
+        else
+        {
             // Ensure the two values compared both ways return the same consistent
             // result, i.e. false. This is not related to the symmetric property
             // of equalities.
@@ -191,23 +195,27 @@ public class EquivsTestCase
         }
     }
 
-    public static IonDatagram[] roundTripDatagram(IonDatagram input) throws IOException{
+    public static IonDatagram[] roundTripDatagram(IonDatagram input) throws IOException {
         IonSystem system = IonSystemBuilder.standard().build();
         IonLoader loader = system.getLoader();
         ByteArrayOutputStream textOutputStream = new ByteArrayOutputStream();
         ByteArrayOutputStream binaryOutputStream = new ByteArrayOutputStream();
-        IonWriter textWriter = IonTextWriterBuilder.standard().build(textOutputStream);
-        IonWriter binaryWriter = IonBinaryWriterBuilder.standard().build(binaryOutputStream);
+        IonReader textReader = null, binaryReader = null;
+        IonWriter textWriter = null, binaryWriter = null;
         IonDatagram[] data = new IonDatagram[3];
-        try {
-            IonReader reader = system.newReader(input);
-            textWriter.writeValues(reader);
-            reader = system.newReader(input);
-            binaryWriter.writeValues(reader);
 
+        try {
+            textReader = system.newReader(input);
+            textWriter = IonTextWriterBuilder.standard().build(textOutputStream);
+            textWriter.writeValues(textReader);
+            binaryWriter = IonBinaryWriterBuilder.standard().build(binaryOutputStream);
+            binaryReader = system.newReader(input);
+            binaryWriter.writeValues(binaryReader);
         } finally {
             textWriter.close();
             binaryWriter.close();
+            textReader.close();
+            binaryReader.close();
         }
         data[0] = input;
         data[1] = loader.load(new ByteArrayInputStream(textOutputStream.toByteArray()));

--- a/test/software/amazon/ion/EquivsTestCase.java
+++ b/test/software/amazon/ion/EquivsTestCase.java
@@ -192,28 +192,27 @@ public class EquivsTestCase
     }
 
     public static IonDatagram[] roundTripDatagram(IonDatagram input) throws IOException{
+        IonSystem system = IonSystemBuilder.standard().build();
+        IonLoader loader = system.getLoader();
+        ByteArrayOutputStream textOutputStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream binaryOutputStream = new ByteArrayOutputStream();
+        IonWriter textWriter = IonTextWriterBuilder.standard().build(textOutputStream);
+        IonWriter binaryWriter = IonBinaryWriterBuilder.standard().build(binaryOutputStream);
+        IonDatagram[] data = new IonDatagram[3];
+        try {
+            IonReader reader = system.newReader(input);
+            textWriter.writeValues(reader);
+            reader = system.newReader(input);
+            binaryWriter.writeValues(reader);
 
-            IonSystem system = IonSystemBuilder.standard().build();
-            IonLoader loader = system.getLoader();
-            ByteArrayOutputStream textOutputStream = new ByteArrayOutputStream();
-            ByteArrayOutputStream binaryOutputStream = new ByteArrayOutputStream();
-            IonWriter textWriter = IonTextWriterBuilder.standard().build(textOutputStream);
-            IonWriter binaryWriter = IonBinaryWriterBuilder.standard().build(binaryOutputStream);
-            IonDatagram[] data = new IonDatagram[3];
-            try {
-                IonReader reader = system.newReader(input);
-                textWriter.writeValues(reader);
-                reader = system.newReader(input);
-                binaryWriter.writeValues(reader);
-
-                data[0] = input;
-                data[1] = loader.load(new ByteArrayInputStream(textOutputStream.toByteArray()));
-                data[2] = loader.load(new ByteArrayInputStream(binaryOutputStream.toByteArray()));
-            } finally {
-                textWriter.close();
-                binaryWriter.close();
-            }
-                return data;
+        } finally {
+            textWriter.close();
+            binaryWriter.close();
+        }
+        data[0] = input;
+        data[1] = loader.load(new ByteArrayInputStream(textOutputStream.toByteArray()));
+        data[2] = loader.load(new ByteArrayInputStream(binaryOutputStream.toByteArray()));
+        return data;
     }
 
     public void roundTripEquivalence(IonDatagram input, boolean myExpectedEquality) throws IOException {

--- a/test/software/amazon/ion/EquivsTestCase.java
+++ b/test/software/amazon/ion/EquivsTestCase.java
@@ -172,21 +172,17 @@ public class EquivsTestCase
      */
     protected void checkEquivalence(final IonValue left,
                                     final IonValue right,
-                                    boolean expectedEquality)
-    {
-        if (expectedEquality)
-        {
+                                    boolean expectedEquality) {
+        if (expectedEquality) {
             IonAssert.assertIonEquals(left, right);
             IonAssert.assertIonEquals(right, left);
 
             // IonDatagram's hashCode() is unsupported
-            if (left.getType()  != DATAGRAM &&
-                right.getType() != DATAGRAM)
+            if (left.getType() != DATAGRAM &&
+                    right.getType() != DATAGRAM)
                 assertEquals("Equal values have unequal hashes",
-                             left.hashCode(), right.hashCode());
-        }
-        else
-        {
+                        left.hashCode(), right.hashCode());
+        } else {
             // Ensure the two values compared both ways return the same consistent
             // result, i.e. false. This is not related to the symmetric property
             // of equalities.
@@ -215,11 +211,12 @@ public class EquivsTestCase
         return data;
     }
 
-    public static void roundTripEquivalence(IonDatagram input) throws IOException {
+    public void roundTripEquivalence(IonDatagram input, boolean myExpectedEquality) throws IOException {
         IonDatagram[] data = roundTripDatagram(input);
-        IonAssert.assertIonEquals(data[0], data[1]);
-        IonAssert.assertIonEquals(data[2], data[0]);
-        IonAssert.assertIonEquals(data[1], data[2]);
+        for(int i = 0; i < data.length - 1; i++){
+            runEquivalenceChecks(data[i], myExpectedEquality);
+            checkEquivalence(data[i], data[i + 1], true);
+        }
     }
 
     @Test
@@ -228,7 +225,7 @@ public class EquivsTestCase
     {
         IonDatagram dg = loader().load(myTestFile);
         runEquivalenceChecks(dg, myExpectedEquality);
-        roundTripEquivalence(dg);
+        roundTripEquivalence(dg, myExpectedEquality);
     }
 
     @Test

--- a/test/software/amazon/ion/EquivsTestCase.java
+++ b/test/software/amazon/ion/EquivsTestCase.java
@@ -179,9 +179,10 @@ public class EquivsTestCase
             IonAssert.assertIonEquals(right, left);
 
             // IonDatagram's hashCode() is unsupported
-            if (left.getType() != DATAGRAM && right.getType() != DATAGRAM)
+            if (left.getType() != DATAGRAM &&
+                right.getType() != DATAGRAM)
                 assertEquals("Equal values have unequal hashes",
-                        left.hashCode(), right.hashCode());
+                             left.hashCode(), right.hashCode());
         }
         else
         {

--- a/test/software/amazon/ion/EquivsTestCase.java
+++ b/test/software/amazon/ion/EquivsTestCase.java
@@ -108,6 +108,7 @@ public class EquivsTestCase
             {
                 for (int i = 0; i < sequenceSize; i++)
                 {
+
                     IonValue thisValue = sequence.get(i);
                     if (embeddedDocuments)
                     {
@@ -179,7 +180,8 @@ public class EquivsTestCase
             IonAssert.assertIonEquals(right, left);
 
             // IonDatagram's hashCode() is unsupported
-            if (left.getType() != DATAGRAM && right.getType() != DATAGRAM)
+            if (left.getType() != DATAGRAM &&
+                    right.getType() != DATAGRAM)
                 assertEquals("Equal values have unequal hashes",
                         left.hashCode(), right.hashCode());
         }
@@ -223,9 +225,9 @@ public class EquivsTestCase
 
     public void roundTripEquivalence(IonDatagram input, boolean myExpectedEquality) throws IOException {
         IonDatagram[] data = roundTripDatagram(input);
-        for(int i = 0; i < data.length; i++){
+        for(int i = 0; i < data.length - 1; i++){
             runEquivalenceChecks(data[i], myExpectedEquality);
-            checkEquivalence(data[i], data[((i + 1) % data.length)], true);
+            checkEquivalence(data[i], data[i + 1], true);
         }
     }
 

--- a/test/software/amazon/ion/EquivsTestCase.java
+++ b/test/software/amazon/ion/EquivsTestCase.java
@@ -30,6 +30,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashSet;
 
 public class EquivsTestCase
     extends IonTestCase
@@ -194,7 +195,7 @@ public class EquivsTestCase
         }
     }
 
-    protected void roundTripEquivalence(IonDatagram input, boolean myExpectedEquality) throws IOException {
+    public static IonDatagram[] roundTripDatagram(IonDatagram input) throws IOException{
         IonSystem system = IonSystemBuilder.standard().build();
         IonLoader loader = system.getLoader();
         ByteArrayOutputStream textOutputStream = new ByteArrayOutputStream();
@@ -207,13 +208,18 @@ public class EquivsTestCase
         reader = system.newReader(input);
         binaryWriter.writeValues(reader);
         binaryWriter.close();
-        IonDatagram text = loader.load(new ByteArrayInputStream(textOutputStream.toByteArray()));
-        IonDatagram binary = loader.load(new ByteArrayInputStream(binaryOutputStream.toByteArray()));
-        runEquivalenceChecks(text, myExpectedEquality);
-        runEquivalenceChecks(binary, myExpectedEquality);
-        checkEquivalence(input, text, true);
-        checkEquivalence(text, binary, true);
-        checkEquivalence(binary, input, true);
+        IonDatagram[] data = new IonDatagram[3];
+        data[0] = input;
+        data[1] = loader.load(new ByteArrayInputStream(textOutputStream.toByteArray()));
+        data[2] = loader.load(new ByteArrayInputStream(binaryOutputStream.toByteArray()));
+        return data;
+    }
+
+    public static void roundTripEquivalence(IonDatagram input) throws IOException {
+        IonDatagram[] data = roundTripDatagram(input);
+        IonAssert.assertIonEquals(data[0], data[1]);
+        IonAssert.assertIonEquals(data[2], data[0]);
+        IonAssert.assertIonEquals(data[1], data[2]);
     }
 
     @Test
@@ -222,7 +228,7 @@ public class EquivsTestCase
     {
         IonDatagram dg = loader().load(myTestFile);
         runEquivalenceChecks(dg, myExpectedEquality);
-        roundTripEquivalence(dg, myExpectedEquality);
+        roundTripEquivalence(dg);
     }
 
     @Test

--- a/test/software/amazon/ion/EquivsTestCase.java
+++ b/test/software/amazon/ion/EquivsTestCase.java
@@ -199,20 +199,21 @@ public class EquivsTestCase
             ByteArrayOutputStream binaryOutputStream = new ByteArrayOutputStream();
             IonWriter textWriter = IonTextWriterBuilder.standard().build(textOutputStream);
             IonWriter binaryWriter = IonBinaryWriterBuilder.standard().build(binaryOutputStream);
+            IonDatagram[] data = new IonDatagram[3];
             try {
                 IonReader reader = system.newReader(input);
                 textWriter.writeValues(reader);
                 reader = system.newReader(input);
                 binaryWriter.writeValues(reader);
-                IonDatagram[] data = new IonDatagram[3];
+
                 data[0] = input;
                 data[1] = loader.load(new ByteArrayInputStream(textOutputStream.toByteArray()));
                 data[2] = loader.load(new ByteArrayInputStream(binaryOutputStream.toByteArray()));
-                return data;
             } finally {
                 textWriter.close();
                 binaryWriter.close();
             }
+                return data;
     }
 
     public void roundTripEquivalence(IonDatagram input, boolean myExpectedEquality) throws IOException {

--- a/test/software/amazon/ion/EquivsTestCase.java
+++ b/test/software/amazon/ion/EquivsTestCase.java
@@ -179,7 +179,7 @@ public class EquivsTestCase
             IonAssert.assertIonEquals(right, left);
 
             // IonDatagram's hashCode() is unsupported
-            if (left.getType() != DATAGRAM &&
+            if (left.getType()  != DATAGRAM &&
                 right.getType() != DATAGRAM)
                 assertEquals("Equal values have unequal hashes",
                              left.hashCode(), right.hashCode());

--- a/test/software/amazon/ion/GoodIonTest.java
+++ b/test/software/amazon/ion/GoodIonTest.java
@@ -89,10 +89,10 @@ public class GoodIonTest
             in.close();
         }
 
-            treeReader = system().newReader(datagram);
-            byte[] encoded = datagram.getBytes();
-            IonReader binaryReader = system().newReader(encoded);
-            ReaderCompare.compare(treeReader, binaryReader);
+        treeReader = system().newReader(datagram);
+        byte[] encoded = datagram.getBytes();
+        IonReader binaryReader = system().newReader(encoded);
+        ReaderCompare.compare(treeReader, binaryReader);
     }
 
 

--- a/test/software/amazon/ion/GoodIonTest.java
+++ b/test/software/amazon/ion/GoodIonTest.java
@@ -28,6 +28,7 @@ import software.amazon.ion.IonReader;
 import software.amazon.ion.IonValue;
 import software.amazon.ion.impl.PrivateUtils;
 import software.amazon.ion.junit.Injected.Inject;
+import software.amazon.ion.junit.IonAssert;
 import software.amazon.ion.streaming.ReaderCompare;
 
 public class GoodIonTest
@@ -98,6 +99,8 @@ public class GoodIonTest
             IonReader binaryReader = system().newReader(encoded);
 
             ReaderCompare.compare(treeReader, binaryReader);
+        } else {
+           EquivsTest.roundTripEquivalence(datagram);
         }
     }
 

--- a/test/software/amazon/ion/GoodIonTest.java
+++ b/test/software/amazon/ion/GoodIonTest.java
@@ -89,19 +89,10 @@ public class GoodIonTest
             in.close();
         }
 
-
-        // Pass 4: Encode to binary, and use Reader
-        if (! myFileIsBinary) {
-            // Check the encoding of text to binary.
             treeReader = system().newReader(datagram);
-
             byte[] encoded = datagram.getBytes();
             IonReader binaryReader = system().newReader(encoded);
-
             ReaderCompare.compare(treeReader, binaryReader);
-        } else {
-           EquivsTest.roundTripEquivalence(datagram);
-        }
     }
 
 

--- a/test/software/amazon/ion/junit/IonAssert.java
+++ b/test/software/amazon/ion/junit/IonAssert.java
@@ -447,13 +447,12 @@ public final class IonAssert
      */
     private static HashMap<String,List<IonValue>> sortFields(IonStruct s)
     {
-        HashMap<String,List<IonValue>> sorted =
-            new HashMap<String,List<IonValue>>();
+        HashMap<String,List<IonValue>> sorted = new HashMap<String,List<IonValue>>();
         for (IonValue v : s)
         {
             SymbolToken tok = v.getFieldNameSymbol();
             String text = tok.getText();
-            if (text == null) {
+            if (text == null && tok.getSid() != 0) {
                 text = UNKNOWN_SYMBOL_TEXT_PREFIX + tok.getSid(); // TODO amzn/ion-java#23
             }
             List<IonValue> fields = sorted.get(text);

--- a/test/software/amazon/ion/junit/IonAssert.java
+++ b/test/software/amazon/ion/junit/IonAssert.java
@@ -447,12 +447,13 @@ public final class IonAssert
      */
     private static HashMap<String,List<IonValue>> sortFields(IonStruct s)
     {
-        HashMap<String,List<IonValue>> sorted = new HashMap<String,List<IonValue>>();
+        HashMap<String,List<IonValue>> sorted =
+            new HashMap<String,List<IonValue>>();
         for (IonValue v : s)
         {
             SymbolToken tok = v.getFieldNameSymbol();
             String text = tok.getText();
-            if (text == null && tok.getSid() != 0) {
+            if (text == null) {
                 text = UNKNOWN_SYMBOL_TEXT_PREFIX + tok.getSid(); // TODO amzn/ion-java#23
             }
             List<IonValue> fields = sorted.get(text);


### PR DESCRIPTION
adds support for round tripping equivalent data within equivstest and goodiontest.
Seems to be the exact same logic as detailed within roundtriptest.test()

-- work in progress --

