### PR TITLE
fixes isInStruct/getFieldName/getFieldNameSymbol behavior for DOM-backed readers

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderTreeSystem.java
+++ b/src/software/amazon/ion/impl/IonReaderTreeSystem.java
@@ -60,7 +60,6 @@ class IonReaderTreeSystem
     /** Holds pairs: IonValue parent, Iterator<IonValue> cursor */
     private   Object[]           _stack = new Object[10];
     protected int                _top;
-    private   boolean            _hoisted;
 
     // Interface that allows access to the _symbols value (whatever that might be in terms of
     // stream processing context)
@@ -102,7 +101,6 @@ class IonReaderTreeSystem
         _curr = null;
         _eof = false;
         _top = 0;
-        _hoisted = hoisted;
         if (value instanceof IonDatagram) {
             // datagrams interacting with these readers must be
             // IonContainerPrivate containers
@@ -254,7 +252,7 @@ class IonReaderTreeSystem
 
     public boolean isInStruct()
     {
-        return (_parent instanceof IonStruct);
+        return getDepth() > 0 && _parent instanceof IonStruct;
     }
 
     public boolean isNullValue()
@@ -269,12 +267,12 @@ class IonReaderTreeSystem
 
     public String getFieldName()
     {
-        return (_curr == null || (_hoisted && _top == 0)) ? null : _curr.getFieldName();
+        return (_curr == null || _top == 0) ? null : _curr.getFieldName();
     }
 
     public final SymbolToken getFieldNameSymbol()
     {
-        if (_curr == null || (_hoisted && _top == 0)) return null;
+        if (_curr == null || _top == 0) return null;
         return _curr.getFieldNameSymbol(_symbolTableAccessor);
     }
 

--- a/test/software/amazon/ion/impl/BinaryWriterTest.java
+++ b/test/software/amazon/ion/impl/BinaryWriterTest.java
@@ -18,12 +18,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import software.amazon.ion.IonException;
 import software.amazon.ion.IonReader;
-import software.amazon.ion.IonSystem;
 import software.amazon.ion.IonType;
 import software.amazon.ion.IonValue;
 import software.amazon.ion.IonWriter;
@@ -31,16 +28,10 @@ import software.amazon.ion.SymbolTable;
 import software.amazon.ion.SymbolToken;
 import software.amazon.ion.Symtabs;
 import software.amazon.ion.junit.IonAssert;
-import software.amazon.ion.system.IonBinaryWriterBuilder;
-import software.amazon.ion.util.NullOutputStream;
 
 public class BinaryWriterTest
     extends OutputStreamWriterTestCase
 {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Override
     protected IonWriter makeWriter(OutputStream out, SymbolTable... imports)
         throws Exception

--- a/test/software/amazon/ion/impl/IonWriterTestCase.java
+++ b/test/software/amazon/ion/impl/IonWriterTestCase.java
@@ -32,7 +32,9 @@ import java.util.Iterator;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import software.amazon.ion.FakeSymbolToken;
 import software.amazon.ion.IonBlob;
 import software.amazon.ion.IonClob;
@@ -67,6 +69,9 @@ public abstract class IonWriterTestCase
     OutputForm myOutputForm;
 
     protected IonWriter iw;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     /**
      * Closes {@link #iw} if it's not null.
@@ -498,9 +503,9 @@ public abstract class IonWriterTestCase
         assertEquals(data, reloadSingleValue());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testWriteValueCantCopyFieldName()
-            throws Exception
+        throws Exception
     {
         IonStruct data = struct("{a:{b:10}}");
         IonValue a = data.get("a");
@@ -509,7 +514,9 @@ public abstract class IonWriterTestCase
 
         iw = makeWriter();
         iw.stepIn(IonType.STRUCT);
-        iw.writeValue(ir);  // should throw IllegalStateException ("Field name not set")
+
+        thrown.expect(IllegalStateException.class);  // field name not set
+        iw.writeValue(ir);
     }
 
     @Test

--- a/test/software/amazon/ion/impl/IonWriterTestCase.java
+++ b/test/software/amazon/ion/impl/IonWriterTestCase.java
@@ -496,16 +496,20 @@ public abstract class IonWriterTestCase
         iw.writeValue(ir);
         iw.stepOut();
         assertEquals(data, reloadSingleValue());
+    }
 
+    @Test(expected = IllegalStateException.class)
+    public void testWriteValueCantCopyFieldName()
+            throws Exception
+    {
+        IonStruct data = struct("{a:{b:10}}");
         IonValue a = data.get("a");
-        ir = system().newReader(a);
+        IonReader ir = system().newReader(a);
         ir.next();
 
         iw = makeWriter();
         iw.stepIn(IonType.STRUCT);
-        iw.writeValue(ir);
-        iw.stepOut();
-        assertEquals(data, reloadSingleValue());
+        iw.writeValue(ir);  // should throw IllegalStateException ("Field name not set")
     }
 
     @Test

--- a/test/software/amazon/ion/impl/TreeReaderTest.java
+++ b/test/software/amazon/ion/impl/TreeReaderTest.java
@@ -84,10 +84,10 @@ public class TreeReaderTest
         IonStruct s = struct("{f:null}");
         in = system().newReader(s.get("f"));
 
-        assertTopLevel(in, /* inStruct */ true);
+        assertTopLevel(in, /* inStruct */ false);
         expectNoCurrentValue();
 
-        check().next().fieldName("f").type(IonType.NULL);
-        assertTopLevel(in, /* inStruct */ true);
+        check().next().fieldName((String)null).type(IonType.NULL);
+        assertTopLevel(in, /* inStruct */ false);
     }
 }


### PR DESCRIPTION
Fix for https://github.com/amzn/ion-java/issues/133