### PR TITLE
Add Automatic-Module-Name in manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
             <!-- Add these properties to the manifest so they may be retrieved at runtime. -->
             <Ion-Java-Build-Time>${build.time}</Ion-Java-Build-Time>
             <Ion-Java-Project-Version>${project.version}</Ion-Java-Project-Version>
+            <Automatic-Module-Name>software.amazon.ion</Automatic-Module-Name>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
Add Automatic-Module-Name in manifest so Java9 modular applications can depend on this library.

It is recommended for java libraries in public repositories like Maven Central to add Automatic-Module-Name manifest entry. This allows the consumers of the library to move to Java 9 modularization and depend on the Automatic-Module-Name value instead of the name derived from the Jar file. This way, your consumers won't need to make changes when your library is eventually converted to a Java 9 module.

Adding Automatic-Module-Name doesn't affect any code and will simply make a name reservation until an actual module-info.java will be added eventually. More details can be found in this [article](https://dzone.com/articles/automatic-module-name-calling-all-java-library-maintainers).

[This article](http://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html) has best naming practices for JPMS modules. ```software.amazon.ion``` seems suitable as it follows your package naming strategy. 

**Description of changes:**
Adds ```Automatic-Module-Name``` header to manifest file so other Java 9 application can depend on a concrete name instead of the name derived from java file (which is ion-java).

Instead of this change, You can also add the module-info.java which makes the library Java 9 compatible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
**Yes, I confirm**
