### PR TITLE
uses decimal.longValue when casting from decimal to long

### DIFF
--- a/src/software/amazon/ion/impl/PrivateScalarConversions.java
+++ b/src/software/amazon/ion/impl/PrivateScalarConversions.java
@@ -800,7 +800,7 @@ public class PrivateScalarConversions
             ) {
                 throw new CantConvertException("BigDecimal value is too large to fit in a long");
             }
-            _long_value = _decimal_value.intValue();
+            _long_value = _decimal_value.longValue();
             add_value_type(AS_TYPE.long_value);
         }
         private final void fn_from_double_to_long() {

--- a/test/software/amazon/ion/impl/PrivateScalarConversionsTest.java
+++ b/test/software/amazon/ion/impl/PrivateScalarConversionsTest.java
@@ -1,0 +1,33 @@
+package software.amazon.ion.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+import software.amazon.ion.Decimal;
+
+import static org.junit.Assert.*;
+
+public class PrivateScalarConversionsTest {
+
+    private long decimalToLong(final Decimal d) {
+        PrivateScalarConversions.ValueVariant v = new PrivateScalarConversions.ValueVariant();
+        v.setValue(d);
+
+        v.cast(PrivateScalarConversions.FNID_FROM_DECIMAL_TO_LONG);
+        return v.getLong();
+    }
+
+    @Test
+    public void decimalToLong() {
+        assertEquals(1, decimalToLong(Decimal.valueOf(1L)));
+    }
+
+    @Test
+    public void decimalToMinLong() {
+        assertEquals(Long.MAX_VALUE, decimalToLong(Decimal.valueOf(Long.MAX_VALUE)));
+    }
+
+    @Test
+    public void decimalToMaxLong() {
+        assertEquals(Long.MIN_VALUE, decimalToLong(Decimal.valueOf(Long.MIN_VALUE)));
+    }
+}


### PR DESCRIPTION
was using intValue previously resulting in overflow. Inludes UTs to
verify the behavior

https://github.com/amzn/ion-java/issues/148

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
