### PR TITLE
Add additonal JDKs to .travis.yml, issue 164

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 jdk:
   - openjdk8
+  - openjdk10
+  - openjdk11
   - oraclejdk8
   - oraclejdk9
+  - oraclejdk10
+   oraclejdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - openjdk8
+  - openjdk9
   - openjdk10
   - openjdk11
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: java
-addons:
-    apt:
-        packages:
-            - openjdk-6-jdk
 jdk:
-  - openjdk6
-  - openjdk7
   - openjdk8
   - oraclejdk8
   - oraclejdk9

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ jdk:
   - oraclejdk8
   - oraclejdk9
   - oraclejdk10
-   oraclejdk11
+  - oraclejdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
 language: java
+addons:
+    apt:
+        packages:
+            - openjdk-6-jdk
 jdk:
+  - openjdk6
+  - openjdk7
+  - openjdk8
   - oraclejdk8
+  - oraclejdk9


### PR DESCRIPTION
https://github.com/amzn/ion-java/issues/164

This adds more JDKs to our `.travis.yml` file.  Looks like we are not source compatible earlier versions of the JDK due to some references to `java.lang.Long.BYTES` which was introduced in JDK8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
