### PR TITLE
Bound checking BigDecimal in Timestamp to guard against DoS

### DIFF
--- a/src/software/amazon/ion/Timestamp.java
+++ b/src/software/amazon/ion/Timestamp.java
@@ -725,8 +725,10 @@ public final class Timestamp
             FRACTIONAL_MILLIS_UPPER_BOUND.compareTo(millis) < 0) {
             throw new IllegalArgumentException("millis: " + millis + " is outside of valid the range: from "
                 + MINIMUM_ALLOWED_FRACTIONAL_MILLIS
+                + " (0001T)"
                 + ", inclusive, to "
                 + FRACTIONAL_MILLIS_UPPER_BOUND
+                + " (10000T)"
                 + " , exclusive");
         }
 
@@ -1863,7 +1865,8 @@ public final class Timestamp
 
     private void checkFractionScale() {
         if(_fraction.scale() >= MAXIMUM_ALLOWED_MILLIS_SCALE) {
-            throw new UnsupportedOperationException("TODO");
+            throw new UnsupportedOperationException("fraction scale is higher than the safe threshold: "
+                + MAXIMUM_ALLOWED_MILLIS_SCALE);
         }
     }
 

--- a/src/software/amazon/ion/Timestamp.java
+++ b/src/software/amazon/ion/Timestamp.java
@@ -93,15 +93,6 @@ public final class Timestamp
     // 10000T in millis, upper bound exclusive
     static final BigDecimal FRACTIONAL_MILLIS_UPPER_BOUND = new BigDecimal(253402300800000L);
 
-    // Used for safe variants of methods that can hang for a large scale, e.g. toString
-    // Determined by running a micro benchmark against BigDecimal#longValue()
-    // Results:
-    // 1000	    ~0ms
-    // 10000	~1ms
-    // 100000	~170ms
-    // 1000000	~704ms
-    private static final int MAXIMUM_ALLOWED_MILLIS_SCALE = 10000;
-
     /**
      * Unknown local offset from UTC.
      */
@@ -732,7 +723,9 @@ public final class Timestamp
                 + " , exclusive");
         }
 
-        long ms = millis.divideToIntegralValue(BigDecimal.ONE).longValue();
+        // quick handle integral zero
+        long ms = isIntegralZero(millis) ? 0 : millis.longValue();
+
         set_fields_from_millis(ms);
 
         this._precision = Precision.SECOND;
@@ -742,24 +735,17 @@ public final class Timestamp
         }
         else {
             BigDecimal secs = millis.movePointLeft(3);
-            BigDecimal secsDown = fastZeroScaleRoundDown(secs);
+            BigDecimal secsDown = isIntegralZero(secs) ? BigDecimal.ZERO : secs.setScale(0, BigDecimal.ROUND_FLOOR);
             this._fraction = secs.subtract(secsDown);
         }
         this._offset = localOffset;
     }
 
-    /**
-     * Same effect of <pre>BigDecimal.setScale(0, RoundingMode.FLOOR)</pre> but avoids inflating the BigDecimal
-     * so is much faster
-     */
-    private BigDecimal fastZeroScaleRoundDown(final BigDecimal decimal) {
-        BigDecimal zeroScale = decimal.divideToIntegralValue(BigDecimal.ONE);
-
-        if(zeroScale.compareTo(BigDecimal.ZERO) < 0) {
-            return zeroScale.add(BigDecimal.ONE.negate());
-        }
-
-        return zeroScale;
+    private boolean isIntegralZero(final BigDecimal decimal) {
+        // zero || no low-order bits || < 1.0
+        return  decimal.signum() == 0
+            || decimal.scale() < -63
+            || (decimal.precision() - decimal.scale() <= 0);
     }
 
     /**
@@ -1460,7 +1446,8 @@ public final class Timestamp
         //                                        month is 0 based for Date
         long millis = Date.UTC(this._year - 1900, this._month - 1, this._day, this._hour, this._minute, this._second);
         if (this._fraction != null) {
-            int frac = this._fraction.movePointRight(3).divideToIntegralValue(BigDecimal.ONE).intValue();
+            BigDecimal fracAsDecimal = this._fraction.movePointRight(3);
+            int frac = isIntegralZero(fracAsDecimal) ? 0 : fracAsDecimal.intValue();
             millis += frac;
         }
         return millis;
@@ -1839,11 +1826,6 @@ public final class Timestamp
      * Returns the string representation (in Ion format) of this Timestamp in
      * its local time.
      *
-     * <br>
-     * <strong>WARNING:</strong> this method can hang for Timestamps with a very large
-     * fractional scale, e.g. 1,000,000.
-     *
-     * @see #safeToString()
      * @see #toZString()
      * @see #print(Appendable)
      */
@@ -1863,36 +1845,11 @@ public final class Timestamp
         return buffer.toString();
     }
 
-    private void checkFractionScale() {
-        if(_fraction.scale() >= MAXIMUM_ALLOWED_MILLIS_SCALE) {
-            throw new UnsupportedOperationException("fraction scale is higher than the safe threshold: "
-                + MAXIMUM_ALLOWED_MILLIS_SCALE);
-        }
-    }
-
-    /**
-     * Safe version of toString failing if the fractional second scale is bigger than a safe threshold to avoid hanging.
-     *
-     * @throws UnsupportedOperationException if the fraction second scale is bigger than a safe threshold.
-     *
-     * @see #toString()
-     */
-    public String safeToString()
-    {
-        checkFractionScale();
-        return toString();
-    }
-
     /**
      * Returns the string representation (in Ion format) of this Timestamp
      * in UTC.
      *
-     * <br>
-     * <strong>WARNING:</strong> this method can hang for Timestamps with a very large
-     * fractional scale, e.g. 1,000,000.
-     *
      * @see #toString()
-     * @see #safeToZString()
      * @see #printZ(Appendable)
      */
     public String toZString()
@@ -1911,36 +1868,16 @@ public final class Timestamp
     }
 
     /**
-     * Safe version of toZString failing if the fractional second scale is bigger than a safe threshold to
-     * avoid hanging.
-     *
-     * @throws UnsupportedOperationException if the fraction second scale is bigger than a safe threshold.
-     *
-     * @see #toZString()
-     */
-    public String safeToZString()
-    {
-        checkFractionScale();
-        return toZString();
-    }
-
-
-    /**
      * Prints to an {@code Appendable} the string representation (in Ion format)
      * of this Timestamp in its local time.
      * <p>
      * This method produces the same output as {@link #toString()}.
-     *
-     * <br>
-     * <strong>WARNING:</strong> this method can hang for Timestamps with a very large
-     * fractional scale, e.g. 1,000,000.
      *
      * @param out not {@code null}
      *
      * @throws IOException propagated when the {@link Appendable} throws it
      *
      * @see #printZ(Appendable)
-     * @see #safePrint(Appendable)
      */
     public void print(Appendable out)
         throws IOException
@@ -1959,36 +1896,16 @@ public final class Timestamp
     }
 
     /**
-     * Safe version of print failing if the fractional second scale is bigger than a safe threshold to
-     * avoid hanging.
-     *
-     * @throws UnsupportedOperationException if the fraction second scale is bigger than a safe threshold.
-     *
-     * @see #print(Appendable)
-     */
-    public void safePrint(Appendable out)
-        throws IOException
-    {
-        checkFractionScale();
-        print(out);
-    }
-
-    /**
      * Prints to an {@code Appendable} the string representation (in Ion format)
      * of this Timestamp in UTC.
      * <p>
      * This method produces the same output as {@link #toZString()}.
-     *
-     * <br>
-     * <strong>WARNING:</strong> this method can hang for Timestamps with a very large
-     * fractional scale, e.g. 1,000,000.
      *
      * @param out not {@code null}
      *
      * @throws IOException propagated when the {@code Appendable} throws it.
      *
      * @see #print(Appendable)
-     * @see #safePrintZ(Appendable)
      */
     public void printZ(Appendable out)
         throws IOException
@@ -2013,21 +1930,6 @@ public final class Timestamp
                 break;
             }
         }
-    }
-
-    /**
-     * Safe version of printZ failing if the fractional second scale is bigger than a safe threshold to
-     * avoid hanging.
-     *
-     * @throws UnsupportedOperationException if the fraction second scale is bigger than a safe threshold.
-     *
-     * @see #printZ(Appendable)
-     */
-    public void safePrintZ(Appendable out)
-        throws IOException
-    {
-        checkFractionScale();
-        printZ(out);
     }
 
     /**

--- a/src/software/amazon/ion/Timestamp.java
+++ b/src/software/amazon/ion/Timestamp.java
@@ -90,11 +90,16 @@ public final class Timestamp
     // 0001-01-01T00:00:00.0Z in millis
     static final BigDecimal MINIMUM_ALLOWED_FRACTIONAL_MILLIS = new BigDecimal(MINIMUM_ALLOWED_TIMESTAMP_IN_MILLIS);
 
-    // 9999-12-31T23:59:59.999999999999Z in millis
-    static final BigDecimal MAXIMUM_ALLOWED_FRACTIONAL_MILLIS = new BigDecimal("253402300799999.999999999");
+    // 10000T in millis, upper bound exclusive
+    static final BigDecimal FRACTIONAL_MILLIS_UPPER_BOUND = new BigDecimal(253402300800000L);
 
-    // determined empirically as a safe scale
-    private static final int MAXIMUM_ALLOWED_MILLIS_SCALE = 100000;
+    // Determined by running a micro benchmark against BigDecimal#longValue()
+    // Results:
+    // 1000	    ~0ms
+    // 10000	~1ms
+    // 100000	~170ms
+    // 1000000	~704ms
+    private static final int MAXIMUM_ALLOWED_MILLIS_SCALE = 10000;
 
     /**
      * Unknown local offset from UTC.
@@ -716,12 +721,12 @@ public final class Timestamp
         // check bounds to avoid hanging when calling longValue() on decimals with large positive exponents,
         // e.g. 1e10000000
         if(millis.compareTo(MINIMUM_ALLOWED_FRACTIONAL_MILLIS) < 0 ||
-            millis.compareTo(MAXIMUM_ALLOWED_FRACTIONAL_MILLIS) > 0) {
+            FRACTIONAL_MILLIS_UPPER_BOUND.compareTo(millis) < 0) {
             throw new IllegalArgumentException("millis: " + millis + " is outside of valid the range: from "
                 + MINIMUM_ALLOWED_FRACTIONAL_MILLIS
-                + " to "
-                + MAXIMUM_ALLOWED_FRACTIONAL_MILLIS
-                + " both inclusive");
+                + ", inclusive, to "
+                + FRACTIONAL_MILLIS_UPPER_BOUND
+                + " , exclusive");
         }
 
         // check scale size to avoid hanging on methods that need to inflate the fractional bigDecimal

--- a/test/software/amazon/ion/TimestampTest.java
+++ b/test/software/amazon/ion/TimestampTest.java
@@ -16,7 +16,7 @@ package software.amazon.ion;
 
 import static software.amazon.ion.Decimal.NEGATIVE_ZERO;
 import static software.amazon.ion.Decimal.negativeZero;
-import static software.amazon.ion.Timestamp.MAXIMUM_ALLOWED_FRACTIONAL_MILLIS;
+import static software.amazon.ion.Timestamp.FRACTIONAL_MILLIS_UPPER_BOUND;
 import static software.amazon.ion.Timestamp.MINIMUM_ALLOWED_FRACTIONAL_MILLIS;
 import static software.amazon.ion.Timestamp.UNKNOWN_OFFSET;
 import static software.amazon.ion.Timestamp.UTC_OFFSET;
@@ -789,10 +789,10 @@ public class TimestampTest
     @Test
     public void testNewTimestampFromBigDecimalWithMaximumAllowedMillis()
     {
-        Timestamp ts = Timestamp.forMillis(MAXIMUM_ALLOWED_FRACTIONAL_MILLIS, PST_OFFSET);
-        checkFields(9999, 12, 31, 15, 59, 59, new BigDecimal("0.999999999999"), PST_OFFSET, SECOND, ts);
-        assertEquals("9999-12-31T15:59:59.999999999999-08:00", ts.toString());
-        assertEquals("9999-12-31T23:59:59.999999999999Z", ts.toZString());
+        Timestamp ts = Timestamp.forMillis(FRACTIONAL_MILLIS_UPPER_BOUND.add(BigDecimal.ONE.negate()), PST_OFFSET);
+        checkFields(9999, 12, 31, 15, 59, 59, new BigDecimal("0.999"), PST_OFFSET, SECOND, ts);
+        assertEquals("9999-12-31T15:59:59.999-08:00", ts.toString());
+        assertEquals("9999-12-31T23:59:59.999Z", ts.toZString());
     }
 
     @Test(expected = NullPointerException.class)
@@ -811,8 +811,8 @@ public class TimestampTest
     @Test(expected = IllegalArgumentException.class)
     public void testNewTimestampFromBigDecimalWithMillisTooBig()
     {
-        // Max + 1
-        Timestamp.forMillis(MAXIMUM_ALLOWED_FRACTIONAL_MILLIS.add(BigDecimal.ONE), PST_OFFSET);
+        // Max
+        Timestamp.forMillis(FRACTIONAL_MILLIS_UPPER_BOUND, PST_OFFSET);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/test/software/amazon/ion/TimestampTest.java
+++ b/test/software/amazon/ion/TimestampTest.java
@@ -30,8 +30,10 @@ import static software.amazon.ion.impl.PrivateUtils.UTC;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.sql.Time;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
@@ -2345,7 +2347,6 @@ public class TimestampTest
 
     // max scale permitted by BigDecimal from the String constructor
     private static BigDecimal LARGE_SCALE_DECIMAL = new BigDecimal("1e-1000000000");
-    private static BigDecimal MAX_SCALE_FOR_SAFE_METHODS = new BigDecimal("1e-10000");
 
     @Test(timeout = 50L)
     public void testForMillisWithLargeScaleBigDecimal()
@@ -2357,27 +2358,5 @@ public class TimestampTest
     public void testGetMillisWithLargeScaleBigDecimal()
     {
         Timestamp.forMillis(LARGE_SCALE_DECIMAL, PST_OFFSET).getMillis();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSafeToStringWithLargeScaleBigDecimal()
-    {
-        Timestamp.forMillis(MAX_SCALE_FOR_SAFE_METHODS, PST_OFFSET).safeToString();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSafeToZStringWithLargeScaleBigDecimal()
-    {
-        Timestamp.forMillis(MAX_SCALE_FOR_SAFE_METHODS, PST_OFFSET).safeToZString();
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSafePrintWithLargeScaleBigDecimal() throws IOException {
-        Timestamp.forMillis(MAX_SCALE_FOR_SAFE_METHODS, PST_OFFSET).safePrint(new StringBuilder());
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSafePrintZWithLargeScaleBigDecimal() throws IOException {
-        Timestamp.forMillis(MAX_SCALE_FOR_SAFE_METHODS, PST_OFFSET).safePrintZ(new StringBuilder());
     }
 }

--- a/test/software/amazon/ion/TimestampTest.java
+++ b/test/software/amazon/ion/TimestampTest.java
@@ -28,6 +28,7 @@ import static software.amazon.ion.Timestamp.Precision.SECOND;
 import static software.amazon.ion.Timestamp.Precision.YEAR;
 import static software.amazon.ion.impl.PrivateUtils.UTC;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -819,12 +820,6 @@ public class TimestampTest
     public void testNewTimestampFromBigDecimalWithScaleTooBigPositive()
     {
         Timestamp.forMillis(new BigDecimal("1e100000"), PST_OFFSET);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testNewTimestampFromBigDecimalWithScaleTooBigNegative()
-    {
-        Timestamp.forMillis(new BigDecimal("1e-100000"), PST_OFFSET);
     }
 
     /**
@@ -2344,5 +2339,45 @@ public class TimestampTest
 
         Timestamp t = Timestamp.forCalendar(cal);
         assertEquals(year, t.getYear());
+    }
+
+    // High scale timeout tests
+
+    // max scale permitted by BigDecimal from the String constructor
+    private static BigDecimal LARGE_SCALE_DECIMAL = new BigDecimal("1e-1000000000");
+    private static BigDecimal MAX_SCALE_FOR_SAFE_METHODS = new BigDecimal("1e-10000");
+
+    @Test(timeout = 50L)
+    public void testForMillisWithLargeScaleBigDecimal()
+    {
+        Timestamp ts = Timestamp.forMillis(LARGE_SCALE_DECIMAL, PST_OFFSET);
+    }
+
+    @Test(timeout = 50L)
+    public void testGetMillisWithLargeScaleBigDecimal()
+    {
+        Timestamp.forMillis(LARGE_SCALE_DECIMAL, PST_OFFSET).getMillis();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSafeToStringWithLargeScaleBigDecimal()
+    {
+        Timestamp.forMillis(MAX_SCALE_FOR_SAFE_METHODS, PST_OFFSET).safeToString();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSafeToZStringWithLargeScaleBigDecimal()
+    {
+        Timestamp.forMillis(MAX_SCALE_FOR_SAFE_METHODS, PST_OFFSET).safeToZString();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSafePrintWithLargeScaleBigDecimal() throws IOException {
+        Timestamp.forMillis(MAX_SCALE_FOR_SAFE_METHODS, PST_OFFSET).safePrint(new StringBuilder());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSafePrintZWithLargeScaleBigDecimal() throws IOException {
+        Timestamp.forMillis(MAX_SCALE_FOR_SAFE_METHODS, PST_OFFSET).safePrintZ(new StringBuilder());
     }
 }


### PR DESCRIPTION
Operations that require inflating the BigDecimal can be expensive for
large numbers, examples:
* longValue
* intValue
* setScale

https://github.com/amzn/ion-java/issues/159


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
