### PR TITLE
Correctly detects overflow for VarUInt and VarInt

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderBinaryRawX.java
+++ b/src/software/amazon/ion/impl/IonReaderBinaryRawX.java
@@ -909,12 +909,12 @@ abstract class IonReaderBinaryRawX
     }
 
     /**
-     * reads a varInt after the last octet was read. The last octet is used to specify the sign and -0 has different
+     * reads a varInt after the first byte was read. The first byte is used to specify the sign and -0 has different
      * representation on the protected API that was called
      *
-     * @param lastOctet last varInt octet
+     * @param firstByte last varInt octet
      */
-    private int readVarInt(int lastOctet) throws IOException {
+    private int readVarInt(int firstByte) throws IOException {
         // VarInt uses the high-order bit of the last octet as a marker; some (but not all) 5-byte VarInts can fit
         // into a Java int.
         // To validate overflows we accumulate the VarInt in a long and then check if it can be represented by an int
@@ -922,7 +922,7 @@ abstract class IonReaderBinaryRawX
         // see http://amzn.github.io/ion-docs/docs/binary.html#varuint-and-varint-fields
 
         long retValue = 0;
-        int b = lastOctet;
+        int b = firstByte;
         boolean isNegative = false;
 
         for (;;) {

--- a/test/software/amazon/ion/impl/VarIntTest.java
+++ b/test/software/amazon/ion/impl/VarIntTest.java
@@ -12,9 +12,7 @@ public class VarIntTest extends IonTestCase {
 
     @Test
     public void readMaxVarUInt() throws Exception {
-        int actual = makeReader("077F7F7FFF").readVarUInt();
-
-        assertEquals(Integer.MAX_VALUE, actual);
+        assertEquals(Integer.MAX_VALUE, makeReader("077F7F7FFF").readVarUInt());
     }
 
     @Test(expected = IonException.class)
@@ -22,18 +20,34 @@ public class VarIntTest extends IonTestCase {
         makeReader("0800000080").readVarUInt(); // Integer.MAX_VALUE + 1
     }
 
+    @Test(expected = IonException.class)
+    public void readEOFVarUInt() throws Exception {
+        makeReader("").readVarUInt();
+    }
+
+    @Test
+    public void readMaxVarUIntOrEOF() throws Exception {
+        assertEquals(Integer.MAX_VALUE, makeReader("077F7F7FFF").readVarUIntOrEOF());
+    }
+
+    @Test(expected = IonException.class)
+    public void overflowVarUIntOrEOF() throws Exception {
+        makeReader("0800000080").readVarUIntOrEOF(); // Integer.MAX_VALUE + 1
+    }
+
+    @Test
+    public void readEOFVarUIntOrEOF() throws Exception {
+        assertEquals(UnifiedInputStreamX.EOF, makeReader("").readVarUIntOrEOF());
+    }
+
     @Test
     public void readMaxVarInt() throws Exception {
-        int actual = makeReader("077F7F7FFF").readVarInt();
-
-        assertEquals(Integer.MAX_VALUE, actual);
+        assertEquals(Integer.MAX_VALUE, makeReader("077F7F7FFF").readVarInt());
     }
 
     @Test
     public void readMinVarInt() throws Exception {
-        int actual = makeReader("4800000080").readVarInt();
-
-        assertEquals(Integer.MIN_VALUE, actual);
+        assertEquals(Integer.MIN_VALUE, makeReader("4800000080").readVarInt());
     }
 
     @Test(expected = IonException.class)
@@ -46,19 +60,14 @@ public class VarIntTest extends IonTestCase {
         makeReader("4800000081").readVarInt(); // Integer.MIN_VALUE - 1
     }
 
-
     @Test
     public void readMaxVarInteger() throws Exception {
-        Integer actual = makeReader("077F7F7FFF").readVarInteger();
-
-        assertEquals(Integer.MAX_VALUE, (int) actual);
+        assertEquals(Integer.MAX_VALUE, (int) makeReader("077F7F7FFF").readVarInteger());
     }
 
     @Test
     public void readMinVarInteger() throws Exception {
-        Integer actual = makeReader("4800000080").readVarInteger();
-
-        assertEquals(Integer.MIN_VALUE, (int) actual);
+        assertEquals(Integer.MIN_VALUE, (int) makeReader("4800000080").readVarInteger());
     }
 
     @Test(expected = IonException.class)
@@ -73,13 +82,10 @@ public class VarIntTest extends IonTestCase {
 
     @Test
     public void readVarIntegerNegativeZero() throws Exception {
-        Integer actual = makeReader("C0").readVarInteger();
-
-        assertNull(actual);
+        assertNull(makeReader("C0").readVarInteger());
     }
 
     private IonReaderBinaryUserX makeReader(String hex) throws Exception {
-
         ByteArrayInputStream input = new ByteArrayInputStream(DatatypeConverter.parseHexBinary("E00100EA" + hex));
 
         UnifiedInputStreamX uis = UnifiedInputStreamX.makeStream(input);

--- a/test/software/amazon/ion/impl/VarIntTest.java
+++ b/test/software/amazon/ion/impl/VarIntTest.java
@@ -1,0 +1,90 @@
+package software.amazon.ion.impl;
+
+import org.junit.Test;
+import software.amazon.ion.IonException;
+import software.amazon.ion.IonTestCase;
+import software.amazon.ion.system.SimpleCatalog;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.ByteArrayInputStream;
+
+public class VarIntTest extends IonTestCase {
+
+    @Test
+    public void readMaxVarUInt() throws Exception {
+        int actual = makeReader("077F7F7FFF").readVarUInt();
+
+        assertEquals(Integer.MAX_VALUE, actual);
+    }
+
+    @Test(expected = IonException.class)
+    public void overflowVarUInt() throws Exception {
+        makeReader("0800000080").readVarUInt(); // Integer.MAX_VALUE + 1
+    }
+
+    @Test
+    public void readMaxVarInt() throws Exception {
+        int actual = makeReader("077F7F7FFF").readVarInt();
+
+        assertEquals(Integer.MAX_VALUE, actual);
+    }
+
+    @Test
+    public void readMinVarInt() throws Exception {
+        int actual = makeReader("4800000080").readVarInt();
+
+        assertEquals(Integer.MIN_VALUE, actual);
+    }
+
+    @Test(expected = IonException.class)
+    public void readVarIntOverflow() throws Exception {
+        makeReader("0800000080").readVarInt(); // Integer.MAX_VALUE + 1
+    }
+
+    @Test(expected = IonException.class)
+    public void readVarIntUnderflow() throws Exception {
+        makeReader("4800000081").readVarInt(); // Integer.MIN_VALUE - 1
+    }
+
+
+    @Test
+    public void readMaxVarInteger() throws Exception {
+        Integer actual = makeReader("077F7F7FFF").readVarInteger();
+
+        assertEquals(Integer.MAX_VALUE, (int) actual);
+    }
+
+    @Test
+    public void readMinVarInteger() throws Exception {
+        Integer actual = makeReader("4800000080").readVarInteger();
+
+        assertEquals(Integer.MIN_VALUE, (int) actual);
+    }
+
+    @Test(expected = IonException.class)
+    public void readVarIntegerOverflow() throws Exception {
+        makeReader("0800000080").readVarInteger(); // Integer.MAX_VALUE + 1
+    }
+
+    @Test(expected = IonException.class)
+    public void readVarIntegerUnderflow() throws Exception {
+        makeReader("4800000081").readVarInt(); // Integer.MIN_VALUE - 1
+    }
+
+    @Test
+    public void readVarIntegerNegativeZero() throws Exception {
+        Integer actual = makeReader("C0").readVarInteger();
+
+        assertNull(actual);
+    }
+
+    private IonReaderBinaryUserX makeReader(String hex) throws Exception {
+
+        ByteArrayInputStream input = new ByteArrayInputStream(DatatypeConverter.parseHexBinary("E00100EA" + hex));
+
+        UnifiedInputStreamX uis = UnifiedInputStreamX.makeStream(input);
+        uis.skip(4);
+
+        return new IonReaderBinaryUserX(new SimpleCatalog(), LocalSymbolTable.DEFAULT_LST_FACTORY, uis, 0);
+    }
+}


### PR DESCRIPTION
#146: Detects if a `VarUInt` or `VarInt` value fits inside a Java `int`, if not throws an exeception 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
