### PR TITLE
Requires the $ion_symbol_table annotation to be a struct's first annotation in order to carry LST semantics.

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderBinaryUserX.java
+++ b/src/software/amazon/ion/impl/IonReaderBinaryUserX.java
@@ -214,13 +214,10 @@ final class IonReaderBinaryUserX
             }
             else if (_value_tid == PrivateIonConstants.tidStruct) {
                 int count = load_annotations();
-                for(int ii=0; ii<count; ii++) {
-                    if (_annotation_ids[ii] == ION_SYMBOL_TABLE_SID) {
-                        _symbols = _lstFactory.newLocalSymtab(_catalog, this, false);
-                        push_symbol_table(_symbols);
-                        _has_next_needed = true;
-                        break;
-                    }
+                if (count > 0 && _annotation_ids[0] == ION_SYMBOL_TABLE_SID) {
+                    _symbols = _lstFactory.newLocalSymtab(_catalog, this, false);
+                    push_symbol_table(_symbols);
+                    _has_next_needed = true;
                 }
             }
             else {

--- a/src/software/amazon/ion/impl/IonReaderTextUserX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextUserX.java
@@ -128,19 +128,12 @@ class IonReaderTextUserX
             if (_value_type != null && !isNullValue() && IonType.DATAGRAM.equals(getContainerType())) {
                 switch (_value_type) {
                 case STRUCT:
-                    if (_annotation_count > 0) {
-                        for (int ii=0; ii<_annotation_count; ii++) {
-                            SymbolToken a = _annotations[ii];
-                            // TODO SID only?
-                            if (ION_SYMBOL_TABLE.equals(a.getText())) {
-                                _symbols = _lstFactory.newLocalSymtab(_catalog,
-                                                                      this,
-                                                                      true);
-                                push_symbol_table(_symbols);
-                                _has_next_called = false;
-                                break;
-                            }
-                        }
+                    if (_annotation_count > 0 && ION_SYMBOL_TABLE.equals(_annotations[0].getText())) {
+                        _symbols = _lstFactory.newLocalSymtab(_catalog,
+                                                              this,
+                                                              true);
+                        push_symbol_table(_symbols);
+                        _has_next_called = false;
                     }
                     break;
                 case SYMBOL:

--- a/src/software/amazon/ion/impl/IonReaderTreeUserX.java
+++ b/src/software/amazon/ion/impl/IonReaderTreeUserX.java
@@ -115,7 +115,7 @@ final class IonReaderTreeUserX
                     }
                 }
                 else if (IonType.STRUCT.equals(next_type)
-                      && _next.hasTypeAnnotation(ION_SYMBOL_TABLE)
+                      && _next.findTypeAnnotation(ION_SYMBOL_TABLE) == 0
                 ) {
                     assert(_next instanceof IonStruct);
                     // read a local symbol table

--- a/src/software/amazon/ion/impl/IonWriterSystem.java
+++ b/src/software/amazon/ion/impl/IonWriterSystem.java
@@ -434,36 +434,9 @@ abstract class IonWriterSystem
     }
 
 
-    final int[] internAnnotationsAndGetSids() throws IOException
-    {
-        int count = _annotation_count;
-        if (count == 0) return PrivateUtils.EMPTY_INT_ARRAY;
-
-        int[] sids = new int[count];
-        for (int i = 0; i < count; i++)
-        {
-            SymbolToken sym = _annotations[i];
-            int sid = sym.getSid();
-            if (sid == UNKNOWN_SYMBOL_ID)
-            {
-                String text = sym.getText();
-                sid = add_symbol(text);
-                _annotations[i] = new SymbolTokenImpl(text, sid);
-            }
-            sids[i] = sid;
-        }
-        return sids;
-    }
-
-
     final boolean hasAnnotations()
     {
         return _annotation_count != 0;
-    }
-
-    final int annotationCount()
-    {
-        return _annotation_count;
     }
 
     final void clearAnnotations()
@@ -471,21 +444,16 @@ abstract class IonWriterSystem
         _annotation_count = 0;
     }
 
-
     @Override
-    final boolean has_annotation(String name, int id)
-    {
-        assert(this._symbol_table.findKnownSymbol(id).equals(name));
-        if (_annotation_count < 1) {
-            return false;
-        }
-
-        for (int ii=0; ii<_annotation_count; ii++) {
-            if (name.equals(_annotations[ii].getText())) {
-                return true;
+    final int findAnnotation(String name) {
+        if (_annotation_count > 0) {
+            for (int ii=0; ii<_annotation_count; ii++) {
+                if (name.equals(_annotations[ii].getText())) {
+                    return ii;
+                }
             }
         }
-        return false;
+        return -1;
     }
 
     final SymbolToken[] getTypeAnnotationSymbols()

--- a/src/software/amazon/ion/impl/IonWriterSystemTree.java
+++ b/src/software/amazon/ion/impl/IonWriterSystemTree.java
@@ -219,7 +219,7 @@ final class IonWriterSystemTree
 
     public void stepOut() throws IOException
     {
-        IonValue prior = _current_parent;
+        PrivateIonValue prior = (PrivateIonValue)_current_parent;
         popParent();
 
         if (_current_parent instanceof IonDatagram

--- a/src/software/amazon/ion/impl/IonWriterUser.java
+++ b/src/software/amazon/ion/impl/IonWriterUser.java
@@ -148,11 +148,9 @@ class IonWriterUser
         return _catalog;
     }
 
-
     @Override
-    boolean has_annotation(String name, int id)
-    {
-        return _current_writer.has_annotation(name, id);
+    int findAnnotation(String name) {
+        return _current_writer.findAnnotation(name);
     }
 
     @Override
@@ -374,7 +372,7 @@ class IonWriterUser
         // see if it looks like we're starting a local symbol table
         if (containerType == IonType.STRUCT
             && _current_writer.getDepth() == 0
-            && has_annotation(ION_SYMBOL_TABLE, ION_SYMBOL_TABLE_SID))
+            && findAnnotation(ION_SYMBOL_TABLE) == 0)
         {
             open_local_symbol_table_copy();
         }

--- a/src/software/amazon/ion/impl/PrivateIonValue.java
+++ b/src/software/amazon/ion/impl/PrivateIonValue.java
@@ -60,6 +60,13 @@ public interface PrivateIonValue
     public SymbolToken[] getTypeAnnotationSymbols(SymbolTableProvider symbolTableProvider);
 
     /**
+     * Returns the given annotation's index in the value's annotations list, or -1 if not present.
+     * @param annotation the annotation to find.
+     * @return the index or -1.
+     */
+    int findTypeAnnotation(String annotation);
+
+    /**
      * Makes this symbol table current for this value.
      * This may directly apply to this IonValue if this
      * value is either loose or a top level datagram

--- a/src/software/amazon/ion/impl/PrivateIonWriterBase.java
+++ b/src/software/amazon/ion/impl/PrivateIonWriterBase.java
@@ -124,8 +124,12 @@ public abstract class PrivateIonWriterBase
     //========================================================================
     // Annotations
 
-
-    abstract boolean has_annotation(String name, int id);
+    /**
+     * Returns the given annotation's index in the value's annotations list, or -1 if not present.
+     * @param name the annotation to find.
+     * @return the index or -1.
+     */
+    abstract int findAnnotation(String name);
 
 
     /**

--- a/src/software/amazon/ion/impl/PrivateUtils.java
+++ b/src/software/amazon/ion/impl/PrivateUtils.java
@@ -644,10 +644,10 @@ public final class PrivateUtils
      *
      * @return boolean true if v can be a local symbol table otherwise false
      */
-    public static boolean valueIsLocalSymbolTable(IonValue v)
+    public static boolean valueIsLocalSymbolTable(PrivateIonValue v)
     {
         return (v instanceof IonStruct
-                && v.hasTypeAnnotation(ION_SYMBOL_TABLE));
+                && v.findTypeAnnotation(ION_SYMBOL_TABLE) == 0);
     }
 
 

--- a/src/software/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/software/amazon/ion/impl/lite/IonValueLite.java
@@ -661,14 +661,16 @@ abstract class IonValueLite
     public final boolean hasTypeAnnotation(String annotation)
     {
         if (annotation != null && annotation.length() > 0) {
-            int pos = find_type_annotation(annotation);
+            int pos = findTypeAnnotation(annotation);
             if (pos >= 0) {
                 return true;
             }
         }
         return false;
     }
-    private final int find_type_annotation(String annotation)
+
+    @Override
+    public final int findTypeAnnotation(String annotation)
     {
         assert(annotation != null && annotation.length() > 0);
 
@@ -802,7 +804,7 @@ abstract class IonValueLite
         checkForLock();
 
         if (annotation != null && annotation.length() > 0) {
-            int pos = find_type_annotation(annotation);
+            int pos = findTypeAnnotation(annotation);
             if (pos < 0) {
                 return;
             }


### PR DESCRIPTION
*Description of changes:*

Relevant line from the spec:
> ...a top-level struct whose first annotation is $ion_symbol_table is interpreted as a local symbol table.

This PR also updates the ion-tests submodule, which brings in the coverage for this change (see `iontestdata/good/equivs/localSymbolTableWithAnnotations.ion` and `iontestdata/good/non-equivs/localSymbolTableWithAnnotations.ion`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
