### PR TITLE
IonStructLite bugfixes

### DIFF
--- a/src/software/amazon/ion/UnknownSymbolException.java
+++ b/src/software/amazon/ion/UnknownSymbolException.java
@@ -36,9 +36,9 @@ public class UnknownSymbolException
         mySid = sid;
         myText = null;
     }
-    public UnknownSymbolException(String text)
+    public UnknownSymbolException(String message)
     {
-        myText = text;
+        myText = message;
         mySid = 0;
     }
 
@@ -53,7 +53,7 @@ public class UnknownSymbolException
         if(myText == null) {
             return "Unknown symbol text for $" + mySid;
         } else {
-            return "Unknown symbol for text: " + myText;
+            return myText;
         }
     }
 }

--- a/src/software/amazon/ion/UnknownSymbolException.java
+++ b/src/software/amazon/ion/UnknownSymbolException.java
@@ -29,10 +29,17 @@ public class UnknownSymbolException
     private static final long serialVersionUID = 1L;
 
     private final int mySid;
+    private final String myText;
 
     public UnknownSymbolException(int sid)
     {
         mySid = sid;
+        myText = null;
+    }
+    public UnknownSymbolException(String text)
+    {
+        myText = text;
+        mySid = 0;
     }
 
     public int getSid()
@@ -43,6 +50,10 @@ public class UnknownSymbolException
     @Override
     public String getMessage()
     {
-        return "Unknown symbol text for $" + mySid;
+        if(myText == null) {
+            return "Unknown symbol text for $" + mySid;
+        } else {
+            return "Unknown symbol for text: " + myText;
+        }
     }
 }

--- a/src/software/amazon/ion/impl/lite/IonStructLite.java
+++ b/src/software/amazon/ion/impl/lite/IonStructLite.java
@@ -401,7 +401,7 @@ final class IonStructLite
         IonValue field;
 
         if (field_idx < 0) {
-            if(hasNullFieldName) throw new UnknownSymbolException("Unable to resolve fieldname due to null fields.");
+            if(hasNullFieldName) throw new UnknownSymbolException("Unable to determine whether the field exists because the struct contains field names with unknown text.");
             field = null;
         } else {
             field = get_child(field_idx);

--- a/src/software/amazon/ion/impl/lite/IonStructLite.java
+++ b/src/software/amazon/ion/impl/lite/IonStructLite.java
@@ -477,7 +477,7 @@ final class IonStructLite
      */
     private void _add(String fieldName, IonValueLite child)
     {
-        if(!hasNullFieldName && fieldName == null) hasNullFieldName = true;
+        hasNullFieldName |= fieldName == null;
         int size = get_child_count();
 
         // add this to the Container child collection

--- a/src/software/amazon/ion/impl/lite/IonStructLite.java
+++ b/src/software/amazon/ion/impl/lite/IonStructLite.java
@@ -401,7 +401,7 @@ final class IonStructLite
         IonValue field;
 
         if (field_idx < 0) {
-            if(hasNullFieldName) throw new UnknownSymbolException("Because a field exists with an unknown name we cannot say for certain whether the requested field exists or not.");
+            if(hasNullFieldName) throw new UnknownSymbolException("Unable to resolve fieldname due to null fields.");
             field = null;
         } else {
             field = get_child(field_idx);

--- a/src/software/amazon/ion/impl/lite/IonStructLite.java
+++ b/src/software/amazon/ion/impl/lite/IonStructLite.java
@@ -34,6 +34,7 @@ import software.amazon.ion.ValueVisitor;
 import software.amazon.ion.impl.PrivateCurriedValueFactory;
 import software.amazon.ion.util.Equivalence;
 import java.util.Set;
+import software.amazon.ion.UnknownSymbolException;
 
 final class IonStructLite
     extends IonContainerLite
@@ -41,7 +42,6 @@ final class IonStructLite
 {
     private static final int HASH_SIGNATURE =
         IonType.STRUCT.toString().hashCode();
-
     // TODO amzn/ion-java#41: add support for _isOrdered
 
     IonStructLite(ContainerlessContext context, boolean isNull)
@@ -54,14 +54,13 @@ final class IonStructLite
         super(existing, context, true);
         // field map can be shallow cloned due to it dealing with String and Integer
         // values - both of which are immutable constructs and so safe to retain as references
-        this._field_map = null == _field_map
-                                ? null
-                                : new HashMap<String, Integer>(existing._field_map);
+        this._field_map = null == existing._field_map ? null : new HashMap<String, Integer>(existing._field_map);
         this._field_map_duplicate_count = existing._field_map_duplicate_count;
+        this.hasNullFieldName = existing.hasNullFieldName;
     }
 
     private Map<String, Integer> _field_map;
-
+    private boolean hasNullFieldName = false;
 
     public int                      _field_map_duplicate_count;
 
@@ -402,9 +401,9 @@ final class IonStructLite
         IonValue field;
 
         if (field_idx < 0) {
+            if(hasNullFieldName) throw new UnknownSymbolException("Because a field exists with an unknown name we cannot say for certain whether the requested field exists or not.");
             field = null;
-        }
-        else {
+        } else {
             field = get_child(field_idx);
         }
 
@@ -450,11 +449,6 @@ final class IonStructLite
     {
         // TODO validate in struct.setFieldName
         String text = child.getFieldNameSymbol().getText();
-        if (text != null)
-        {
-            validateFieldName(text);
-        }
-
         IonValueLite concrete = (IonValueLite) child;
         _add(text, concrete);
 
@@ -483,6 +477,7 @@ final class IonStructLite
      */
     private void _add(String fieldName, IonValueLite child)
     {
+        if(!hasNullFieldName && fieldName == null) hasNullFieldName = true;
         int size = get_child_count();
 
         // add this to the Container child collection

--- a/test/software/amazon/ion/StructTest.java
+++ b/test/software/amazon/ion/StructTest.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.Random;
+
+import com.sun.org.apache.bcel.internal.classfile.Unknown;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -739,26 +741,18 @@ public class StructTest
     }
 
     @Test
-    public void testMapAfterClone()
+    public void testUnknownSymbolException()
     {
-        String[] inserts = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"};
-        IonStruct s1 = (IonStruct)oneValue("{}");
-        for(int i = 0; i < inserts.length; i++) {
-            s1.add(inserts[i], oneValue(Integer.toString(i)));
-        }
-        IonStruct s2 = system().clone(s1);
-        for(int i = 0; i < inserts.length; i++) {
-            assertEquals(s2.get(inserts[i]), oneValue(Integer.toString(i)));
-        }
-        int transitionCutoff = 4;
-        s1 = (IonStruct)oneValue("{}");
-        for(int i = 0; i < transitionCutoff; i++) {
-            s1.add(inserts[i], oneValue(Integer.toString(i)));
-        }
-        s2 = system().clone(s1);
-        for(int i = 0; i < transitionCutoff; i++) {
-            assertEquals(s2.get(inserts[i]), oneValue(Integer.toString(i)));
-        }
+        String input = "$ion_symbol_table::{imports:[{name:\"foo\", version:1, max_id:1}]} { $10: \"Unknown symbol\"}";
+        IonDatagram dg = loader().load(input);
+        IonStruct val = (IonStruct) dg.get(0);
+        try {
+            val.get("z");
+            fail("Should've thrown UnknownSymbolException");
+        } catch (UnknownSymbolException e) { }
+        try {
+            val = system().clone(val);
+        } catch (UnknownSymbolException e) { }
     }
 
     @Test

--- a/test/software/amazon/ion/StructTest.java
+++ b/test/software/amazon/ion/StructTest.java
@@ -739,6 +739,29 @@ public class StructTest
     }
 
     @Test
+    public void testMapAfterClone()
+    {
+        String[] inserts = {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"};
+        IonStruct s1 = (IonStruct)oneValue("{}");
+        for(int i = 0; i < inserts.length; i++) {
+            s1.add(inserts[i], oneValue(Integer.toString(i)));
+        }
+        IonStruct s2 = system().clone(s1);
+        for(int i = 0; i < inserts.length; i++) {
+            assertEquals(s2.get(inserts[i]), oneValue(Integer.toString(i)));
+        }
+        int transitionCutoff = 4;
+        s1 = (IonStruct)oneValue("{}");
+        for(int i = 0; i < transitionCutoff; i++) {
+            s1.add(inserts[i], oneValue(Integer.toString(i)));
+        }
+        s2 = system().clone(s1);
+        for(int i = 0; i < transitionCutoff; i++) {
+            assertEquals(s2.get(inserts[i]), oneValue(Integer.toString(i)));
+        }
+    }
+
+    @Test
     public void testRemoveAfterClone()
     {
         IonStruct s1 = (IonStruct) oneValue("{a:1,b:2}");


### PR DESCRIPTION
*Description of changes:*
Updated ionstructlite so fieldmap will not always resolve as null on construction, added a boolean hasNullField to throw correctly when a fieldname does not resolve and correctness cannot be determined.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
