### PR TITLE
Updated number exceptions to indicate what the source of the error was.

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextSystemX.java
@@ -41,6 +41,7 @@ import software.amazon.ion.impl.IonReaderTextRawTokensX.IonReaderTextTokenExcept
 import software.amazon.ion.impl.IonTokenConstsX.CharacterSequence;
 import software.amazon.ion.impl.PrivateScalarConversions.AS_TYPE;
 import software.amazon.ion.impl.PrivateScalarConversions.CantConvertException;
+import java.lang.Character;
 
 /**
  * This reader calls the {@link IonReaderTextRawX} for low level events.
@@ -235,26 +236,21 @@ class IonReaderTextSystemX
                     break;
                 }
             }
-        }
-        else if (token_type == IonTokenConstsX.TOKEN_HEX) {
-            boolean is_negative = (cs.charAt(0) == '-');
-            // prefix = is_negative ? "-0x" : "0x";
-            int pos;
-            if (is_negative) {
-                pos = 1;
-            }
-            else {
-                pos = 0;
-            }
-            assert((cs.length() > 2) && (cs.charAt(pos) == '0') && (cs.charAt(pos+1) == 'x' || cs.charAt(pos+1) == 'X'));
-            cs.deleteCharAt(pos);
-            cs.deleteCharAt(pos);
-        }
-        else if (token_type == IonTokenConstsX.TOKEN_BINARY) {
+        } else if (token_type == IonTokenConstsX.TOKEN_HEX) {
             boolean isNegative = (cs.charAt(0) == '-');
-            int position = isNegative ? 1 : 0;
-            cs.deleteCharAt(position);
-            cs.deleteCharAt(position);
+            // prefix = is_negative ? "-0x" : "0x";
+            int pos = isNegative ? 1 : 0;
+            if (cs.length() <= (isNegative ? 3 : 2) || Character.toLowerCase(cs.charAt(pos + 1)) != 'x') {
+                parse_error("Invalid hexadecimal value.");
+            }
+            cs.deleteCharAt(pos);
+            cs.deleteCharAt(pos);
+        } else if (token_type == IonTokenConstsX.TOKEN_BINARY) {
+            boolean isNegative = (cs.charAt(0) == '-');
+            int pos = isNegative ? 1 : 0;
+            if (cs.length() <= (isNegative ? 3 : 2)) parse_error("Invalid binary int value");
+            cs.deleteCharAt(pos);
+            cs.deleteCharAt(pos);
         }
 
 

--- a/test/software/amazon/ion/IntTest.java
+++ b/test/software/amazon/ion/IntTest.java
@@ -132,7 +132,6 @@ public class IntTest
         assertEquals(Integer.MIN_VALUE, value.intValue());
     }
 
-
     @Test
     public void testPositiveSign()
     {
@@ -243,6 +242,8 @@ public class IntTest
     {
         checkInt(-3, oneValue("-0x3"));
         checkInt(-3, oneValue("-0x0003"));
+        badValue("0x");
+        badValue("-0x");
     }
 
     @Test
@@ -293,6 +294,8 @@ public class IntTest
     public void testBinaryInt()
     {
         assertEquals(system().newInt(4), oneValue("0b0100"));
+        badValue("-0b");
+        badValue("0b");
     }
 
     @Test


### PR DESCRIPTION
Description of changes:
Updated IonReaderTextSystemX to throw parse errors on invalid binary ints and hexidecimals with descriptive messages.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
