### PR TITLE
 Decouples IonReader from IonSystem and adds IonReaderBuilder.

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderBinarySystemX.java
+++ b/src/software/amazon/ion/impl/IonReaderBinarySystemX.java
@@ -24,7 +24,6 @@ import java.util.Date;
 import java.util.Iterator;
 import software.amazon.ion.Decimal;
 import software.amazon.ion.IntegerSize;
-import software.amazon.ion.IonSystem;
 import software.amazon.ion.IonType;
 import software.amazon.ion.NullValueException;
 import software.amazon.ion.SymbolTable;
@@ -38,16 +37,14 @@ class IonReaderBinarySystemX
     extends IonReaderBinaryRawX
     implements PrivateReaderWriter
 {
-    IonSystem _system;
     SymbolTable _symbols;
-    // ValueVariant _v; actually owned by the raw reader so it can be cleared at appropriate times
 
-    IonReaderBinarySystemX(IonSystem system, UnifiedInputStreamX in)
+    IonReaderBinarySystemX(UnifiedInputStreamX in)
     {
         super();
         init_raw(in);
-        _system = system;
-        _symbols = system.getSystemSymbolTable();
+        // TODO check IVM to determine version: amznlabs/ion-java#19, amznlabs/ion-java#24
+        _symbols = SharedSymbolTable.getSystemSymbolTable(1);
     }
 
 

--- a/src/software/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextSystemX.java
@@ -58,19 +58,13 @@ class IonReaderTextSystemX
 {
     private static int UNSIGNED_BYTE_MAX_VALUE = 255;
 
-    protected IonSystem _system;
+    SymbolTable _system_symtab;
 
-
-    protected IonReaderTextSystemX(IonSystem system, UnifiedInputStreamX iis)
+    protected IonReaderTextSystemX(UnifiedInputStreamX iis)
     {
-        _system = system;
+        _system_symtab = PrivateUtils.systemSymtab(1); // TODO check IVM to determine version: amznlabs/ion-java#19, amznlabs/ion-java#24
         init_once();
         init(iis, IonType.DATAGRAM);
-    }
-
-    public IonSystem getSystem()
-    {
-        return _system;
     }
 
     // TODO getIntegerType() is duplicated in IonReaderBinarySystemX. It could
@@ -623,7 +617,7 @@ class IonReaderTextSystemX
         SymbolTable symtab = super.getSymbolTable();
         if (symtab == null)
         {
-            symtab = _system.getSystemSymbolTable();
+            symtab = _system_symtab;
         }
         return symtab;
     }

--- a/src/software/amazon/ion/impl/IonReaderTextUserX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextUserX.java
@@ -16,11 +16,9 @@ package software.amazon.ion.impl;
 
 import static software.amazon.ion.SystemSymbols.ION_1_0;
 import static software.amazon.ion.SystemSymbols.ION_SYMBOL_TABLE;
-import static software.amazon.ion.impl.PrivateUtils.newLocalSymtab;
 
 import java.util.regex.Pattern;
 import software.amazon.ion.IonCatalog;
-import software.amazon.ion.IonSystem;
 import software.amazon.ion.IonType;
 import software.amazon.ion.OffsetSpan;
 import software.amazon.ion.SeekableReader;
@@ -63,47 +61,29 @@ class IonReaderTextUserX
      * {@link OffsetSpan}s.
      */
     private final int _physical_start_offset;
+    private final PrivateLocalSymbolTableFactory _lstFactory;
 
     // IonSystem   _system; now in IonReaderTextSystemX where it could be null
     IonCatalog  _catalog;
     SymbolTable _symbols;
 
 
-    protected IonReaderTextUserX(IonSystem system, IonCatalog catalog,
+    protected IonReaderTextUserX(IonCatalog catalog,
+                                 PrivateLocalSymbolTableFactory lstFactory,
                                  UnifiedInputStreamX uis,
                                  int physicalStartOffset)
     {
-        super(system, uis);
+        super(uis);
+        _symbols = _system_symtab;
         _physical_start_offset = physicalStartOffset;
-        initUserReader(system, catalog);
+        _catalog = catalog;
+        _lstFactory = lstFactory;
     }
 
-    protected IonReaderTextUserX(IonSystem system, IonCatalog catalog,
+    protected IonReaderTextUserX(IonCatalog catalog,
+                                 PrivateLocalSymbolTableFactory lstFactory,
                                  UnifiedInputStreamX uis) {
-        super(system, uis);
-        _physical_start_offset = 0;
-        initUserReader(system, catalog);
-    }
-
-    private void initUserReader(IonSystem system, IonCatalog catalog) {
-        if (system == null) {
-            throw new IllegalArgumentException();
-        }
-        _system = system;
-        if (catalog != null) {
-            _catalog = catalog;
-        }
-        else {
-            _catalog = system.getCatalog();
-        }
-        // not needed, getSymbolTable will force this when necessary
-        //  _symbols = system.getSystemSymbolTable();
-    }
-
-    @Override
-    public IonSystem getSystem()
-    {
-        return _system;
+        this(catalog, lstFactory, uis, 0);
     }
 
     /**
@@ -153,11 +133,9 @@ class IonReaderTextUserX
                             SymbolToken a = _annotations[ii];
                             // TODO SID only?
                             if (ION_SYMBOL_TABLE.equals(a.getText())) {
-                                _symbols = newLocalSymtab(_system,
-                                                          _system.getSystemSymbolTable(),
-                                                          _catalog,
-                                                          this,
-                                                          true);
+                                _symbols = _lstFactory.newLocalSymtab(_catalog,
+                                                                      this,
+                                                                      true);
                                 push_symbol_table(_symbols);
                                 _has_next_called = false;
                                 break;
@@ -175,7 +153,7 @@ class IonReaderTextUserX
                             if (ION_1_0.equals(version))
                             {
                                 symbol_table_reset();
-                                push_symbol_table(_system.getSystemSymbolTable());
+                                push_symbol_table(_system_symtab);
                                 _has_next_called = false;
                             }
                             else
@@ -202,7 +180,7 @@ class IonReaderTextUserX
     {
         IonType t = next();
         assert( IonType.SYMBOL.equals(t) );
-        _symbols = null; // was: _symbols.getSystemSymbolTable(); - the null is fixed in getSymbolTable()
+        _symbols = _system_symtab;
         return;
     }
 
@@ -210,10 +188,6 @@ class IonReaderTextUserX
     @Override
     public SymbolTable getSymbolTable()
     {
-        if (_symbols == null) {
-            SymbolTable system_symbols = _system.getSystemSymbolTable();
-            _symbols = newLocalSymtab(_system, system_symbols);
-        }
         return _symbols;
     }
 

--- a/src/software/amazon/ion/impl/IonReaderTreeSystem.java
+++ b/src/software/amazon/ion/impl/IonReaderTreeSystem.java
@@ -49,8 +49,7 @@ import software.amazon.ion.impl.PrivateIonValue.SymbolTableProvider;
 class IonReaderTreeSystem
     implements IonReader, PrivateReaderWriter
 {
-    protected IonSystem           _system;
-    protected SymbolTable         _symbols;
+    protected final SymbolTable   _system_symtab;
     protected Iterator<IonValue>  _iter;
     protected IonValue            _parent;
     protected PrivateIonValue   _next;
@@ -69,16 +68,17 @@ class IonReaderTreeSystem
     {
         if (value == null) {
             // do nothing
+            _system_symtab = null;
             _symbolTableAccessor = null;
         }
         else {
-            _system = value.getSystem();
+            _system_symtab = value.getSystem().getSystemSymbolTable();
             re_init(value, /* hoisted */ false);
             _symbolTableAccessor = new SymbolTableProvider()
             {
                 public SymbolTable getSymbolTable()
                 {
-                    return null == _symbols ? _system.getSystemSymbolTable() : _symbols;
+                    return IonReaderTreeSystem.this.getSymbolTable();
                 }
             };
         }
@@ -97,7 +97,6 @@ class IonReaderTreeSystem
 
     void re_init(IonValue value, boolean hoisted)
     {
-        _symbols = null;
         _curr = null;
         _eof = false;
         _top = 0;
@@ -119,12 +118,6 @@ class IonReaderTreeSystem
     public void close()
     {
         _eof = true;
-    }
-
-    protected void set_symbol_table(SymbolTable symtab)
-    {
-        _symbols = symtab;
-        return;
     }
 
     private void push() {
@@ -208,16 +201,7 @@ class IonReaderTreeSystem
 
     public SymbolTable getSymbolTable()
     {
-        SymbolTable symboltable = null;
-
-        if (_curr != null) {
-            symboltable = _curr.getSymbolTable();
-        }
-        else if (_parent != null) {
-            symboltable = _parent.getSymbolTable();
-        }
-
-        return symboltable;
+        return _system_symtab;
     }
 
     public IonType getType()

--- a/src/software/amazon/ion/impl/IonWriterSystem.java
+++ b/src/software/amazon/ion/impl/IonWriterSystem.java
@@ -15,7 +15,6 @@
 package software.amazon.ion.impl;
 
 import static software.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
-import static software.amazon.ion.impl.PrivateUtils.newLocalSymtab;
 import static software.amazon.ion.impl.PrivateUtils.newSymbolToken;
 import static software.amazon.ion.impl.PrivateUtils.newSymbolTokens;
 
@@ -226,7 +225,7 @@ abstract class IonWriterSystem
         assert _symbol_table.isSystemTable();
         // no catalog since it doesn't matter as this is a
         // pure local table, with no imports
-        return newLocalSymtab(null /*system*/, _symbol_table);
+        return LocalSymbolTable.DEFAULT_LST_FACTORY.newLocalSymtab(_symbol_table);
     }
 
     @Override

--- a/src/software/amazon/ion/impl/IonWriterUser.java
+++ b/src/software/amazon/ion/impl/IonWriterUser.java
@@ -256,10 +256,9 @@ class IonWriterUser
 
         // convert the struct we just wrote with the TreeWriter to a
         // local symbol table
-        SymbolTable symtab =
-            PrivateUtils.newLocalSymtab(activeSystemSymbolTable(),
-                                          _catalog,
-                                          _symbol_table_value);
+        LocalSymbolTableAsStruct.Factory lstFactory =
+            (LocalSymbolTableAsStruct.Factory)((PrivateValueFactory)_symtab_value_factory).getLstFactory();
+        SymbolTable symtab = lstFactory.newLocalSymtab(_catalog, _symbol_table_value);
 
         _symbol_table_value = null;
         _current_writer     = _system_writer;

--- a/src/software/amazon/ion/impl/LocalSymbolTableAsStruct.java
+++ b/src/software/amazon/ion/impl/LocalSymbolTableAsStruct.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package software.amazon.ion.impl;
+
+import static software.amazon.ion.SystemSymbols.IMPORTS;
+import static software.amazon.ion.SystemSymbols.ION_SYMBOL_TABLE;
+import static software.amazon.ion.SystemSymbols.MAX_ID;
+import static software.amazon.ion.SystemSymbols.NAME;
+import static software.amazon.ion.SystemSymbols.SYMBOLS;
+import static software.amazon.ion.SystemSymbols.VERSION;
+
+import java.util.ArrayList;
+import java.util.List;
+import software.amazon.ion.IonCatalog;
+import software.amazon.ion.IonList;
+import software.amazon.ion.IonReader;
+import software.amazon.ion.IonStruct;
+import software.amazon.ion.IonType;
+import software.amazon.ion.IonValue;
+import software.amazon.ion.SymbolTable;
+import software.amazon.ion.ValueFactory;
+
+/**
+ * A LocalSymbolTable that memoizes its IonStruct representation.
+ * @deprecated Should not be used in new code without data demonstrating its
+ *             benefits. Instead, use {@link LocalSymbolTable}.
+ */
+@Deprecated
+class LocalSymbolTableAsStruct
+    extends LocalSymbolTable
+{
+
+    static class Factory implements PrivateLocalSymbolTableFactory
+    {
+
+        private final ValueFactory imageFactory;
+
+        /**
+         * @param imageFactory
+         *          the factory to use when building a DOM image, not null
+         */
+        public Factory(ValueFactory imageFactory)
+        {
+            this.imageFactory = imageFactory;
+        }
+
+        @Override
+        public SymbolTable newLocalSymtab(IonCatalog catalog,
+                                          IonReader reader,
+                                          boolean alreadyInStruct)
+        {
+            List<String> symbolsList = new ArrayList<String>();
+            LocalSymbolTableImports imports = readLocalSymbolTable(reader,
+                                                                   catalog,
+                                                                   alreadyInStruct,
+                                                                   symbolsList);
+            return new LocalSymbolTableAsStruct(imageFactory, imports, symbolsList);
+        }
+
+        @Override
+        public SymbolTable newLocalSymtab(SymbolTable defaultSystemSymtab,
+                                          SymbolTable... imports)
+        {
+            LocalSymbolTableImports unifiedSymtabImports =
+                new LocalSymbolTableImports(defaultSystemSymtab, imports);
+
+            return new LocalSymbolTableAsStruct(imageFactory,
+                                                unifiedSymtabImports,
+                                                null /* local symbols */);
+        }
+
+        /**
+         * Constructs a new local symbol table represented by the passed in
+         * {@link IonStruct}.
+         *
+         * @param catalog
+         *          may be null
+         * @param ionRep
+         *          the struct represented the local symtab
+         */
+        // TODO this should die with the 'backed' DOM
+        public SymbolTable newLocalSymtab(IonCatalog catalog,
+                                          IonStruct ionRep)
+        {
+            assert imageFactory == ionRep.getSystem();
+            IonReader reader = new IonReaderTreeSystem(ionRep);
+
+            List<String> symbolsList = new ArrayList<String>();
+            LocalSymbolTableImports imports = readLocalSymbolTable(reader,
+                                                                   catalog,
+                                                                   false,
+                                                                   symbolsList);
+
+            LocalSymbolTableAsStruct table = new LocalSymbolTableAsStruct(imageFactory,
+                                                                          imports,
+                                                                          symbolsList);
+            table.myImage = ionRep;
+
+            return table;
+        }
+
+    }
+
+    /**
+     * The factory used to build the {@link #myImage} of a local symtab.
+     * It's used by the datagram level to maintain the tree representation.
+     * It cannot be changed since local symtabs can't be moved between trees.
+     */
+    private final ValueFactory myImageFactory;
+
+    /**
+     * Memoized result of {@link #getIonRepresentation()};
+     * Once this is created, we maintain it as symbols are added.
+     */
+    private IonStruct myImage;
+
+    /**
+     * @param imageFactory      never null
+     * @param imports           never null
+     * @param symbolsList       may be null or empty
+     */
+    private LocalSymbolTableAsStruct(ValueFactory imageFactory,
+                                     LocalSymbolTableImports imports,
+                                     List<String> symbolsList)
+    {
+        super(imports, symbolsList);
+        myImageFactory = imageFactory;
+    }
+
+    @Override
+    int putSymbol(String symbolName)
+    {
+        int sid = super.putSymbol(symbolName);
+        if (myImage != null)
+        {
+            recordLocalSymbolInIonRep(myImage, symbolName, sid);
+        }
+        return sid;
+    }
+
+    //
+    // TODO: there needs to be a better way to associate a System with
+    //       the symbol table, which is required if someone is to be
+    //       able to generate an instance.  The other way to resolve
+    //       this dependency would be for the IonSystem object to be
+    //       able to take a SymbolTable and synthesize an Ion
+    //       value from it, by using the public API's to see the useful
+    //       contents.  But what about open content?  If the origin of
+    //       the symbol table was an IonValue you could get the sys
+    //       from it, and update it, thereby preserving any extra bits.
+    //       If, OTOH, it was synthesized from scratch (a common case)
+    //       then extra content doesn't matter.
+    //
+
+    /**
+     * Only valid on local symtabs that already have an _image_factory set.
+     *
+     * @return Not null.
+     */
+    IonStruct getIonRepresentation()
+    {
+        synchronized (this)
+        {
+            IonStruct image = myImage;
+
+            if (image == null)
+            {
+                // Start a new image from scratch
+                myImage = image = makeIonRepresentation(myImageFactory);
+            }
+
+            return image;
+        }
+    }
+
+    /**
+     * NOT SYNCHRONIZED! Call only from a synch'd method.
+     *
+     * @return a new struct, not null.
+     */
+    private IonStruct makeIonRepresentation(ValueFactory factory)
+    {
+        IonStruct ionRep = factory.newEmptyStruct();
+
+        ionRep.addTypeAnnotation(ION_SYMBOL_TABLE);
+
+        SymbolTable[] importedTables = getImportedTablesNoCopy();
+
+        if (importedTables.length > 1)
+        {
+            IonList importsList = factory.newEmptyList();
+            for (int i = 1; i < importedTables.length; i++)
+            {
+                SymbolTable importedTable = importedTables[i];
+                IonStruct importStruct = factory.newEmptyStruct();
+
+                importStruct.add(NAME,
+                                 factory.newString(importedTable.getName()));
+                importStruct.add(VERSION,
+                                 factory.newInt(importedTable.getVersion()));
+                importStruct.add(MAX_ID,
+                                 factory.newInt(importedTable.getMaxId()));
+
+                importsList.add(importStruct);
+            }
+            ionRep.add(IMPORTS, importsList);
+        }
+
+        if (mySymbolsCount > 0)
+        {
+            int sid = myFirstLocalSid;
+            for (int offset = 0; offset < mySymbolsCount; offset++, sid++)
+            {
+                String symbolName = mySymbolNames[offset];
+                recordLocalSymbolInIonRep(ionRep, symbolName, sid);
+            }
+        }
+
+        return ionRep;
+    }
+
+    /**
+     * NOT SYNCHRONIZED! Call within constructor or from synched method.
+     * @param symbolName can be null when there's a gap in the local symbols list.
+     */
+    private void recordLocalSymbolInIonRep(IonStruct ionRep,
+                                           String symbolName,
+                                           int sid)
+    {
+        assert sid >= myFirstLocalSid;
+
+        ValueFactory sys = ionRep.getSystem();
+
+        // TODO this is crazy inefficient and not as reliable as it looks
+        // since it doesn't handle the case where's theres more than one list
+        IonValue syms = ionRep.get(SYMBOLS);
+        while (syms != null && syms.getType() != IonType.LIST)
+        {
+            ionRep.remove(syms);
+            syms = ionRep.get(SYMBOLS);
+        }
+        if (syms == null)
+        {
+            syms = sys.newEmptyList();
+            ionRep.put(SYMBOLS, syms);
+        }
+
+        int this_offset = sid - myFirstLocalSid;
+        IonValue name = sys.newString(symbolName);
+        ((IonList)syms).add(this_offset, name);
+    }
+
+}

--- a/src/software/amazon/ion/impl/PrivateIonReaderFactory.java
+++ b/src/software/amazon/ion/impl/PrivateIonReaderFactory.java
@@ -36,21 +36,26 @@ import software.amazon.ion.util.IonStreamUtils;
 @Deprecated
 public final class PrivateIonReaderFactory
 {
-    public static final IonReader makeReader(IonSystem system,
-                                             IonCatalog catalog,
+    public static final IonReader makeReader(IonCatalog catalog,
                                              byte[] bytes)
     {
-        return makeReader(system, catalog, bytes, 0, bytes.length);
+        return makeReader(catalog, bytes, 0, bytes.length);
     }
 
-    public static IonReader makeSystemReader(IonSystem system, byte[] bytes)
+    public static final IonReader makeReader(IonCatalog catalog,
+                                             byte[] bytes,
+                                             PrivateLocalSymbolTableFactory lstFactory)
+   {
+       return makeReader(catalog, bytes, 0, bytes.length, lstFactory);
+   }
+
+    public static IonReader makeSystemReader(byte[] bytes)
     {
-        return makeSystemReader(system, bytes, 0, bytes.length);
+        return makeSystemReader(bytes, 0, bytes.length);
     }
 
 
-    public static final IonReader makeReader(IonSystem system,
-                                             IonCatalog catalog,
+    public static final IonReader makeReader(IonCatalog catalog,
                                              byte[] bytes,
                                              int offset,
                                              int length)
@@ -58,7 +63,7 @@ public final class PrivateIonReaderFactory
         try
         {
             UnifiedInputStreamX uis = makeUnifiedStream(bytes, offset, length);
-            return makeReader(system, catalog, uis, offset);
+            return makeReader(catalog, uis, offset, LocalSymbolTable.DEFAULT_LST_FACTORY);
         }
         catch (IOException e)
         {
@@ -66,15 +71,31 @@ public final class PrivateIonReaderFactory
         }
     }
 
-    public static IonReader makeSystemReader(IonSystem system,
+    public static final IonReader makeReader(IonCatalog catalog,
                                              byte[] bytes,
+                                             int offset,
+                                             int length,
+                                             PrivateLocalSymbolTableFactory lstFactory)
+    {
+        try
+        {
+            UnifiedInputStreamX uis = makeUnifiedStream(bytes, offset, length);
+            return makeReader(catalog, uis, offset, lstFactory);
+        }
+        catch (IOException e)
+        {
+            throw new IonException(e);
+        }
+    }
+
+    public static IonReader makeSystemReader(byte[] bytes,
                                              int offset,
                                              int length)
     {
         try
         {
             UnifiedInputStreamX uis = makeUnifiedStream(bytes, offset, length);
-            return makeSystemReader(system, uis, offset);
+            return makeSystemReader(uis, offset);
         }
         catch (IOException e)
         {
@@ -83,122 +104,129 @@ public final class PrivateIonReaderFactory
     }
 
 
-    public static final IonReader makeReader(IonSystem system,
-                                                 IonCatalog catalog,
-                                                 char[] chars)
+    public static final IonReader makeReader(IonCatalog catalog,
+                                             char[] chars)
     {
-        return makeReader(system, catalog, chars, 0, chars.length);
+        return makeReader(catalog, chars, 0, chars.length);
     }
 
-    public static final IonReader makeSystemReader(IonSystem system,
-                                                   char[] chars)
+    public static final IonReader makeSystemReader(char[] chars)
     {
         UnifiedInputStreamX in = makeStream(chars);
-        return new IonReaderTextSystemX(system, in);
+        return new IonReaderTextSystemX(in);
     }
 
 
-    public static final IonReader makeReader(IonSystem system,
-                                             IonCatalog catalog,
+    public static final IonReader makeReader(IonCatalog catalog,
                                              char[] chars,
                                              int offset,
                                              int length)
     {
         UnifiedInputStreamX in = makeStream(chars, offset, length);
-        return new IonReaderTextUserX(system, catalog, in, offset);
+        return new IonReaderTextUserX(catalog, LocalSymbolTable.DEFAULT_LST_FACTORY, in, offset);
     }
 
-    public static final IonReader makeSystemReader(IonSystem system,
-                                                   char[] chars,
+    public static final IonReader makeSystemReader(char[] chars,
                                                    int offset,
                                                    int length)
     {
         UnifiedInputStreamX in = makeStream(chars, offset, length);
-        return new IonReaderTextSystemX(system, in);
+        return new IonReaderTextSystemX(in);
     }
 
 
-    public static final IonReader makeReader(IonSystem system,
-                                                 IonCatalog catalog,
-                                                 CharSequence chars)
+    public static final IonReader makeReader(IonCatalog catalog,
+                                             CharSequence chars)
+    {
+        return makeReader(catalog, chars, LocalSymbolTable.DEFAULT_LST_FACTORY);
+    }
+
+    public static final IonReader makeReader(IonCatalog catalog,
+                                             CharSequence chars,
+                                             PrivateLocalSymbolTableFactory lstFactory)
     {
         UnifiedInputStreamX in = makeStream(chars);
-        return new IonReaderTextUserX(system, catalog, in);
+        return new IonReaderTextUserX(catalog, lstFactory, in);
     }
 
-    public static final IonReader makeSystemReader(IonSystem system,
-                                                   CharSequence chars)
+    public static final IonReader makeSystemReader(CharSequence chars)
     {
         UnifiedInputStreamX in = makeStream(chars);
-        return new IonReaderTextSystemX(system, in);
+        return new IonReaderTextSystemX(in);
     }
 
 
-    public static final IonReader makeReader(IonSystem system,
-                                             IonCatalog catalog,
+    public static final IonReader makeReader(IonCatalog catalog,
                                              CharSequence chars,
                                              int offset,
                                              int length)
     {
         UnifiedInputStreamX in = makeStream(chars, offset, length);
-        return new IonReaderTextUserX(system, catalog, in, offset);
+        return new IonReaderTextUserX(catalog, LocalSymbolTable.DEFAULT_LST_FACTORY, in, offset);
     }
 
-    public static final IonReader makeSystemReader(IonSystem system,
-                                                   CharSequence chars,
+    public static final IonReader makeSystemReader(CharSequence chars,
                                                    int offset,
                                                    int length)
     {
         UnifiedInputStreamX in = makeStream(chars, offset, length);
-        return new IonReaderTextSystemX(system, in);
+        return new IonReaderTextSystemX(in);
     }
 
-
-    public static final IonReader makeReader(IonSystem system,
-                                             IonCatalog catalog,
+    public static final IonReader makeReader(IonCatalog catalog,
                                              InputStream is)
+    {
+        return makeReader(catalog, is, LocalSymbolTable.DEFAULT_LST_FACTORY);
+    }
+
+    public static final IonReader makeReader(IonCatalog catalog,
+                                             InputStream is,
+                                             PrivateLocalSymbolTableFactory lstFactory)
     {
         try {
             UnifiedInputStreamX uis = makeUnifiedStream(is);
-            return makeReader(system, catalog, uis, 0);
+            return makeReader(catalog, uis, 0, lstFactory);
         }
         catch (IOException e) {
             throw new IonException(e);
         }
     }
 
-    public static IonReader makeSystemReader(IonSystem system,
-                                             InputStream is)
+    public static IonReader makeSystemReader(InputStream is)
     {
         try {
             UnifiedInputStreamX uis = makeUnifiedStream(is);
-            return makeSystemReader(system, uis, 0);
+            return makeSystemReader(uis, 0);
         }
         catch (IOException e) {
             throw new IonException(e);
         }
     }
 
-
-    public static final IonReader makeReader(IonSystem system,
-                                             IonCatalog catalog,
+    public static final IonReader makeReader(IonCatalog catalog,
                                              Reader chars)
     {
-        try {
-            UnifiedInputStreamX in = makeStream(chars);
-            return new IonReaderTextUserX(system, catalog, in);
-        }
-        catch (IOException e) {
-            throw new IonException(e);
-        }
+        return makeReader(catalog, chars, LocalSymbolTable.DEFAULT_LST_FACTORY);
     }
 
-    public static final IonReader makeSystemReader(IonSystem system,
-                                                       Reader chars)
+    public static final IonReader makeReader(IonCatalog catalog,
+                                             Reader chars,
+                                             PrivateLocalSymbolTableFactory lstFactory)
     {
         try {
             UnifiedInputStreamX in = makeStream(chars);
-            return new IonReaderTextSystemX(system, in);
+            return new IonReaderTextUserX(catalog, lstFactory, in);
+        }
+        catch (IOException e) {
+            throw new IonException(e);
+        }
+    }
+
+    public static final IonReader makeSystemReader(Reader chars)
+    {
+        try {
+            UnifiedInputStreamX in = makeStream(chars);
+            return new IonReaderTextSystemX(in);
         }
         catch (IOException e) {
             throw new IonException(e);
@@ -206,11 +234,10 @@ public final class PrivateIonReaderFactory
     }
 
 
-    public static final IonReader makeReader(IonSystem system,
-                                             IonCatalog catalog,
+    public static final IonReader makeReader(IonCatalog catalog,
                                              IonValue value)
     {
-        return new IonReaderTreeUserX(value, catalog);
+        return new IonReaderTreeUserX(value, catalog, LocalSymbolTable.DEFAULT_LST_FACTORY);
     }
 
     public static final IonReader makeSystemReader(IonSystem system,
@@ -227,35 +254,34 @@ public final class PrivateIonReaderFactory
 
 
 
-    private static IonReader makeReader(IonSystem system,
-                                        IonCatalog catalog,
+    private static IonReader makeReader(IonCatalog catalog,
                                         UnifiedInputStreamX uis,
-                                        int offset)
+                                        int offset,
+                                        PrivateLocalSymbolTableFactory lstFactory)
         throws IOException
     {
         IonReader r;
         if (has_binary_cookie(uis)) {
-            r = new IonReaderBinaryUserX(system, catalog, uis, offset);
+            r = new IonReaderBinaryUserX(catalog, lstFactory, uis, offset);
         }
         else {
-            r = new IonReaderTextUserX(system, catalog, uis, offset);
+            r = new IonReaderTextUserX(catalog, lstFactory, uis, offset);
         }
         return r;
     }
 
-    private static IonReader makeSystemReader(IonSystem system,
-                                              UnifiedInputStreamX uis,
+    private static IonReader makeSystemReader(UnifiedInputStreamX uis,
                                               int offset)
         throws IOException
     {
         IonReader r;
         if (has_binary_cookie(uis)) {
             // TODO pass offset, or spans will be incorrect
-            r = new IonReaderBinarySystemX(system, uis);
+            r = new IonReaderBinarySystemX(uis);
         }
         else {
             // TODO pass offset, or spans will be incorrect
-            r = new IonReaderTextSystemX(system, uis);
+            r = new IonReaderTextSystemX(uis);
         }
         return r;
     }
@@ -284,7 +310,6 @@ public final class PrivateIonReaderFactory
         return uis;
     }
 
-
     private static UnifiedInputStreamX makeUnifiedStream(InputStream in)
         throws IOException
     {
@@ -295,7 +320,6 @@ public final class PrivateIonReaderFactory
         UnifiedInputStreamX uis = UnifiedInputStreamX.makeStream(in);
         return uis;
     }
-
 
     private static final boolean has_binary_cookie(UnifiedInputStreamX uis)
         throws IOException

--- a/src/software/amazon/ion/impl/PrivateIonTextWriterBuilder.java
+++ b/src/software/amazon/ion/impl/PrivateIonTextWriterBuilder.java
@@ -191,7 +191,7 @@ public class PrivateIonTextWriterBuilder
                                                                    appender);
 
         SymbolTable initialSymtab =
-            initialSymtab(system, defaultSystemSymtab, imports);
+            initialSymtab(((PrivateValueFactory)system).getLstFactory(), defaultSystemSymtab, imports);
 
         return new IonWriterUser(catalog, system, systemWriter, initialSymtab);
     }

--- a/src/software/amazon/ion/impl/PrivateLocalSymbolTableFactory.java
+++ b/src/software/amazon/ion/impl/PrivateLocalSymbolTableFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package software.amazon.ion.impl;
+
+import software.amazon.ion.IonCatalog;
+import software.amazon.ion.IonReader;
+import software.amazon.ion.IonType;
+import software.amazon.ion.SymbolTable;
+
+/**
+ * NOT FOR APPLICATION USE
+ *
+ * Implementations of this interface may be provided to IonReaders in order
+ * to force them to construct LocalSymbolTables in a different way.
+ *
+ * In practice, this is used to construct a different LocalSymbolTable
+ * implementation for use with the DOM than is used purely by readers
+ * and writers.
+ *
+ * If {@link LocalSymbolTableAsStruct} is ever deleted, this can go away
+ * too.
+ */
+@SuppressWarnings("javadoc")
+public interface PrivateLocalSymbolTableFactory
+{
+    /**
+     * Constructs a new local symbol table represented by the current value of
+     * the passed in {@link IonReader}.
+     * <p>
+     * <b>NOTE:</b> It is assumed that the passed in reader is positioned
+     * properly on/before a value that represents a local symtab semantically.
+     * That is, no exception-checks are made on the {@link IonType}
+     * and annotation, callers are responsible for checking this!
+     *
+     * @param catalog
+     *          the catalog containing shared symtabs referenced by import
+     *          declarations within the local symtab
+     * @param reader
+     *          the reader positioned on the local symbol table represented as
+     *          a struct
+     * @param alreadyInStruct
+     *          denotes whether the reader is already positioned on the struct;
+     *          false if it is positioned before the struct
+     */
+    public SymbolTable newLocalSymtab(IonCatalog catalog,
+                                      IonReader reader,
+                                      boolean alreadyInStruct);
+
+    /**
+     * Constructs a new local symtab with given imports and local symbols.
+     *
+     * @param defaultSystemSymtab
+     *          the default system symtab, which will be used if the first
+     *          import in {@code imports} isn't a system symtab, never null
+     * @param imports
+     *          the set of shared symbol tables to import; the first (and only
+     *          the first) may be a system table, in which case the
+     *          {@code defaultSystemSymtab} is ignored
+     *
+     * @throws IllegalArgumentException
+     *          if any import is a local table, or if any but the first is a
+     *          system table
+     * @throws NullPointerException
+     *          if any import is null
+     */
+    public SymbolTable newLocalSymtab(SymbolTable defaultSystemSymtab,
+                                      SymbolTable... imports);
+}

--- a/src/software/amazon/ion/impl/PrivateValueFactory.java
+++ b/src/software/amazon/ion/impl/PrivateValueFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package software.amazon.ion.impl;
+
+import software.amazon.ion.IonStruct;
+import software.amazon.ion.ValueFactory;
+
+public interface PrivateValueFactory extends ValueFactory
+{
+    /**
+     * Gets the {@link LocalSymbolTableAsStruct.Factory} associated with this
+     * {@link ValueFactory}. This is used to construct local symbol tables
+     * backed by {@link IonStruct}s. Note that this should not be used in new
+     * code; use {@link LocalSymbolTable} instead.
+     *
+     * @return a LocalSymbolTableAsStruct.Factory; never null.
+     */
+    @SuppressWarnings("javadoc")
+    public PrivateLocalSymbolTableFactory getLstFactory();
+}

--- a/src/software/amazon/ion/impl/lite/IonDatagramLite.java
+++ b/src/software/amazon/ion/impl/lite/IonDatagramLite.java
@@ -1010,8 +1010,7 @@ final class IonDatagramLite
                         rep = __iterator.get_datagram_ivm();
                     }
                     else {
-                        IonSystem sys = __iterator.get_datagram_system();
-                        rep = PrivateUtils.symtabTree(sys, new_symbol_table);
+                        rep = PrivateUtils.symtabTree(new_symbol_table);
                     }
                     assert(rep != null && __iterator.get_datagram_system() == rep.getSystem());
 
@@ -1118,7 +1117,7 @@ final class IonDatagramLite
             int count = 0;
             while (curr.isLocalTable()) {
                 count++;
-                curr = PrivateUtils.symtabTree(sys, curr).getSymbolTable();
+                curr = PrivateUtils.symtabTree(curr).getSymbolTable();
             }
             // we should terminate when the symbol tables symbol table is the system symbol table
             assert(curr != null);

--- a/src/software/amazon/ion/impl/lite/IonLoaderLite.java
+++ b/src/software/amazon/ion/impl/lite/IonLoaderLite.java
@@ -29,6 +29,7 @@ import software.amazon.ion.IonReader;
 import software.amazon.ion.IonSystem;
 import software.amazon.ion.IonWriter;
 import software.amazon.ion.impl.PrivateIonWriterFactory;
+import software.amazon.ion.impl.PrivateLocalSymbolTableFactory;
 
 final class IonLoaderLite
     implements IonLoader
@@ -37,6 +38,8 @@ final class IonLoaderLite
 
     /** Not null. */
     private final IonCatalog    _catalog;
+
+    private final PrivateLocalSymbolTableFactory _lstFactory;
 
     /**
      * @param system must not be null.
@@ -49,6 +52,7 @@ final class IonLoaderLite
 
         _system = system;
         _catalog = catalog;
+        _lstFactory = system.getLstFactory();
     }
 
     public IonSystem getSystem()
@@ -93,7 +97,7 @@ final class IonLoaderLite
     public IonDatagram load(String ionText) throws IonException
     {
         try {
-            IonReader reader = makeReader(_system, _catalog, ionText);
+            IonReader reader = makeReader(_catalog, ionText, _lstFactory);
             IonDatagramLite datagram = load_helper(reader);
             return datagram;
         }
@@ -105,7 +109,7 @@ final class IonLoaderLite
     public IonDatagram load(Reader ionText) throws IonException, IOException
     {
         try {
-            IonReader reader = makeReader(_system, _catalog, ionText);
+            IonReader reader = makeReader(_catalog, ionText, _lstFactory);
             IonDatagramLite datagram = load_helper(reader);
             return datagram;
         }
@@ -119,7 +123,7 @@ final class IonLoaderLite
     public IonDatagram load(byte[] ionData) throws IonException
     {
         try {
-            IonReader reader = makeReader(_system, _catalog, ionData, 0, ionData.length);
+            IonReader reader = makeReader(_catalog, ionData, 0, ionData.length, _lstFactory);
             IonDatagramLite datagram = load_helper(reader);
             return datagram;
         }
@@ -132,7 +136,7 @@ final class IonLoaderLite
         throws IonException, IOException
     {
         try {
-            IonReader reader = makeReader(_system, _catalog, ionData);
+            IonReader reader = makeReader(_catalog, ionData, _lstFactory);
             IonDatagramLite datagram = load_helper(reader);
             return datagram;
         }

--- a/src/software/amazon/ion/impl/lite/PrivateLiteDomTrampoline.java
+++ b/src/software/amazon/ion/impl/lite/PrivateLiteDomTrampoline.java
@@ -17,6 +17,7 @@ package software.amazon.ion.impl.lite;
 import software.amazon.ion.IonSystem;
 import software.amazon.ion.SymbolTable;
 import software.amazon.ion.impl.PrivateIonBinaryWriterBuilder;
+import software.amazon.ion.system.IonReaderBuilder;
 import software.amazon.ion.system.IonTextWriterBuilder;
 
 /**
@@ -27,10 +28,12 @@ import software.amazon.ion.system.IonTextWriterBuilder;
 @Deprecated
 public final class PrivateLiteDomTrampoline
 {
+
     public static IonSystem newLiteSystem(IonTextWriterBuilder twb,
-                                          PrivateIonBinaryWriterBuilder bwb)
+                                          PrivateIonBinaryWriterBuilder bwb,
+                                          IonReaderBuilder rb)
     {
-        return new IonSystemLite(twb, bwb);
+        return new IonSystemLite(twb, bwb, rb);
     }
 
     public static boolean isLiteSystem(IonSystem system)

--- a/src/software/amazon/ion/impl/lite/ValueFactoryLite.java
+++ b/src/software/amazon/ion/impl/lite/ValueFactoryLite.java
@@ -28,7 +28,9 @@ import software.amazon.ion.IonType;
 import software.amazon.ion.IonValue;
 import software.amazon.ion.SymbolToken;
 import software.amazon.ion.Timestamp;
-import software.amazon.ion.ValueFactory;
+import software.amazon.ion.impl.PrivateLocalSymbolTableFactory;
+import software.amazon.ion.impl.PrivateUtils;
+import software.amazon.ion.impl.PrivateValueFactory;
 
 /**
  *  This class handles all of the IonValueLite
@@ -36,9 +38,15 @@ import software.amazon.ion.ValueFactory;
  *
  */
 abstract class ValueFactoryLite
-    implements ValueFactory
+    implements PrivateValueFactory
 {
+    protected final PrivateLocalSymbolTableFactory _lstFactory;
     private ContainerlessContext _context;
+
+    ValueFactoryLite()
+    {
+        _lstFactory = PrivateUtils.newLocalSymbolTableAsStructFactory(this);
+    }
 
     protected void set_system(IonSystemLite system) {
         _context = ContainerlessContext.wrap(system);
@@ -435,5 +443,11 @@ abstract class ValueFactoryLite
         }
 
         return e;
+    }
+
+    @Override
+    public PrivateLocalSymbolTableFactory getLstFactory()
+    {
+        return _lstFactory;
     }
 }

--- a/src/software/amazon/ion/system/IonReaderBuilder.java
+++ b/src/software/amazon/ion/system/IonReaderBuilder.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package software.amazon.ion.system;
+
+import static software.amazon.ion.impl.PrivateIonReaderFactory.makeReader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import software.amazon.ion.IonCatalog;
+import software.amazon.ion.IonException;
+import software.amazon.ion.IonReader;
+import software.amazon.ion.IonStruct;
+import software.amazon.ion.IonSystem;
+import software.amazon.ion.IonValue;
+
+/**
+ * Build a new {@link IonReader} from the given {@link IonCatalog} and data
+ * source. A data source is required, while an IonCatalog is optional. If no
+ * IonCatalog is provided, an empty {@link SimpleCatalog} will be used.
+ * <p>
+ * {@link IonReader}s parse incrementally, so syntax errors in the input data
+ * will not be detected as side effects of any of the {@code build} methods
+ * in this class.
+ */
+@SuppressWarnings("deprecation")
+public class IonReaderBuilder
+{
+
+    private IonCatalog catalog = null;
+
+    private IonReaderBuilder()
+    {
+    }
+
+    private IonReaderBuilder(IonReaderBuilder that)
+    {
+        this.catalog = that.catalog;
+    }
+
+    /**
+     * The standard builder of {@link IonReader}s, with all configuration
+     * properties having their default values.
+     *
+     * @return a new, mutable builder instance.
+     */
+    public static IonReaderBuilder standard()
+    {
+        return new Mutable();
+    }
+
+    /**
+     * Creates a mutable copy of this builder.
+     *
+     * @return a new builder with the same configuration as {@code this}.
+     */
+    public IonReaderBuilder copy()
+    {
+        return new Mutable(this);
+    }
+
+    /**
+     * Returns an immutable builder configured exactly like this one.
+     *
+     * @return this builder instance, if immutable;
+     * otherwise an immutable copy of this builder.
+     */
+    public IonReaderBuilder immutable()
+    {
+        return this;
+    }
+
+    /**
+     * Returns a mutable builder configured exactly like this one.
+     *
+     * @return this instance, if mutable;
+     * otherwise a mutable copy of this instance.
+     */
+    public IonReaderBuilder mutable()
+    {
+        return copy();
+    }
+
+    /** NOT FOR APPLICATION USE! */
+    protected void mutationCheck()
+    {
+        throw new UnsupportedOperationException("This builder is immutable");
+    }
+
+    /**
+     * Declares the catalog to use when building an {@link IonReader},
+     * returning a new mutable builder the current one is immutable.
+     *
+     * @param catalog the catalog to use in built readers.
+     *  If null, a new {@link SimpleCatalog} will be used.
+     *
+     * @return this builder instance, if mutable;
+     * otherwise a mutable copy of this builder.
+     *
+     * @see #setCatalog(IonCatalog)
+     * @see #withCatalog(IonCatalog)
+     */
+    public IonReaderBuilder withCatalog(IonCatalog catalog)
+    {
+        IonReaderBuilder b = mutable();
+        b.setCatalog(catalog);
+        return b;
+    }
+
+    /**
+     * Sets the catalog to use when building an {@link IonReader}.
+     *
+     * @param catalog the catalog to use in built readers.
+     *  If null, a new {@link SimpleCatalog} will be used.
+     *
+     * @see #getCatalog()
+     * @see #withCatalog(IonCatalog)
+     *
+     * @throws UnsupportedOperationException if this builder is immutable.
+     */
+    public void setCatalog(IonCatalog catalog)
+    {
+        mutationCheck();
+        this.catalog = catalog;
+    }
+
+    /**
+     * Gets the catalog to use when building an {@link IonReader}, or null
+     * if none has been manually set. The catalog is needed to resolve shared
+     * symbol table imports.
+     *
+     * @see #setCatalog(IonCatalog)
+     * @see #withCatalog(IonCatalog)
+     */
+    public IonCatalog getCatalog()
+    {
+        return catalog;
+    }
+
+    private IonCatalog validateCatalog()
+    {
+        // matches behavior in IonSystemBuilder when no catalog provided
+        return catalog != null ? catalog : new SimpleCatalog();
+    }
+
+    /**
+     * Based on the builder's configuration properties, creates a new IonReader
+     * instance over the given block of Ion data, detecting whether it's text or
+     * binary data.
+     * <p>
+     * This method will auto-detect and uncompress GZIPped Ion data.
+     *
+     * @param ionData the source of the Ion data, which may be either Ion binary
+     * data or UTF-8 Ion text. The reader retains a reference to the array, so
+     * its data must not be modified while the reader is active. Must not be
+     * null.
+     *
+     * @return a new {@link IonReader} instance; not {@code null}.
+     *
+     * @see IonSystem#newReader(byte[])
+     */
+    public IonReader build(byte[] ionData)
+    {
+        return makeReader(validateCatalog(), ionData);
+    }
+
+    /**
+     * Based on the builder's configuration properties, creates a new IonReader
+     * instance over the given block of Ion data, detecting whether it's text or
+     * binary data.
+     * <p>
+     * This method will auto-detect and uncompress GZIPped Ion data.
+     *
+     * @param ionData the source of the Ion data, which is used only within the
+     * range of bytes starting at {@code offset} for {@code len} bytes.
+     * The data in that range may be either Ion binary data or UTF-8 Ion text.
+     * The reader retains a reference to the array, so its data must not be
+     * modified while the reader is active. Must not be null.
+     * @param offset must be non-negative and less than {@code ionData.length}.
+     * @param length must be non-negative and {@code offset+length} must not
+     * exceed {@code ionData.length}.
+     *
+     * @see IonSystem#newReader(byte[], int, int)
+     */
+    public IonReader build(byte[] ionData, int offset, int length)
+    {
+        return makeReader(validateCatalog(), ionData, offset, length);
+    }
+
+    /**
+     * Based on the builder's configuration properties, creates a new IonReader
+     * instance over the given stream of Ion data, detecting whether it's text or
+     * binary data.
+     * <p>
+     * This method will auto-detect and uncompress GZIPped Ion data.
+     * <p>
+     * Because this library performs its own buffering, it's recommended that
+     * users avoid adding additional buffering to the given stream.
+     *
+     * @param ionData the source of the Ion data, which may be either Ion binary
+     * data or UTF-8 Ion text. Must not be null.
+     *
+     * @return a new reader instance.
+     * Callers must call {@link IonReader#close()} when finished with it.
+     *
+     * @throws IonException if the source throws {@link IOException}.
+     *
+     * @see IonSystem#newReader(InputStream)
+     */
+    public IonReader build(InputStream ionData)
+    {
+        return makeReader(validateCatalog(), ionData);
+    }
+
+    /**
+     * Based on the builder's configuration properties, creates a new
+     * {@link IonReader} instance over Ion text data.
+     * <p>
+     * Applications should generally use {@link #build(InputStream)}
+     * whenever possible, since this library has much faster Unicode decoding
+     * than the Java IO framework.
+     * <p>
+     * Because this library performs its own buffering, it's recommended that
+     * you avoid adding additional buffering to the given stream.
+     *
+     * @param ionText the source of the Ion text data. Must not be null.
+     *
+     * @throws IonException if the source throws {@link IOException}.
+     *
+     * @see IonSystem#newReader(Reader)
+     */
+    public IonReader build(Reader ionText)
+    {
+        return makeReader(validateCatalog(), ionText);
+    }
+
+    /**
+     * Based on the builder's configuration properties, creates a new
+     * {@link IonReader} instance over an {@link IonValue} data model. Typically
+     * this is used to iterate over a collection, such as an {@link IonStruct}.
+     *
+     * @param value must not be null.
+     *
+     * @see IonSystem#newReader(IonValue)
+     */
+    public IonReader build(IonValue value)
+    {
+        return makeReader(validateCatalog(), value);
+    }
+
+    /**
+     * Based on the builder's configuration properties, creates an new
+     * {@link IonReader} instance over Ion text data.
+     *
+     * @param ionText the source of the Ion text data. Must not be null.
+     *
+     * @see IonSystem#newReader(String)
+     */
+    public IonReader build(String ionText)
+    {
+        return makeReader(validateCatalog(), ionText);
+    }
+
+    private static class Mutable extends IonReaderBuilder
+    {
+
+        private Mutable()
+        {
+        }
+
+        private Mutable(IonReaderBuilder that)
+        {
+            super(that);
+        }
+
+        @Override
+        public IonReaderBuilder immutable()
+        {
+            return new IonReaderBuilder(this);
+        }
+
+        @Override
+        public IonReaderBuilder mutable()
+        {
+            return this;
+        }
+
+        @Override
+        protected void mutationCheck()
+        {
+        }
+
+    }
+
+}

--- a/src/software/amazon/ion/system/IonSystemBuilder.java
+++ b/src/software/amazon/ion/system/IonSystemBuilder.java
@@ -286,7 +286,8 @@ public class IonSystemBuilder
         // This is what we need, more or less.
 //        bwb = bwb.fillDefaults();
 
-        return newLiteSystem(twb, bwb);
+        IonReaderBuilder rb = IonReaderBuilder.standard().withCatalog(catalog);
+        return newLiteSystem(twb, bwb, rb);
     }
 
     //=========================================================================

--- a/test/AllTests.java
+++ b/test/AllTests.java
@@ -83,6 +83,7 @@ import software.amazon.ion.streaming.ReaderTest;
 import software.amazon.ion.streaming.RoundTripStreamingTest;
 import software.amazon.ion.streaming.SpanTests;
 import software.amazon.ion.system.IonBinaryWriterBuilderTest;
+import software.amazon.ion.system.IonReaderBuilderTest;
 import software.amazon.ion.system.IonSystemBuilderTest;
 import software.amazon.ion.system.IonTextWriterBuilderTest;
 import software.amazon.ion.system.SimpleCatalogTest;
@@ -186,6 +187,7 @@ import software.amazon.ion.util.TextTest;
     IonBinaryWriterBuilderTest.class,
     IonReaderToIonValueTest.class,
     BinaryReaderWrappedValueLengthTest.class,
+    IonReaderBuilderTest.class,
 
     // experimental binary writer tests
     PooledBlockAllocatorProviderTest.class,

--- a/test/software/amazon/ion/DatagramTest.java
+++ b/test/software/amazon/ion/DatagramTest.java
@@ -15,11 +15,11 @@
 package software.amazon.ion;
 
 import static software.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
-import static software.amazon.ion.Symtabs.FRED_MAX_IDS;
 import static software.amazon.ion.SystemSymbols.ION_1_0;
 import static software.amazon.ion.SystemSymbols.ION_1_0_SID;
 import static software.amazon.ion.SystemSymbols.ION_SYMBOL_TABLE;
 import static software.amazon.ion.SystemSymbols.SYMBOLS;
+import static software.amazon.ion.impl.Symtabs.FRED_MAX_IDS;
 import static software.amazon.ion.junit.IonAssert.assertIonEquals;
 
 import java.io.ByteArrayOutputStream;
@@ -45,6 +45,7 @@ import software.amazon.ion.ReadOnlyValueException;
 import software.amazon.ion.SymbolTable;
 import software.amazon.ion.impl.PrivateIonSystem;
 import software.amazon.ion.impl.PrivateIonValue;
+import software.amazon.ion.impl.Symtabs;
 
 
 public class DatagramTest

--- a/test/software/amazon/ion/LoaderTest.java
+++ b/test/software/amazon/ion/LoaderTest.java
@@ -42,6 +42,7 @@ import software.amazon.ion.IonStruct;
 import software.amazon.ion.IonSymbol;
 import software.amazon.ion.IonSystem;
 import software.amazon.ion.IonValue;
+import software.amazon.ion.impl.Symtabs;
 import software.amazon.ion.system.SimpleCatalog;
 
 public class LoaderTest

--- a/test/software/amazon/ion/SharedSymtabMaker.java
+++ b/test/software/amazon/ion/SharedSymtabMaker.java
@@ -15,7 +15,7 @@
 package software.amazon.ion;
 
 import static junit.framework.Assert.assertSame;
-import static software.amazon.ion.Symtabs.sharedSymtabStruct;
+import static software.amazon.ion.impl.Symtabs.sharedSymtabStruct;
 
 import software.amazon.ion.IonReader;
 import software.amazon.ion.IonStruct;

--- a/test/software/amazon/ion/SystemProcessingTestCase.java
+++ b/test/software/amazon/ion/SystemProcessingTestCase.java
@@ -15,12 +15,12 @@
 package software.amazon.ion;
 
 import static software.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
-import static software.amazon.ion.Symtabs.LocalSymbolTablePrefix;
 import static software.amazon.ion.SystemSymbols.ION_1_0;
 import static software.amazon.ion.SystemSymbols.ION_1_0_SID;
 import static software.amazon.ion.SystemSymbols.ION_SHARED_SYMBOL_TABLE;
 import static software.amazon.ion.SystemSymbols.ION_SHARED_SYMBOL_TABLE_SID;
 import static software.amazon.ion.TestUtils.FERMATA;
+import static software.amazon.ion.impl.Symtabs.LocalSymbolTablePrefix;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -29,6 +29,7 @@ import software.amazon.ion.IonType;
 import software.amazon.ion.SymbolTable;
 import software.amazon.ion.Timestamp;
 import software.amazon.ion.impl.SymbolTableTest;
+import software.amazon.ion.impl.Symtabs;
 import software.amazon.ion.system.SimpleCatalog;
 
 

--- a/test/software/amazon/ion/impl/BinaryWriterTest.java
+++ b/test/software/amazon/ion/impl/BinaryWriterTest.java
@@ -26,7 +26,6 @@ import software.amazon.ion.IonValue;
 import software.amazon.ion.IonWriter;
 import software.amazon.ion.SymbolTable;
 import software.amazon.ion.SymbolToken;
-import software.amazon.ion.Symtabs;
 import software.amazon.ion.junit.IonAssert;
 
 public class BinaryWriterTest

--- a/test/software/amazon/ion/impl/BinaryWriterWithLocalSymtabsTest.java
+++ b/test/software/amazon/ion/impl/BinaryWriterWithLocalSymtabsTest.java
@@ -14,10 +14,10 @@
 
 package software.amazon.ion.impl;
 
-import static software.amazon.ion.Symtabs.FRED_MAX_IDS;
-import static software.amazon.ion.Symtabs.LOCAL_SYMBOLS_ABC;
-import static software.amazon.ion.Symtabs.makeLocalSymtab;
 import static software.amazon.ion.impl.PrivateUtils.EMPTY_STRING_ARRAY;
+import static software.amazon.ion.impl.Symtabs.FRED_MAX_IDS;
+import static software.amazon.ion.impl.Symtabs.LOCAL_SYMBOLS_ABC;
+import static software.amazon.ion.impl.Symtabs.makeLocalSymtab;
 
 import java.io.ByteArrayOutputStream;
 import org.junit.After;
@@ -27,7 +27,6 @@ import software.amazon.ion.IonTestCase;
 import software.amazon.ion.IonValue;
 import software.amazon.ion.IonWriter;
 import software.amazon.ion.SymbolTable;
-import software.amazon.ion.Symtabs;
 import software.amazon.ion.system.IonBinaryWriterBuilder;
 
 public class BinaryWriterWithLocalSymtabsTest

--- a/test/software/amazon/ion/impl/IonWriterTestCase.java
+++ b/test/software/amazon/ion/impl/IonWriterTestCase.java
@@ -14,13 +14,13 @@
 
 package software.amazon.ion.impl;
 
-import static software.amazon.ion.Symtabs.FRED_MAX_IDS;
 import static software.amazon.ion.SystemSymbols.ION_SHARED_SYMBOL_TABLE;
 import static software.amazon.ion.SystemSymbols.ION_SYMBOL_TABLE;
 import static software.amazon.ion.SystemSymbols.NAME_SID;
 import static software.amazon.ion.TestUtils.FERMATA;
 import static software.amazon.ion.impl.PrivateIonWriterBase.ERROR_MISSING_FIELD_NAME;
 import static software.amazon.ion.impl.PrivateUtils.newSymbolToken;
+import static software.amazon.ion.impl.Symtabs.FRED_MAX_IDS;
 import static software.amazon.ion.junit.IonAssert.assertIonEquals;
 import static software.amazon.ion.junit.IonAssert.expectNextField;
 
@@ -54,7 +54,6 @@ import software.amazon.ion.IonValue;
 import software.amazon.ion.IonWriter;
 import software.amazon.ion.SymbolTable;
 import software.amazon.ion.SymbolToken;
-import software.amazon.ion.Symtabs;
 import software.amazon.ion.SystemSymbols;
 import software.amazon.ion.TestUtils;
 import software.amazon.ion.impl.PrivateIonWriter;

--- a/test/software/amazon/ion/impl/LocalSymbolTableImportAdapterTest.java
+++ b/test/software/amazon/ion/impl/LocalSymbolTableImportAdapterTest.java
@@ -1,15 +1,15 @@
 package software.amazon.ion.impl;
 
+import static software.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.ion.IonDatagram;
 import software.amazon.ion.IonWriter;
 import software.amazon.ion.ReadOnlyValueException;
 import software.amazon.ion.SymbolTable;
-import static software.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
 import software.amazon.ion.SymbolToken;
 
 public class LocalSymbolTableImportAdapterTest extends BaseSymbolTableWrapperTest
@@ -251,12 +251,16 @@ public class LocalSymbolTableImportAdapterTest extends BaseSymbolTableWrapperTes
 
         public LocalSymbolTable build()
         {
-            return LocalSymbolTable.makeNewLocalSymbolTable(
-                system,
+            LocalSymbolTable lst = (LocalSymbolTable) LocalSymbolTable.DEFAULT_LST_FACTORY.newLocalSymtab(
                 system.getSystemSymbolTable(),
-                Arrays.asList(symbols),
                 importedTables
             );
+
+            for(String symbol : symbols) {
+                lst.intern(symbol);
+            }
+
+            return lst;
         }
 
         public LocalSymbolTableBuilder setSymbols(final String... symbols)

--- a/test/software/amazon/ion/impl/LocalSymbolTableTest.java
+++ b/test/software/amazon/ion/impl/LocalSymbolTableTest.java
@@ -14,11 +14,11 @@
 
 package software.amazon.ion.impl;
 
-import static software.amazon.ion.Symtabs.FRED_MAX_IDS;
-import static software.amazon.ion.Symtabs.LOCAL_SYMBOLS_ABC;
-import static software.amazon.ion.Symtabs.makeLocalSymtab;
 import static software.amazon.ion.impl.PrivateUtils.EMPTY_STRING_ARRAY;
 import static software.amazon.ion.impl.PrivateUtils.copyLocalSymbolTable;
+import static software.amazon.ion.impl.Symtabs.FRED_MAX_IDS;
+import static software.amazon.ion.impl.Symtabs.LOCAL_SYMBOLS_ABC;
+import static software.amazon.ion.impl.Symtabs.makeLocalSymtab;
 
 import org.junit.Test;
 import software.amazon.ion.IonException;
@@ -26,7 +26,6 @@ import software.amazon.ion.IonTestCase;
 import software.amazon.ion.SubstituteSymbolTableException;
 import software.amazon.ion.SymbolTable;
 import software.amazon.ion.SymbolToken;
-import software.amazon.ion.Symtabs;
 import software.amazon.ion.impl.LocalSymbolTable;
 import software.amazon.ion.impl.SubstituteSymbolTable;
 

--- a/test/software/amazon/ion/impl/OptimizedBinaryWriterSymbolTableTest.java
+++ b/test/software/amazon/ion/impl/OptimizedBinaryWriterSymbolTableTest.java
@@ -14,9 +14,9 @@
 
 package software.amazon.ion.impl;
 
-import static software.amazon.ion.Symtabs.printLocalSymtab;
 import static software.amazon.ion.impl.PrivateUtils.isNonSymbolScalar;
 import static software.amazon.ion.impl.PrivateUtils.symtabExtends;
+import static software.amazon.ion.impl.Symtabs.printLocalSymtab;
 import static software.amazon.ion.junit.IonAssert.assertIonEquals;
 import static software.amazon.ion.junit.IonAssert.assertIonIteratorEquals;
 
@@ -24,7 +24,6 @@ import org.junit.Test;
 import software.amazon.ion.IonDatagram;
 import software.amazon.ion.IonType;
 import software.amazon.ion.SymbolTable;
-import software.amazon.ion.Symtabs;
 import software.amazon.ion.impl.PrivateUtils;
 
 /**

--- a/test/software/amazon/ion/impl/OptimizedBinaryWriterTestCase.java
+++ b/test/software/amazon/ion/impl/OptimizedBinaryWriterTestCase.java
@@ -15,8 +15,8 @@
 package software.amazon.ion.impl;
 
 import static java.lang.reflect.Proxy.newProxyInstance;
-import static software.amazon.ion.Symtabs.makeLocalSymtab;
 import static software.amazon.ion.SystemSymbols.ION_SYMBOL_TABLE;
+import static software.amazon.ion.impl.Symtabs.makeLocalSymtab;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/test/software/amazon/ion/impl/OutputStreamWriterTestCase.java
+++ b/test/software/amazon/ion/impl/OutputStreamWriterTestCase.java
@@ -26,7 +26,6 @@ import software.amazon.ion.IonType;
 import software.amazon.ion.IonValue;
 import software.amazon.ion.IonWriter;
 import software.amazon.ion.SymbolTable;
-import software.amazon.ion.Symtabs;
 import software.amazon.ion.SystemSymbols;
 import software.amazon.ion.Timestamp;
 

--- a/test/software/amazon/ion/impl/SharedSymbolTableTest.java
+++ b/test/software/amazon/ion/impl/SharedSymbolTableTest.java
@@ -14,10 +14,10 @@
 
 package software.amazon.ion.impl;
 
-import static software.amazon.ion.Symtabs.sharedSymtabStruct;
 import static software.amazon.ion.impl.PrivateUtils.EMPTY_STRING_ARRAY;
 import static software.amazon.ion.impl.PrivateUtils.stringIterator;
 import static software.amazon.ion.impl.SymbolTableTest.checkSharedTable;
+import static software.amazon.ion.impl.Symtabs.sharedSymtabStruct;
 
 import java.io.IOException;
 import org.junit.Test;
@@ -30,7 +30,6 @@ import software.amazon.ion.IonWriter;
 import software.amazon.ion.SharedSymtabMaker;
 import software.amazon.ion.SymbolTable;
 import software.amazon.ion.SymbolToken;
-import software.amazon.ion.Symtabs;
 import software.amazon.ion.SystemSymbols;
 import software.amazon.ion.junit.Injected.Inject;
 

--- a/test/software/amazon/ion/impl/SymbolTableTest.java
+++ b/test/software/amazon/ion/impl/SymbolTableTest.java
@@ -14,11 +14,7 @@
 
 package software.amazon.ion.impl;
 
-import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
 import static software.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
-import software.amazon.ion.SymbolToken;
-import static software.amazon.ion.Symtabs.printLocalSymtab;
 import static software.amazon.ion.SystemSymbols.ION;
 import static software.amazon.ion.SystemSymbols.ION_1_0;
 import static software.amazon.ion.SystemSymbols.ION_1_0_SID;
@@ -30,6 +26,7 @@ import static software.amazon.ion.SystemSymbols.SYMBOLS;
 import static software.amazon.ion.impl.PrivateUtils.EMPTY_STRING_ARRAY;
 import static software.amazon.ion.impl.PrivateUtils.stringIterator;
 import static software.amazon.ion.impl.PrivateUtils.symtabTree;
+import static software.amazon.ion.impl.Symtabs.printLocalSymtab;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -56,7 +53,7 @@ import software.amazon.ion.IonValue;
 import software.amazon.ion.IonWriter;
 import software.amazon.ion.ReadOnlyValueException;
 import software.amazon.ion.SymbolTable;
-import software.amazon.ion.Symtabs;
+import software.amazon.ion.SymbolToken;
 import software.amazon.ion.SystemSymbols;
 import software.amazon.ion.Timestamp;
 import software.amazon.ion.system.SimpleCatalog;
@@ -939,11 +936,12 @@ public class SymbolTableTest
     @Test
     public void testSymtabImageMaintenance()
     {
-        SymbolTable st = system().newLocalSymbolTable();
+        IonSystem system = system();
+        SymbolTable st = ((PrivateValueFactory)system).getLstFactory().newLocalSymtab(system.getSystemSymbolTable());
         st.intern("foo");
-        IonStruct image = symtabTree(system(), st);
+        IonStruct image = symtabTree(st);
         st.intern("bar");
-        image = symtabTree(system(), st);
+        image = symtabTree(st);
         IonList symbols = (IonList) image.get(SYMBOLS);
         assertEquals("[\"foo\",\"bar\"]", symbols.toString());
     }
@@ -1212,9 +1210,6 @@ public class SymbolTableTest
         throws IOException
     {
         IonStruct stStruct = writeIonRep(st);
-        checkFirstImport(name, version, expectedSymbols, stStruct);
-
-        stStruct = PrivateUtils.symtabTree(system(), st);
         checkFirstImport(name, version, expectedSymbols, stStruct);
 
         SymbolTable importedTable = st.getImportedTables()[0];

--- a/test/software/amazon/ion/impl/Symtabs.java
+++ b/test/software/amazon/ion/impl/Symtabs.java
@@ -12,14 +12,13 @@
  * language governing permissions and limitations under the License.
  */
 
-package software.amazon.ion;
+package software.amazon.ion.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static software.amazon.ion.SystemSymbols.ION_SHARED_SYMBOL_TABLE;
 import static software.amazon.ion.SystemSymbols.ION_SYMBOL_TABLE;
-import static software.amazon.ion.impl.PrivateUtils.newLocalSymtab;
 import static software.amazon.ion.util.IonTextUtils.printString;
 
 import java.io.IOException;
@@ -31,6 +30,7 @@ import software.amazon.ion.SymbolTable;
 import software.amazon.ion.SystemSymbols;
 import software.amazon.ion.ValueFactory;
 import software.amazon.ion.impl.PrivateIonSystem;
+import software.amazon.ion.impl.PrivateLocalSymbolTableFactory;
 import software.amazon.ion.system.IonSystemBuilder;
 import software.amazon.ion.system.SimpleCatalog;
 
@@ -203,24 +203,6 @@ public class Symtabs
         return s.toString();
     }
 
-
-    /**
-     * Creates a local symtab with local symbols but no imports.
-     *
-     * @param system
-     * @param localSymbols
-     *          the array (var-args) of local symbols that the resulting
-     *          local symtab to contain; may be {@code null} to indicate no
-     *          local symbols; elements may be {@code null} to indicate a gap
-     */
-    public static SymbolTable makeLocalSymtab(IonSystem system,
-                                              String... localSymbols)
-    {
-        return newLocalSymtab(system, system.getSystemSymbolTable(),
-                              Arrays.asList(localSymbols));
-    }
-
-
     /**
      * Creates a local symtab with local symbols and imports.
      */
@@ -232,9 +214,27 @@ public class Symtabs
 
         for (String localSymbol : localSymbols)
         {
-            localSymtab.intern(localSymbol);
+            if (localSymbol == null)
+            {
+                // This injects a gap.
+                ((LocalSymbolTable)localSymtab).putSymbol(null);
+            }
+            else
+            {
+                localSymtab.intern(localSymbol);
+            }
         }
 
         return localSymtab;
     }
+
+    /**
+     * Trampoline to {@link LocalSymbolTable#DEFAULT_LST_FACTORY}
+     * @return the {@link LocalSymbolTable.Factory} singleton.
+     */
+    public static PrivateLocalSymbolTableFactory localSymbolTableFactory()
+    {
+        return LocalSymbolTable.DEFAULT_LST_FACTORY;
+    }
+
 }

--- a/test/software/amazon/ion/impl/TextWriterTest.java
+++ b/test/software/amazon/ion/impl/TextWriterTest.java
@@ -29,7 +29,6 @@ import software.amazon.ion.IonSequence;
 import software.amazon.ion.IonStruct;
 import software.amazon.ion.IonWriter;
 import software.amazon.ion.SymbolTable;
-import software.amazon.ion.Symtabs;
 import software.amazon.ion.SystemSymbols;
 import software.amazon.ion.impl.PrivateUtils;
 import software.amazon.ion.system.IonTextWriterBuilder;

--- a/test/software/amazon/ion/impl/ValueWriterTest.java
+++ b/test/software/amazon/ion/impl/ValueWriterTest.java
@@ -23,7 +23,6 @@ import software.amazon.ion.IonReader;
 import software.amazon.ion.IonSymbol;
 import software.amazon.ion.IonWriter;
 import software.amazon.ion.SymbolTable;
-import software.amazon.ion.Symtabs;
 
 public class ValueWriterTest
     extends IonWriterTestCase

--- a/test/software/amazon/ion/impl/lite/IonContextTest.java
+++ b/test/software/amazon/ion/impl/lite/IonContextTest.java
@@ -15,7 +15,7 @@
 package software.amazon.ion.impl.lite;
 
 import static software.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
-import static software.amazon.ion.Symtabs.CATALOG;
+import static software.amazon.ion.impl.Symtabs.CATALOG;
 
 import org.junit.Test;
 import software.amazon.ion.IonDatagram;
@@ -27,7 +27,7 @@ import software.amazon.ion.IonTestCase;
 import software.amazon.ion.IonValue;
 import software.amazon.ion.SymbolTable;
 import software.amazon.ion.SymbolToken;
-import software.amazon.ion.Symtabs;
+import software.amazon.ion.impl.Symtabs;
 import software.amazon.ion.impl.lite.ContainerlessContext;
 import software.amazon.ion.impl.lite.IonContainerLite;
 import software.amazon.ion.impl.lite.IonContext;

--- a/test/software/amazon/ion/streaming/ReaderTest.java
+++ b/test/software/amazon/ion/streaming/ReaderTest.java
@@ -14,7 +14,7 @@
 
 package software.amazon.ion.streaming;
 
-import static software.amazon.ion.Symtabs.printLocalSymtab;
+import static software.amazon.ion.impl.Symtabs.printLocalSymtab;
 import static software.amazon.ion.junit.IonAssert.checkNullSymbol;
 
 import java.io.IOException;
@@ -27,9 +27,10 @@ import software.amazon.ion.BinaryTest;
 import software.amazon.ion.Decimal;
 import software.amazon.ion.IonType;
 import software.amazon.ion.ReaderMaker;
+import software.amazon.ion.SymbolTable;
 import software.amazon.ion.SymbolToken;
-import software.amazon.ion.junit.IonAssert;
 import software.amazon.ion.junit.Injected.Inject;
+import software.amazon.ion.junit.IonAssert;
 
 public class ReaderTest
     extends ReaderTestCase
@@ -367,4 +368,15 @@ public class ReaderTest
         testSkippingLob("{a:1, b:{ c:", " }}");
         testSkippingLob("{a:1, b:{ c:", "}}");
     }
+
+    @Test
+    public void testGetSymbolTableBeforeFirstValue()
+    {
+        read("123");
+        SymbolTable symtab = in.getSymbolTable();
+        expectNoCurrentValue();
+        assertNotNull(symtab);
+        assertTrue(symtab.isSystemTable());
+    }
+
 }

--- a/test/software/amazon/ion/system/IonBinaryWriterBuilderTest.java
+++ b/test/software/amazon/ion/system/IonBinaryWriterBuilderTest.java
@@ -21,25 +21,20 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static software.amazon.ion.TestUtils.symbolTableEquals;
-import static software.amazon.ion.impl.PrivateUtils.newLocalSymtab;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Collections;
 import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.ion.IonCatalog;
 import software.amazon.ion.IonSystem;
 import software.amazon.ion.IonWriter;
 import software.amazon.ion.SymbolTable;
-import software.amazon.ion.Symtabs;
 import software.amazon.ion.impl.PrivateIonBinaryWriterBuilder;
 import software.amazon.ion.impl.PrivateIonWriter;
 import software.amazon.ion.impl.PrivateUtils;
-import software.amazon.ion.system.IonBinaryWriterBuilder;
-import software.amazon.ion.system.IonSystemBuilder;
-import software.amazon.ion.system.SimpleCatalog;
+import software.amazon.ion.impl.Symtabs;
 
 public class IonBinaryWriterBuilderTest
 {
@@ -240,11 +235,9 @@ public class IonBinaryWriterBuilderTest
     public void testInitialSymtab()
         throws IOException
     {
-        IonSystem system = IonSystemBuilder.standard().build();
         SymbolTable sst = PrivateUtils.systemSymtab(1);
 
-        SymbolTable lst0 = newLocalSymtab(system, sst,
-                                          Collections.<String>emptyList());
+        SymbolTable lst0 = Symtabs.localSymbolTableFactory().newLocalSymtab(sst);
         lst0.intern("hello");
 
         PrivateIonBinaryWriterBuilder b =
@@ -284,12 +277,10 @@ public class IonBinaryWriterBuilderTest
     @Test
     public void testImmutableInitialSymtab()
     {
-        IonSystem system = IonSystemBuilder.standard().build();
         SymbolTable sst = PrivateUtils.systemSymtab(1);
 
         // Immutable local symtabs shouldn't get copied.
-        SymbolTable lst = newLocalSymtab(system, sst,
-                                         Collections.<String>emptyList());
+        SymbolTable lst = Symtabs.localSymbolTableFactory().newLocalSymtab(sst);
         lst.intern("hello");
         lst.makeReadOnly();
 

--- a/test/software/amazon/ion/system/IonReaderBuilderTest.java
+++ b/test/software/amazon/ion/system/IonReaderBuilderTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package software.amazon.ion.system;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import software.amazon.ion.IonCatalog;
+import software.amazon.ion.IonReader;
+import software.amazon.ion.IonType;
+import software.amazon.ion.IonWriter;
+import software.amazon.ion.impl.PrivateIonBinaryWriterBuilder;
+
+/**
+ * Note: because the IonReaderBuilder is used by IonSystem.newReader(...),
+ * its build() methods are well-exercised elsewhere. See: ReaderMaker.
+ */
+public class IonReaderBuilderTest
+{
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testMutable()
+    {
+        IonCatalog catalog = new SimpleCatalog();
+        IonReaderBuilder mutable = IonReaderBuilder.standard().withCatalog(catalog);
+        assertSame(catalog, mutable.getCatalog());
+        IonReaderBuilder mutableSame = mutable.withCatalog(new SimpleCatalog());
+        assertNotSame(catalog, mutable.getCatalog());
+        assertSame(mutable, mutableSame);
+    }
+
+    @Test
+    public void testImmutable()
+    {
+        IonCatalog catalog = new SimpleCatalog();
+        IonReaderBuilder mutable = IonReaderBuilder.standard().withCatalog(catalog);
+        IonReaderBuilder immutable = mutable.immutable();
+        mutable.withCatalog(new SimpleCatalog());
+        assertNotSame(catalog, mutable.getCatalog());
+        assertSame(catalog, immutable.getCatalog());
+    }
+
+    @Test
+    public void testMutatingImmutableFails()
+    {
+        IonReaderBuilder immutable = IonReaderBuilder.standard().immutable();
+        thrown.expect(UnsupportedOperationException.class);
+        immutable.setCatalog(new SimpleCatalog());
+    }
+
+    @Test
+    public void testMutateCopiedImmutable()
+    {
+        IonCatalog catalog = new SimpleCatalog();
+        IonReaderBuilder immutable = IonReaderBuilder.standard().withCatalog(catalog).immutable();
+        IonReaderBuilder mutableCopy = immutable.copy();
+        assertSame(immutable, immutable.immutable());
+        assertNotSame(immutable, mutableCopy);
+        assertSame(catalog, mutableCopy.getCatalog());
+        mutableCopy.withCatalog(new SimpleCatalog());
+        assertNotSame(catalog, mutableCopy.getCatalog());
+    }
+
+    @Test
+    public void testMutateCopiedMutable()
+    {
+        IonCatalog catalog = new SimpleCatalog();
+        IonReaderBuilder mutable = IonReaderBuilder.standard().withCatalog(catalog);
+        IonReaderBuilder mutableCopy = mutable.copy();
+        assertNotSame(mutable, mutable.immutable());
+        assertNotSame(mutable, mutableCopy);
+        assertSame(mutable, mutable.mutable());
+        assertSame(catalog, mutableCopy.getCatalog());
+        IonReaderBuilder mutableSame = mutableCopy.withCatalog(new SimpleCatalog());
+        assertNotSame(catalog, mutableCopy.getCatalog());
+        assertSame(mutableCopy, mutableSame);
+    }
+
+    @Test
+    public void testSystemFreeRoundtrip() throws IOException
+    {
+        // No IonSystem in sight.
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonWriter writer = PrivateIonBinaryWriterBuilder.standard().build(out);
+        writer.writeInt(42);
+        writer.finish();
+        IonReader reader = IonReaderBuilder.standard().build(out.toByteArray());
+        assertEquals(IonType.INT, reader.next());
+        assertEquals(42, reader.intValue());
+    }
+
+}

--- a/test/software/amazon/ion/system/IonTextWriterBuilderTest.java
+++ b/test/software/amazon/ion/system/IonTextWriterBuilderTest.java
@@ -36,8 +36,8 @@ import org.junit.Test;
 import software.amazon.ion.IonCatalog;
 import software.amazon.ion.IonWriter;
 import software.amazon.ion.SymbolTable;
-import software.amazon.ion.Symtabs;
 import software.amazon.ion.impl.PrivateIonWriter;
+import software.amazon.ion.impl.Symtabs;
 import software.amazon.ion.system.IonTextWriterBuilder;
 import software.amazon.ion.system.SimpleCatalog;
 


### PR DESCRIPTION
IonReaders do not need a ValueFactory (usually an IonSystem), which is responsible for constructing DOM objects (IonValues). Requiring an IonSystem to construct an IonReader represents a confusing entanglement of the DOM and reader/writer APIs. This PR removes the dependency on IonSystem from all IonReaders.

The root cause of this entanglement involves LocalSymbolTables. Previously, all LocalSymbolTables contained a memoized IonStruct containing the Ion representation of that symbol table. This IonStruct LST representation is used in various DOM locations, including IonLoaders, IonSystem.iterate, IonDatagram operations, and the "tree" writers. It is not used by the regular reader/writers, which nevertheless required an IonSystem when constructing new LocalSymbolTables because of the need for a ValueFactory to create the IonStruct LST representation. The only aspect of an IonSystem that IonReaders need is a system symbol table, which can be passed in individually.

This change addresses the problem by splitting LocalSymbolTable into two classes: the LocalSymbolTable base class, and the LocalSymbolTableAsStruct subclass, which contains all of the DOM logic for creating and maintaining the backing IonStruct. LocalSymbolTableAsStruct is only used in the DOM applications previously mentioned, while regular readers and writers only need to use the LocalSymbolTable base class. This frees them from depending on IonSystem, and paves the way for a truly IonSystem-free way of constructing an IonReader, namely through the standalone IonReaderBuilder.

Note that two of the DOM use cases mentioned (IonLoader.load and IonSystem.iterate) actually use IonReaders behind the scenes. To enable decoupling from IonSystem even in these cases, a LocalSymbolTableFactory interface was added. This allows a custom LST creation strategy to be injected into an IonReader. IonLoader.load and IonSystem.iterate will inject a factory that constructs LocalSymbolTableAsStructs in order to maintain the struct-backed behavior of their LSTs.

Another option for solving the problem would have been to completely eliminate the IonStruct LST representation from all LocalSymbolTables. But because the IonStruct representation was memoized, removing that behavior could have performance implications that we'd want to fully understand. There is some extant use in IonDatagramLite and the "tree" writers that looks difficult to remove. We should continue to evaluate whether the behavior has any benefits in those use cases; if not, it should be removed entirely.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
