### PR TITLE
Fixes for compile errors when using Java 11

### DIFF
--- a/test/software/amazon/ion/SequenceTestCase.java
+++ b/test/software/amazon/ion/SequenceTestCase.java
@@ -679,7 +679,7 @@ public abstract class SequenceTestCase
 
         try
         {
-            seq.toArray(null);
+            seq.toArray((Object[]) null);
             fail("expected exception");
         }
         catch (NullPointerException e) { }

--- a/test/software/amazon/ion/TrueSequenceTestCase.java
+++ b/test/software/amazon/ion/TrueSequenceTestCase.java
@@ -489,7 +489,7 @@ public abstract class TrueSequenceTestCase
 
         try
         {
-            seq.toArray(null);
+            seq.toArray((Object[]) null);
             fail("expected exception");
         }
         catch (NullPointerException e) { }

--- a/test/software/amazon/ion/impl/VarIntTest.java
+++ b/test/software/amazon/ion/impl/VarIntTest.java
@@ -5,7 +5,6 @@ import software.amazon.ion.IonException;
 import software.amazon.ion.IonTestCase;
 import software.amazon.ion.system.SimpleCatalog;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 
 public class VarIntTest extends IonTestCase {
@@ -86,11 +85,41 @@ public class VarIntTest extends IonTestCase {
     }
 
     private IonReaderBinaryUserX makeReader(String hex) throws Exception {
-        ByteArrayInputStream input = new ByteArrayInputStream(DatatypeConverter.parseHexBinary("E00100EA" + hex));
+        ByteArrayInputStream input = new ByteArrayInputStream(parseHexBinary("E00100EA" + hex));
 
         UnifiedInputStreamX uis = UnifiedInputStreamX.makeStream(input);
         uis.skip(4);
 
         return new IonReaderBinaryUserX(new SimpleCatalog(), LocalSymbolTable.DEFAULT_LST_FACTORY, uis, 0);
+    }
+
+    private static byte[] parseHexBinary(String str) {
+        int len = str.length();
+        if (len % 2 != 0) {
+            throw new IllegalArgumentException("str must have even length");
+        }
+
+        byte[] result = new byte[len / 2];
+
+        for (int i = 0; i < len; i += 2) {
+            int high = parseHexChar(str.charAt(i));
+            int low  = parseHexChar(str.charAt(i + 1));
+            result[i / 2] = (byte) ((high << 4) | low);
+        }
+
+        return result;
+    }
+
+    private static int parseHexChar(char c) {
+        if (c >= '0' && c <= '9') {
+            return c - '0';
+        }
+        if (c >= 'a' && c <= 'f') {
+            return (c - 'a') + 10;
+        }
+        if (c >= 'A' && c <= 'F') {
+            return (c - 'A') + 10;
+        }
+        throw new IllegalArgumentException("invalid hex character: " + c);
     }
 }


### PR DESCRIPTION
*Description of changes:*
A couple quick fixes for problems I ran into when building using OpenJDK 11, now that it's GA. Good news is only test code is affected.

First: IonSequence now inherits a new `toArray(IntFunction<T[]>)` default method from java.util.Collection in addition to the `toArray(T[])` method it defines, making references to `seq.toArray(null)` ambiguous. Easy enough fix, presumably no one is doing that in real code.

Second: Java EE modules have been dropped from the standard library, breaking a reference to `javax.xml.bind.DatatypeConverter.parseHexBinary(String)` used to construct some test data. I inlined a quick-and-dirty implementation, or happy to back that out and add a test-scoped dependency on `javax.xml.bind:jaxb-api` if you prefer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.