### PR TITLE
Disallows writing and reading symbol IDs out of range of the local symbol table.

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderBinarySystemX.java
+++ b/src/software/amazon/ion/impl/IonReaderBinarySystemX.java
@@ -403,7 +403,7 @@ class IonReaderBinarySystemX
         return _v.getString();
     }
 
-    public final SymbolToken symbolValue()
+    public SymbolToken symbolValue()
     {
         if (_value_type != SYMBOL) throw new IllegalStateException();
         if (_value_is_null) return null;
@@ -439,7 +439,7 @@ class IonReaderBinarySystemX
         return name;
     }
 
-    public final SymbolToken getFieldNameSymbol()
+    public SymbolToken getFieldNameSymbol()
     {
         if (_value_field_id == SymbolTable.UNKNOWN_SYMBOL_ID) return null;
         int sid = _value_field_id;

--- a/src/software/amazon/ion/impl/IonReaderBinaryUserX.java
+++ b/src/software/amazon/ion/impl/IonReaderBinaryUserX.java
@@ -25,6 +25,8 @@ import software.amazon.ion.SeekableReader;
 import software.amazon.ion.Span;
 import software.amazon.ion.SpanProvider;
 import software.amazon.ion.SymbolTable;
+import software.amazon.ion.SymbolToken;
+import software.amazon.ion.UnknownSymbolException;
 import software.amazon.ion.impl.PrivateScalarConversions.AS_TYPE;
 import software.amazon.ion.impl.UnifiedInputStreamX.FromByteArray;
 import software.amazon.ion.impl.UnifiedSavePointManagerX.SavePoint;
@@ -224,6 +226,37 @@ final class IonReaderBinaryUserX
                 assert (_value_tid != PrivateIonConstants.tidTypedecl);
             }
         }
+    }
+
+    private void validateSymbolToken(SymbolToken symbol) {
+        if (symbol != null) {
+            if (symbol.getText() == null && symbol.getSid() > getSymbolTable().getMaxId()) {
+                throw new UnknownSymbolException(symbol.getSid());
+            }
+        }
+    }
+
+    @Override
+    public SymbolToken[] getTypeAnnotationSymbols() {
+        SymbolToken[] annotations = super.getTypeAnnotationSymbols();
+        for (SymbolToken annotation : annotations) {
+            validateSymbolToken(annotation);
+        }
+        return annotations;
+    }
+
+    @Override
+    public final SymbolToken getFieldNameSymbol() {
+        SymbolToken fieldName = super.getFieldNameSymbol();
+        validateSymbolToken(fieldName);
+        return fieldName;
+    }
+
+    @Override
+    public final SymbolToken symbolValue() {
+        SymbolToken symbol = super.symbolValue();
+        validateSymbolToken(symbol);
+        return symbol;
     }
 
     //

--- a/src/software/amazon/ion/impl/IonReaderBinaryUserX.java
+++ b/src/software/amazon/ion/impl/IonReaderBinaryUserX.java
@@ -214,13 +214,10 @@ final class IonReaderBinaryUserX
             }
             else if (_value_tid == PrivateIonConstants.tidStruct) {
                 int count = load_annotations();
-                for(int ii=0; ii<count; ii++) {
-                    if (_annotation_ids[ii] == ION_SYMBOL_TABLE_SID) {
-                        _symbols = _lstFactory.newLocalSymtab(_catalog, this, false);
-                        push_symbol_table(_symbols);
-                        _has_next_needed = true;
-                        break;
-                    }
+                if (count > 0 && _annotation_ids[0] == ION_SYMBOL_TABLE_SID) {
+                    _symbols = _lstFactory.newLocalSymtab(_catalog, this, false);
+                    push_symbol_table(_symbols);
+                    _has_next_needed = true;
                 }
             }
             else {

--- a/src/software/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextSystemX.java
@@ -662,7 +662,7 @@ class IonReaderTextSystemX
     }
 
     @Override
-    public final SymbolToken getFieldNameSymbol()
+    public SymbolToken getFieldNameSymbol()
     {
         SymbolToken sym = super.getFieldNameSymbol();
         if (sym != null)

--- a/src/software/amazon/ion/impl/IonReaderTextUserX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextUserX.java
@@ -128,19 +128,12 @@ class IonReaderTextUserX
             if (_value_type != null && !isNullValue() && IonType.DATAGRAM.equals(getContainerType())) {
                 switch (_value_type) {
                 case STRUCT:
-                    if (_annotation_count > 0) {
-                        for (int ii=0; ii<_annotation_count; ii++) {
-                            SymbolToken a = _annotations[ii];
-                            // TODO SID only?
-                            if (ION_SYMBOL_TABLE.equals(a.getText())) {
-                                _symbols = _lstFactory.newLocalSymtab(_catalog,
-                                                                      this,
-                                                                      true);
-                                push_symbol_table(_symbols);
-                                _has_next_called = false;
-                                break;
-                            }
-                        }
+                    if (_annotation_count > 0 && ION_SYMBOL_TABLE.equals(_annotations[0].getText())) {
+                        _symbols = _lstFactory.newLocalSymtab(_catalog,
+                                                              this,
+                                                              true);
+                        push_symbol_table(_symbols);
+                        _has_next_called = false;
                     }
                     break;
                 case SYMBOL:

--- a/src/software/amazon/ion/impl/IonReaderTextUserX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextUserX.java
@@ -27,6 +27,7 @@ import software.amazon.ion.SpanProvider;
 import software.amazon.ion.SymbolTable;
 import software.amazon.ion.SymbolToken;
 import software.amazon.ion.TextSpan;
+import software.amazon.ion.UnknownSymbolException;
 import software.amazon.ion.UnsupportedIonVersionException;
 
 /**
@@ -177,6 +178,36 @@ class IonReaderTextUserX
         return;
     }
 
+    private void validateSymbolToken(SymbolToken symbol) {
+        if (symbol != null) {
+            if (symbol.getText() == null && symbol.getSid() > getSymbolTable().getMaxId()) {
+                throw new UnknownSymbolException(symbol.getSid());
+            }
+        }
+    }
+
+    @Override
+    public SymbolToken[] getTypeAnnotationSymbols() {
+        SymbolToken[] annotations = super.getTypeAnnotationSymbols();
+        for (SymbolToken annotation : annotations) {
+            validateSymbolToken(annotation);
+        }
+        return annotations;
+    }
+
+    @Override
+    public final SymbolToken getFieldNameSymbol() {
+        SymbolToken fieldName = super.getFieldNameSymbol();
+        validateSymbolToken(fieldName);
+        return fieldName;
+    }
+
+    @Override
+    public final SymbolToken symbolValue() {
+        SymbolToken symbol = super.symbolValue();
+        validateSymbolToken(symbol);
+        return symbol;
+    }
 
     @Override
     public SymbolTable getSymbolTable()

--- a/src/software/amazon/ion/impl/IonReaderTreeUserX.java
+++ b/src/software/amazon/ion/impl/IonReaderTreeUserX.java
@@ -115,7 +115,7 @@ final class IonReaderTreeUserX
                     }
                 }
                 else if (IonType.STRUCT.equals(next_type)
-                      && _next.hasTypeAnnotation(ION_SYMBOL_TABLE)
+                      && _next.findTypeAnnotation(ION_SYMBOL_TABLE) == 0
                 ) {
                     assert(_next instanceof IonStruct);
                     // read a local symbol table

--- a/src/software/amazon/ion/impl/IonWriterSystem.java
+++ b/src/software/amazon/ion/impl/IonWriterSystem.java
@@ -434,36 +434,9 @@ abstract class IonWriterSystem
     }
 
 
-    final int[] internAnnotationsAndGetSids() throws IOException
-    {
-        int count = _annotation_count;
-        if (count == 0) return PrivateUtils.EMPTY_INT_ARRAY;
-
-        int[] sids = new int[count];
-        for (int i = 0; i < count; i++)
-        {
-            SymbolToken sym = _annotations[i];
-            int sid = sym.getSid();
-            if (sid == UNKNOWN_SYMBOL_ID)
-            {
-                String text = sym.getText();
-                sid = add_symbol(text);
-                _annotations[i] = new SymbolTokenImpl(text, sid);
-            }
-            sids[i] = sid;
-        }
-        return sids;
-    }
-
-
     final boolean hasAnnotations()
     {
         return _annotation_count != 0;
-    }
-
-    final int annotationCount()
-    {
-        return _annotation_count;
     }
 
     final void clearAnnotations()
@@ -471,21 +444,16 @@ abstract class IonWriterSystem
         _annotation_count = 0;
     }
 
-
     @Override
-    final boolean has_annotation(String name, int id)
-    {
-        assert(this._symbol_table.findKnownSymbol(id).equals(name));
-        if (_annotation_count < 1) {
-            return false;
-        }
-
-        for (int ii=0; ii<_annotation_count; ii++) {
-            if (name.equals(_annotations[ii].getText())) {
-                return true;
+    final int findAnnotation(String name) {
+        if (_annotation_count > 0) {
+            for (int ii=0; ii<_annotation_count; ii++) {
+                if (name.equals(_annotations[ii].getText())) {
+                    return ii;
+                }
             }
         }
-        return false;
+        return -1;
     }
 
     final SymbolToken[] getTypeAnnotationSymbols()

--- a/src/software/amazon/ion/impl/IonWriterSystem.java
+++ b/src/software/amazon/ion/impl/IonWriterSystem.java
@@ -391,6 +391,7 @@ abstract class IonWriterSystem
             if (sid < 0) {
                 throw new IllegalArgumentException();
             }
+            validateSymbolId(sid);
 
             _field_name_type = IonType.INT;
             _field_name_sid = sid;
@@ -483,6 +484,9 @@ abstract class IonWriterSystem
             for (int i = 0; i < count; i++)
             {
                 SymbolToken sym = annotations[i];
+                if (sym.getText() == null) {
+                    validateSymbolId(sym.getSid());
+                }
                 sym = PrivateUtils.localize(symtab, sym);
                 _annotations[i] = sym;
             }

--- a/src/software/amazon/ion/impl/IonWriterSystemTree.java
+++ b/src/software/amazon/ion/impl/IonWriterSystemTree.java
@@ -219,7 +219,7 @@ final class IonWriterSystemTree
 
     public void stepOut() throws IOException
     {
-        IonValue prior = _current_parent;
+        PrivateIonValue prior = (PrivateIonValue)_current_parent;
         popParent();
 
         if (_current_parent instanceof IonDatagram

--- a/src/software/amazon/ion/impl/IonWriterUser.java
+++ b/src/software/amazon/ion/impl/IonWriterUser.java
@@ -148,11 +148,9 @@ class IonWriterUser
         return _catalog;
     }
 
-
     @Override
-    boolean has_annotation(String name, int id)
-    {
-        return _current_writer.has_annotation(name, id);
+    int findAnnotation(String name) {
+        return _current_writer.findAnnotation(name);
     }
 
     @Override
@@ -374,7 +372,7 @@ class IonWriterUser
         // see if it looks like we're starting a local symbol table
         if (containerType == IonType.STRUCT
             && _current_writer.getDepth() == 0
-            && has_annotation(ION_SYMBOL_TABLE, ION_SYMBOL_TABLE_SID))
+            && findAnnotation(ION_SYMBOL_TABLE) == 0)
         {
             open_local_symbol_table_copy();
         }

--- a/src/software/amazon/ion/impl/PrivateIonSystem.java
+++ b/src/software/amazon/ion/impl/PrivateIonSystem.java
@@ -36,19 +36,19 @@ public interface PrivateIonSystem
     public SymbolTable newSharedSymbolTable(IonStruct ionRep);
 
     /**
-     * TODO Must correct amzn/ion-java#63 before exposing this or using from public API.
+     * TODO Must correct amzn/ion-java#14 before exposing this or using from public API.
      */
     public Iterator<IonValue> systemIterate(String ionText);
 
     /**
-     * TODO Must correct amzn/ion-java#63 before exposing this or using from public API.
+     * TODO Must correct amzn/ion-java#14 before exposing this or using from public API.
      */
     public Iterator<IonValue> systemIterate(Reader ionText);
 
     public Iterator<IonValue> systemIterate(byte[] ionData);
 
     /**
-     * TODO Must correct amzn/ion-java#63 before exposing this or using from public API.
+     * TODO Must correct amzn/ion-java#14 before exposing this or using from public API.
      */
     public Iterator<IonValue> systemIterate(InputStream ionData);
 

--- a/src/software/amazon/ion/impl/PrivateIonValue.java
+++ b/src/software/amazon/ion/impl/PrivateIonValue.java
@@ -60,6 +60,13 @@ public interface PrivateIonValue
     public SymbolToken[] getTypeAnnotationSymbols(SymbolTableProvider symbolTableProvider);
 
     /**
+     * Returns the given annotation's index in the value's annotations list, or -1 if not present.
+     * @param annotation the annotation to find.
+     * @return the index or -1.
+     */
+    int findTypeAnnotation(String annotation);
+
+    /**
      * Makes this symbol table current for this value.
      * This may directly apply to this IonValue if this
      * value is either loose or a top level datagram

--- a/src/software/amazon/ion/impl/PrivateIonWriterBase.java
+++ b/src/software/amazon/ion/impl/PrivateIonWriterBase.java
@@ -124,8 +124,12 @@ public abstract class PrivateIonWriterBase
     //========================================================================
     // Annotations
 
-
-    abstract boolean has_annotation(String name, int id);
+    /**
+     * Returns the given annotation's index in the value's annotations list, or -1 if not present.
+     * @param name the annotation to find.
+     * @return the index or -1.
+     */
+    abstract int findAnnotation(String name);
 
 
     /**

--- a/src/software/amazon/ion/impl/PrivateIonWriterBase.java
+++ b/src/software/amazon/ion/impl/PrivateIonWriterBase.java
@@ -165,9 +165,8 @@ public abstract class PrivateIonWriterBase
     abstract int[] getTypeAnnotationIds();
 
     /**
-     * Write symbolId out as an IonSymbol value.  The value does not
-     * have to be valid in the symbol table, unless the output is
-     * text, in which case it does.
+     * Write symbolId out as an IonSymbol value.  The value must
+     * be valid in the symbol table.
      *
      * @param symbolId symbol table id to write
      */
@@ -217,6 +216,13 @@ public abstract class PrivateIonWriterBase
         writeNull(IonType.NULL);
     }
 
+    final void validateSymbolId(int sid) {
+        if (sid > getSymbolTable().getMaxId()) {
+            // There is no slot for this symbol ID in the symbol table,
+            // so an error would be raised on read. Fail early on write.
+            throw new UnknownSymbolException(sid);
+        }
+    }
 
     public final void writeSymbolToken(SymbolToken tok)
         throws IOException
@@ -234,6 +240,7 @@ public abstract class PrivateIonWriterBase
         else
         {
             int sid = tok.getSid();
+            validateSymbolId(sid);
             writeSymbol(sid);
         }
     }

--- a/src/software/amazon/ion/impl/PrivateUtils.java
+++ b/src/software/amazon/ion/impl/PrivateUtils.java
@@ -644,10 +644,10 @@ public final class PrivateUtils
      *
      * @return boolean true if v can be a local symbol table otherwise false
      */
-    public static boolean valueIsLocalSymbolTable(IonValue v)
+    public static boolean valueIsLocalSymbolTable(PrivateIonValue v)
     {
         return (v instanceof IonStruct
-                && v.hasTypeAnnotation(ION_SYMBOL_TABLE));
+                && v.findTypeAnnotation(ION_SYMBOL_TABLE) == 0);
     }
 
 

--- a/src/software/amazon/ion/impl/bin/IonManagedBinaryWriter.java
+++ b/src/software/amazon/ion/impl/bin/IonManagedBinaryWriter.java
@@ -48,6 +48,7 @@ import software.amazon.ion.IonType;
 import software.amazon.ion.SymbolTable;
 import software.amazon.ion.SymbolToken;
 import software.amazon.ion.Timestamp;
+import software.amazon.ion.UnknownSymbolException;
 import software.amazon.ion.impl.PrivateUtils;
 import software.amazon.ion.impl.bin.IonRawBinaryWriter.StreamCloseMode;
 import software.amazon.ion.impl.bin.IonRawBinaryWriter.StreamFlushMode;
@@ -842,6 +843,12 @@ import software.amazon.ion.impl.bin.IonRawBinaryWriter.StreamFlushMode;
         {
             // string content always makes us intern
             return intern(text);
+        }
+        final int sid = token.getSid();
+        if (sid > getSymbolTable().getMaxId()) {
+            // There is no slot for this symbol ID in the symbol table,
+            // so an error would be raised on read. Fail early on write.
+            throw new UnknownSymbolException(sid);
         }
         // no text, we just return what we got
         return token;

--- a/src/software/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/software/amazon/ion/impl/lite/IonValueLite.java
@@ -661,14 +661,16 @@ abstract class IonValueLite
     public final boolean hasTypeAnnotation(String annotation)
     {
         if (annotation != null && annotation.length() > 0) {
-            int pos = find_type_annotation(annotation);
+            int pos = findTypeAnnotation(annotation);
             if (pos >= 0) {
                 return true;
             }
         }
         return false;
     }
-    private final int find_type_annotation(String annotation)
+
+    @Override
+    public final int findTypeAnnotation(String annotation)
     {
         assert(annotation != null && annotation.length() > 0);
 
@@ -802,7 +804,7 @@ abstract class IonValueLite
         checkForLock();
 
         if (annotation != null && annotation.length() > 0) {
-            int pos = find_type_annotation(annotation);
+            int pos = findTypeAnnotation(annotation);
             if (pos < 0) {
                 return;
             }

--- a/test/software/amazon/ion/CloneTest.java
+++ b/test/software/amazon/ion/CloneTest.java
@@ -74,8 +74,6 @@ public class CloneTest
         assertEquals(99, copy.symbolValue().getSid());
     }
 
-    static final boolean DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT = true;
-
     @Test
     public void testIonValueCloneWithUnknownAnnotationText()
     {
@@ -83,15 +81,8 @@ public class CloneTest
         IonInt original = system().newInt(5);
         original.setTypeAnnotationSymbols(tok);
 
-        if (! DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            thrown.expect(UnknownSymbolException.class);
-            thrown.expectMessage("$99");
-        }
-
         IonInt actual = original.clone();
-        if (DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            assertEquals(original, actual);
-        }
+        assertEquals(original, actual);
     }
 
     @Test
@@ -101,15 +92,8 @@ public class CloneTest
         IonInt original = system().newInt(5);
         original.setTypeAnnotationSymbols(tok);
 
-        if (! DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            thrown.expect(UnknownSymbolException.class);
-            thrown.expectMessage("$99");
-        }
-
         IonInt actual = system().clone(original);
-        if (DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            assertEquals(original, actual);
-        }
+        assertEquals(original, actual);
     }
 
     @Test

--- a/test/software/amazon/ion/HashCodeCorrectnessTest.java
+++ b/test/software/amazon/ion/HashCodeCorrectnessTest.java
@@ -543,10 +543,11 @@ public class HashCodeCorrectnessTest
                                        "{a:456, b:456}");
         assertIonNotEqImpliesHashNotEq("{a:annot::123, b:123}",
                                        "{a:456, b:annot::456}");
-        assertIonNotEqImpliesHashNotEq("{$99:123, $98:123}",
-                                       "{$99:456, $98:456}");
-        assertIonNotEqImpliesHashNotEq("{$99:annot::123, $98:123}",
-                                       "{$99:456, $98:annot::456}");
+        String sharedSymbolTable = "$ion_symbol_table::{imports:[{name:\"foo\", version: 1, max_id:90}]}";
+        assertIonNotEqImpliesHashNotEq(sharedSymbolTable + "{$99:123, $98:123}",
+                                       sharedSymbolTable + "{$99:456, $98:456}");
+        assertIonNotEqImpliesHashNotEq(sharedSymbolTable + "{$99:annot::123, $98:123}",
+                                       sharedSymbolTable + "{$99:456, $98:annot::456}");
     }
 
     @Test
@@ -564,18 +565,20 @@ public class HashCodeCorrectnessTest
                                        "{alpha:a, beta:b}");
         assertIonNotEqImpliesHashNotEq("{a:alpha, b:beta, c:charlie}",
                                        "{alpha:a, beta:b, charlie:c}");
-        assertIonNotEqImpliesHashNotEq("{$99:a}",
-                                       "{a:$99}");
-        assertIonNotEqImpliesHashNotEq("{$99:a, $999:b}",
-                                       "{a:$99, b:$999}");
-        assertIonNotEqImpliesHashNotEq("{$99:a, $999:b, $9999:c}",
-                                       "{a:$99, b:$999, c:$9999}");
+        String sharedSymbolTable = "$ion_symbol_table::{imports:[{name:\"foo\", version: 1, max_id:9990}]} ";
+        assertIonNotEqImpliesHashNotEq(sharedSymbolTable + "{$99:a}",
+                                       sharedSymbolTable + "{a:$99}");
+        assertIonNotEqImpliesHashNotEq(sharedSymbolTable + "{$99:a, $999:b}",
+                                       sharedSymbolTable + "{a:$99, b:$999}");
+        assertIonNotEqImpliesHashNotEq(sharedSymbolTable + "{$99:a, $999:b, $9999:c}",
+                                       sharedSymbolTable + "{a:$99, b:$999, c:$9999}");
     }
 
     protected void testTypeAnnotationHashCode(String text, IonType type)
     {
+        String sharedSymbolTable = "$ion_symbol_table::{imports:[{name:\"foo\", version: 1, max_id:90}]}";
         checkType(type, oneValue("annot1::" + text));
-        checkType(type, oneValue("$99::" + text));
+        checkType(type, oneValue(sharedSymbolTable + "$99::" + text));
 
         assertIonEqImpliesHashEq(oneValue("annot1::" + text),
                                  oneValue("annot2::" + text));
@@ -584,12 +587,12 @@ public class HashCodeCorrectnessTest
         assertIonEqImpliesHashEq(oneValue("annot1::annot2::annot3::" + text),
                                  oneValue("annot1::annot2::annot3::" + text));
 
-        assertIonEqImpliesHashEq(oneValue("$99::" + text),
-                                 oneValue("$98::" + text));
-        assertIonEqImpliesHashEq(oneValue("$99::$98::" + text),
-                                 oneValue("$99::$98::" + text));
-        assertIonEqImpliesHashEq(oneValue("$99::$98::$97::" + text),
-                                 oneValue("$99::$98::$97::" + text));
+        assertIonEqImpliesHashEq(oneValue(sharedSymbolTable + "$99::" + text),
+                                 oneValue(sharedSymbolTable + "$98::" + text));
+        assertIonEqImpliesHashEq(oneValue(sharedSymbolTable + "$99::$98::" + text),
+                                 oneValue(sharedSymbolTable + "$99::$98::" + text));
+        assertIonEqImpliesHashEq(oneValue(sharedSymbolTable + "$99::$98::$97::" + text),
+                                 oneValue(sharedSymbolTable + "$99::$98::$97::" + text));
 
         assertIonNotEqImpliesHashNotEq("annot1::" + text,
                                        "annot2::" + text);
@@ -598,12 +601,12 @@ public class HashCodeCorrectnessTest
         assertIonNotEqImpliesHashNotEq("annot1::annot2::annot3::" + text,
                                        "annot3::annot2::annot1::" + text);
 
-        assertIonNotEqImpliesHashNotEq("$99::" + text,
-                                       "$98::" + text);
-        assertIonNotEqImpliesHashNotEq("$99::$98::" + text,
-                                       "$98::$99::" + text);
-        assertIonNotEqImpliesHashNotEq("$99::$98::$97::" + text,
-                                       "$97::$98::$99::" + text);
+        assertIonNotEqImpliesHashNotEq(sharedSymbolTable + "$99::" + text,
+                                       sharedSymbolTable + "$98::" + text);
+        assertIonNotEqImpliesHashNotEq(sharedSymbolTable + "$99::$98::" + text,
+                                       sharedSymbolTable + "$98::$99::" + text);
+        assertIonNotEqImpliesHashNotEq(sharedSymbolTable + "$99::$98::$97::" + text,
+                                       sharedSymbolTable + "$97::$98::$99::" + text);
     }
 
     @Test

--- a/test/software/amazon/ion/IonValueTest.java
+++ b/test/software/amazon/ion/IonValueTest.java
@@ -272,11 +272,12 @@ public class IonValueTest
     @Test
     public void testDetachWithUnknownAnnotation()
     {
-        IonList list = (IonList) system().singleValue("[$99::null]");
+        String sharedSymbolTable = "$ion_symbol_table::{imports:[{name:\"foo\", version: 1, max_id: 90}]}";
+        IonList list = (IonList) system().singleValue(sharedSymbolTable + "[$99::null]");
         IonValue child = list.get(0);
         child.removeFromContainer();
 
-        IonAssert.assertIonEquals(system().singleValue("$99::null"), child);
+        IonAssert.assertIonEquals(system().singleValue(sharedSymbolTable + "$99::null"), child);
     }
 
 

--- a/test/software/amazon/ion/StructTest.java
+++ b/test/software/amazon/ion/StructTest.java
@@ -14,7 +14,6 @@
 
 package software.amazon.ion;
 
-import static software.amazon.ion.CloneTest.DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT;
 import static software.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
 
 import java.io.PrintWriter;
@@ -50,6 +49,10 @@ import software.amazon.ion.impl.PrivateUtils;
 public class StructTest
     extends ContainerTestCase
 {
+
+    private static final String SHARED_SYMBOL_TABLE
+            = "$ion_symbol_table::{imports:[{name:\"foo\", version:1, max_id:90}]} ";
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -217,7 +220,7 @@ public class StructTest
     @Test
     public void testPutAfterUnknownFieldName()
     {
-        IonStruct value = struct("{$99:null}");
+        IonStruct value = struct(SHARED_SYMBOL_TABLE + "{$99:null}");
         value.put("hi", system().newNull());
     }
 
@@ -1120,7 +1123,7 @@ public class StructTest
     @Test
     public void testCloneAndRemoveWithSpecialFieldNames()
     {
-        IonStruct s1 = struct("{c:1,$99:2,'$19':3,'$20':3}");
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "{c:1,$99:2,'$19':3,'$20':3}");
 
         // Unlike cloneAndRetain(), cloneAndRemove() allows null args since it
         // makes sense to request removal of unknown field names.
@@ -1138,7 +1141,7 @@ public class StructTest
     @Test
     public void testCloneAndRemoveWithUnknownFieldNameOnRoot()
     {
-        IonStruct s1 = struct("{$99:a::{c:1,d:2,d:3}}");
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "{$99:a::{c:1,d:2,d:3}}");
 
         IonStruct root = (IonStruct) s1.iterator().next();
 
@@ -1150,7 +1153,7 @@ public class StructTest
     @Test
     public void testCloneAndRemoveWithUnknownFieldNameOnField()
     {
-        IonStruct s1 = struct("a::{$99:1,d:2,e:3,d:3}");
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "a::{$99:1,d:2,e:3,d:3}");
 
         // OK if the unknown symbol is on a removed node.
         IonStruct actual = s1.cloneAndRemove(null, "e");
@@ -1158,7 +1161,7 @@ public class StructTest
         assertEquals(expected, actual);
 
         // Not OK if the unknown symbol is on a retained node.
-        s1 = struct("a::{c:1,$99:2,e:3,d:3}");
+        s1 = struct(SHARED_SYMBOL_TABLE + "a::{c:1,$99:2,e:3,d:3}");
         thrown.expect(UnknownSymbolException.class);
         thrown.expectMessage("$99");
         s1.cloneAndRemove("c", "e");
@@ -1168,7 +1171,7 @@ public class StructTest
     @Test
     public void testCloneAndRemoveWithUnknownSymbolTextOnField()
     {
-        IonStruct s1 = struct("a::{c:$99,d:2,e:3,d:3}");
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "a::{c:$99,d:2,e:3,d:3}");
 
         // OK if the unknown symbol is on a removed node.
         IonStruct actual = s1.cloneAndRemove("c", "e");
@@ -1176,7 +1179,7 @@ public class StructTest
         assertEquals(expected, actual);
 
         // Not OK if the unknown symbol is on a retained node.
-        s1 = struct("a::{c:1,d:$99,e:3,d:3}");
+        s1 = struct(SHARED_SYMBOL_TABLE + "a::{c:1,d:$99,e:3,d:3}");
         thrown.expect(UnknownSymbolException.class);
         thrown.expectMessage("$99");
         s1.cloneAndRemove("c", "e");
@@ -1185,23 +1188,17 @@ public class StructTest
     @Test
     public void testCloneAndRemoveWithUnknownAnnotationTextOnRoot()
     {
-        IonStruct s1 = struct("$99::{c:1,d:2,e:3,d:3}");
-        if (! DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            thrown.expect(UnknownSymbolException.class);
-            thrown.expectMessage("$99");
-        }
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "$99::{c:1,d:2,e:3,d:3}");
         IonStruct actual = s1.cloneAndRemove("c", "e");
-        if (DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            // If we don't fail we should at least retain the SID.
-            IonStruct expected = struct("$99::{d:2,d:3}");
-            assertEquals(expected, actual);
-        }
+        // If we don't fail we should at least retain the SID.
+        IonStruct expected = struct(SHARED_SYMBOL_TABLE + "$99::{d:2,d:3}");
+        assertEquals(expected, actual);
     }
 
     @Test
     public void testCloneAndRemoveWithUnknownAnnotationTextOnField()
     {
-        IonStruct s1 = struct("a::{c:$99::1,d:2,e:3,d:3}");
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "a::{c:$99::1,d:2,e:3,d:3}");
 
         // OK if the unknown symbol is on a removed node.
         IonStruct actual = s1.cloneAndRemove("c", "e");
@@ -1209,17 +1206,11 @@ public class StructTest
         assertEquals(expected, actual);
 
         // Not OK if the unknown symbol is on a retained node.
-        s1 = struct("a::{c:1,d:$99::2,e:3}");
-        if (! DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            thrown.expect(UnknownSymbolException.class);
-            thrown.expectMessage("$99");
-        }
+        s1 = struct(SHARED_SYMBOL_TABLE + "a::{c:1,d:$99::2,e:3}");
         actual = s1.cloneAndRemove("c", "e");
-        if (DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            // If we don't fail we should at least retain the SID.
-            expected = struct("a::{d:$99::2}");
-            assertEquals(expected, actual);
-        }
+        // If we don't fail we should at least retain the SID.
+        expected = struct(SHARED_SYMBOL_TABLE + "a::{d:$99::2}");
+        assertEquals(expected, actual);
     }
 
     //-------------------------------------------------------------------------
@@ -1246,7 +1237,7 @@ public class StructTest
     @Test
     public void testCloneAndRetainWithSpecialFieldNames()
     {
-        IonStruct s1 = struct("{c:1,$99:2,'$19':3,'$20':3}");
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "{c:1,$99:2,'$19':3,'$20':3}");
         IonStruct actual = s1.cloneAndRetain("c", "$20");
         IonStruct expected = struct("{c:1,'$20':3}");
         assertEquals(expected, actual);
@@ -1262,7 +1253,7 @@ public class StructTest
     @Test
     public void testCloneAndRetainWithUnknownFieldNameOnRoot()
     {
-        IonStruct s1 = struct("{$99:a::{c:1,d:2,d:3}}");
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "{$99:a::{c:1,d:2,d:3}}");
 
         IonStruct root = (IonStruct) s1.iterator().next();
 
@@ -1274,7 +1265,7 @@ public class StructTest
     @Test
     public void testCloneAndRetainWithUnknownFieldNameOnField()
     {
-        IonStruct s1 = struct("a::{$99:1,d:2,e:3,d:3}");
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "a::{$99:1,d:2,e:3,d:3}");
 
         // OK if the unknown symbol is on a removed node.
         IonStruct actual = s1.cloneAndRetain("d", "e");
@@ -1282,7 +1273,7 @@ public class StructTest
         assertEquals(expected, actual);
 
         // Not OK if the unknown symbol is on a retained node.
-        s1 = struct("a::{c:1,$99:2,e:3,d:3}");
+        s1 = struct(SHARED_SYMBOL_TABLE + "a::{c:1,$99:2,e:3,d:3}");
         thrown.expect(NullPointerException.class);
         s1.cloneAndRetain(null, "e");
     }
@@ -1291,7 +1282,7 @@ public class StructTest
     @Test
     public void testCloneAndRetainWithUnknownSymbolTextOnField()
     {
-        IonStruct s1 = struct("a::{c:$99,d:2,e:3,d:3}");
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "a::{c:$99,d:2,e:3,d:3}");
 
         // OK if the unknown symbol is on a removed node.
         IonStruct actual = s1.cloneAndRetain("d");
@@ -1299,7 +1290,7 @@ public class StructTest
         assertEquals(expected, actual);
 
         // Not OK if the unknown symbol is on a retained node.
-        s1 = struct("a::{c:1,d:$99,e:3,d:3}");
+        s1 = struct(SHARED_SYMBOL_TABLE + "a::{c:1,d:$99,e:3,d:3}");
         thrown.expect(UnknownSymbolException.class);
         thrown.expectMessage("$99");
         s1.cloneAndRetain("c", "d");
@@ -1308,23 +1299,17 @@ public class StructTest
     @Test
     public void testCloneAndRetainWithUnknownAnnotationTextOnRoot()
     {
-        IonStruct s1 = struct("$99::{c:1,d:2,e:3,d:3}");
-        if (! DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            thrown.expect(UnknownSymbolException.class);
-            thrown.expectMessage("$99");
-        }
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "$99::{c:1,d:2,e:3,d:3}");
         IonStruct actual = s1.cloneAndRetain("c", "e");
-        if (DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            // If we don't fail we should at least retain the SID.
-            IonStruct expected = struct("$99::{c:1,e:3}");
-            assertEquals(expected, actual);
-        }
+        // If we don't fail we should at least retain the SID.
+        IonStruct expected = struct(SHARED_SYMBOL_TABLE + "$99::{c:1,e:3}");
+        assertEquals(expected, actual);
     }
 
     @Test
     public void testCloneAndRetainWithUnknownAnnotationTextOnField()
     {
-        IonStruct s1 = struct("a::{c:$99::1,d:2,e:3,d:3}");
+        IonStruct s1 = struct(SHARED_SYMBOL_TABLE + "a::{c:$99::1,d:2,e:3,d:3}");
 
         // OK if the unknown symbol is on a removed node.
         IonStruct actual = s1.cloneAndRetain("d");
@@ -1332,16 +1317,10 @@ public class StructTest
         assertEquals(expected, actual);
 
         // Not OK if the unknown symbol is on a retained node.
-        if (! DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            thrown.expect(UnknownSymbolException.class);
-            thrown.expectMessage("$99");
-        }
         actual = s1.cloneAndRetain("c", "e");
-        if (DEFECTIVE_CLONE_OF_UNKNOWN_ANNOTATION_TEXT) {
-            // If we don't fail we should at least retain the SID.
-            expected = struct("a::{c:$99::1,e:3}");
-            assertEquals(expected, actual);
-        }
+        // If we don't fail we should at least retain the SID.
+        expected = struct(SHARED_SYMBOL_TABLE + "a::{c:$99::1,e:3}");
+        assertEquals(expected, actual);
     }
 
 

--- a/test/software/amazon/ion/SymbolTest.java
+++ b/test/software/amazon/ion/SymbolTest.java
@@ -165,7 +165,7 @@ public class SymbolTest
     @Test
     public void testSyntheticSymbols()
     {
-        String symText = "$324";
+        String symText = "$ion_symbol_table::{imports:[{name:\"foo\", version: 1, max_id: 315}]} $324";
         IonSymbol value = (IonSymbol) oneValue(symText);
         checkUnknownSymbol(324, value);
 

--- a/test/software/amazon/ion/SystemProcessingTestCase.java
+++ b/test/software/amazon/ion/SystemProcessingTestCase.java
@@ -403,7 +403,7 @@ public abstract class SystemProcessingTestCase
             "            max_id:" + Symtabs.FRED_MAX_IDS[2] + "}]," +
             "}\n" +
             "local1 local2 fred_1 fred_2 fred_3 $12 " +
-            "fred_3::$99 [{fred_3:local2}]";
+            "fred_3::$10 [{fred_3:local2}]";
         // TODO { $12:something }
         // TODO $12::something
         // Nesting flushed out a bug at one point
@@ -450,7 +450,7 @@ public abstract class SystemProcessingTestCase
 // TODO checkAbsentSidLiteral("fred_3", fred3id);
 
         nextValue();
-        checkSymbol(null, 99);
+        checkSymbol("fred_1", fred1id);
         checkMissingAnnotation("fred_3", fred3id);
 
         nextValue();
@@ -835,6 +835,7 @@ public abstract class SystemProcessingTestCase
         throws Exception
     {
         startIteration(ION_1_0 +
+                       " $ion_symbol_table::{imports:[{name:\"foo\", version: 1, max_id: 10}]}" +
                        " { $10:10, $11:11, $12:12, $13:13, $14:14," +
                        "   $15:15, $16:16, $17:17, $18:18, $19:19 }");
         nextValue();
@@ -852,7 +853,7 @@ public abstract class SystemProcessingTestCase
     public void testUnknownFieldNames()
         throws Exception
     {
-        startIteration(ION_1_0 + " $10 { $11:$11, $12:$12 } ");
+        startIteration(ION_1_0 + " $ion_symbol_table::{imports:[{name:\"foo\", version: 1, max_id: 3}]} $10 { $11:$11, $12:$12 } ");
 
         nextValue();
         checkSymbol(null, 10);
@@ -877,7 +878,7 @@ public abstract class SystemProcessingTestCase
     public void testUnknownAnnotations()
         throws Exception
     {
-        startIteration(ION_1_0 + " $10::$10 $11::[ $12::$12 ]");
+        startIteration(ION_1_0 + " $ion_symbol_table::{imports:[{name:\"foo\", version: 1, max_id: 3}]} $10::$10 $11::[ $12::$12 ]");
 
         nextValue();
         checkSymbol(null, 10);
@@ -1121,12 +1122,12 @@ public abstract class SystemProcessingTestCase
     public void testIvmWithAnnotationSid()
         throws Exception
     {
-        startIteration("$99::" + ION_1_0 + " 123");
+        startIteration("$0::" + ION_1_0 + " 123");
 
-        // $99::$ion_1_0 is not an IVM, but an annotated user-value symbol
+        // $0::$ion_1_0 is not an IVM, but an annotated user-value symbol
         nextValue();
         checkSymbol(ION_1_0);
-        checkAnnotation(null, 99);
+        checkAnnotation(null, 0);
 
         nextValue();
         checkInt(123);

--- a/test/software/amazon/ion/TestUtils.java
+++ b/test/software/amazon/ion/TestUtils.java
@@ -132,7 +132,6 @@ public class TestUtils
              "bad/clobWithNullCharacter.ion"                // TODO amzn/ion-java#43
             , "bad/clobWithNonAsciiCharacter.ion"           // TODO amzn/ion-java#99
             , "bad/structOrderedEmpty.10n"                  // TODO amzn/ion-java#100
-            , "bad/symbolIDUnmapped.ion"                    // TODO amzn/ion-java#101
             , "bad/emptyAnnotatedInt.10n"                   // TODO amzn/ion-java#55
             , "bad/timestamp/timestampNegativeFraction.10n" // TODO amzn/ion-java#102
             , "bad/utf8/surrogate_5.ion"                    // TODO amzn/ion-java#60
@@ -147,6 +146,7 @@ public class TestUtils
             , "good/whitespace.ion"                         // TODO amzn/ion-java#104
             , "bad/negativeIntZero.10n"                     // TODO amzn/ion-java#138
             , "bad/negativeIntZeroLn.10n"                   // TODO amzn/ion-java#138
+            , "good/item1.10n"                              // TODO amzn/ion-java#126 (roundtrip symbols with unknown text)
         );
 
 

--- a/test/software/amazon/ion/TrBwBrProcessingTest.java
+++ b/test/software/amazon/ion/TrBwBrProcessingTest.java
@@ -14,6 +14,8 @@
 
 package software.amazon.ion;
 
+import org.junit.Ignore;
+import org.junit.Test;
 import software.amazon.ion.IonReader;
 
 /**
@@ -30,5 +32,15 @@ public class TrBwBrProcessingTest
 
         IonReader textReader = system().newSystemReader(text);
         myBytes = writeBinaryBytes(textReader);
+    }
+
+    @Override
+    @Ignore
+    @Test
+    public void testLocalSymtabWithMalformedSymbolEntries() throws Exception {
+        // TODO amzn/ion-java#151 this test exercises null slots in the local symbol table. The reader should collapse
+        // all local symbol table null slots to $0. Currently, since this doesn't happen, the reader passes $10 to the
+        // writer, which fails due to an out-of-range symbol ID.
+        super.testLocalSymtabWithMalformedSymbolEntries();
     }
 }

--- a/test/software/amazon/ion/impl/IonWriterTestCase.java
+++ b/test/software/amazon/ion/impl/IonWriterTestCase.java
@@ -56,6 +56,7 @@ import software.amazon.ion.SymbolTable;
 import software.amazon.ion.SymbolToken;
 import software.amazon.ion.SystemSymbols;
 import software.amazon.ion.TestUtils;
+import software.amazon.ion.UnknownSymbolException;
 import software.amazon.ion.impl.PrivateIonWriter;
 import software.amazon.ion.junit.IonAssert;
 
@@ -229,7 +230,7 @@ public abstract class IonWriterTestCase
         iw = makeWriter();
         iw.stepIn(IonType.STRUCT);
         iw.setFieldName("foo");
-        iw.setFieldNameSymbol(newSymbolToken((String) null, 99)); // Replaces "foo"
+        iw.setFieldNameSymbol(newSymbolToken((String) null, 0)); // Replaces "foo"
         iw.writeNull();
         iw.stepOut();
 
@@ -237,7 +238,7 @@ public abstract class IonWriterTestCase
         r.next();
         r.stepIn();
         r.next();
-        check(r).fieldName(null, 99);
+        check(r).fieldName(null, 0);
     }
 
     @Test
@@ -322,11 +323,27 @@ public abstract class IonWriterTestCase
         throws Exception
     {
         iw = makeWriter();
+        thrown.expect(UnknownSymbolException.class);
         iw.writeSymbolToken(newSymbolToken((String) null, 99));
+    }
 
-        IonReader in = reread();
-        in.next();
-        IonAssert.checkSymbol(in, null, 99);
+    @Test
+    public void testWritingUnknownFieldName()
+        throws Exception
+    {
+        iw = makeWriter();
+        iw.stepIn(IonType.STRUCT);
+        thrown.expect(UnknownSymbolException.class);
+        iw.setFieldNameSymbol(newSymbolToken((String) null, 99));
+    }
+
+    @Test
+    public void testWritingUnknownAnnotation()
+        throws Exception
+    {
+        iw = makeWriter();
+        thrown.expect(UnknownSymbolException.class);
+        iw.setTypeAnnotationSymbols(newSymbolToken((String) null, 99));
     }
 
     @Test
@@ -728,10 +745,10 @@ public abstract class IonWriterTestCase
         iw = makeWriter();
         IonDatagram expected = system().newDatagram();
 
-        iw.setTypeAnnotationSymbols(newSymbolToken((String) null, 99));
+        iw.setTypeAnnotationSymbols(newSymbolToken((String) null, 0));
         iw.writeNull(); // expected: the type annotation is written
         IonValue v = expected.add().newNull();
-        v.setTypeAnnotationSymbols(newSymbolToken(99));
+        v.setTypeAnnotationSymbols(newSymbolToken(0));
 
         assertEquals(expected, reload());
     }
@@ -816,7 +833,7 @@ public abstract class IonWriterTestCase
             checkSymbol(SystemSymbols.ION_1_0, it.next());
         }
         checkAnnotation(SystemSymbols.ION_SYMBOL_TABLE, it.next());
-        // TODO amzn/ion-java#63
+        // TODO amzn/ion-java#14
         if (myOutputForm != OutputForm.TEXT)
         {
             checkSymbol(null, 12, it.next());
@@ -994,7 +1011,7 @@ public abstract class IonWriterTestCase
         if (myOutputForm == OutputForm.BINARY) {
             checkAnnotation(ION_SYMBOL_TABLE, it.next());
         }
-        // TODO amzn/ion-java#63
+        // TODO amzn/ion-java#14
         if (myOutputForm == OutputForm.BINARY)
         {
             checkSymbol(null, 10, it.next());
@@ -1038,7 +1055,7 @@ public abstract class IonWriterTestCase
         if (myOutputForm != OutputForm.TEXT) {
             checkAnnotation(SystemSymbols.ION_SYMBOL_TABLE, it.next());
         }
-        // TODO amzn/ion-java#63
+        // TODO amzn/ion-java#14
         if (myOutputForm != OutputForm.TEXT)
         {
             checkSymbol(null, 10, it.next());

--- a/test/software/amazon/ion/streaming/SeekableReaderTest.java
+++ b/test/software/amazon/ion/streaming/SeekableReaderTest.java
@@ -112,7 +112,7 @@ public class SeekableReaderTest
     @Test
     public void testHoistingWithinContainers()
     {
-        read("{f:v,g:[c, (d), e], /* h */ $99:null} s");
+        read("{f:v,g:[c, (d), e], /* h */ $0:null} s");
 
         in.next();
         in.stepIn();


### PR DESCRIPTION
*Issue #, if available:*
#101 

*Description of changes:*
Relevant quote from the spec:
> Any symbol ID outside of the range of the local symbol table (or system symbol table if no local symbol table is defined) for which it is encoded under MUST raise an error.

Note: there is some code duplication here, particularly in `IonReaderBinarySystemX` and `IonReaderTextSystemX`. With the current factoring, the two don't share a non-interface ancestor, so there's no clean way to make them override the same methods without a major refactor which is out of scope for this PR.

Most of the other changes are in a large number of tests that were relying on the previous incorrect behavior. I've corrected these by adding an unresolved shared symbol table with a large enough max_id, or by making the previously out-of-range symbol identifier $0.

Test coverage comes from the new ion-tests commit, and from new tests in `IonWriterTestCase` which exercise attempting to write out-of-range symbol IDs for symbol values, field names, and annotations.

These fixes require adding `good/item1.10n` to the skip list because symbols with unknown text are not handed off correctly from the reader to a writer. This is because import location is not included in SymbolToken, meaning that the writer attempts to rely on local symbol ID for symbols with unknown text, which is now always out of range of the local symbol table and therefore always results in an error. See #126.

Finally, this fix reminds us that local symbol IDs with undefined text should be treated as symbol zero. This will simplify handoff of SymbolTokens from reader to writer by not forcing the writer to retain the null slots from the reader's symbol table. See #151.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
