### PR TITLE
 #160, use java.util.Date instead of TimeZone.getDefault().getRawOffset() 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: java
 jdk:
+  - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
   - oraclejdk8
+  - oraclejdk9
+  - oraclejdk10
+  - oraclejdk11

--- a/src/software/amazon/ion/Timestamp.java
+++ b/src/software/amazon/ion/Timestamp.java
@@ -23,7 +23,6 @@ import java.math.RoundingMode;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.TimeZone;
 import software.amazon.ion.impl.PrivateUtils;
 import software.amazon.ion.util.IonTextUtils;
 
@@ -290,8 +289,8 @@ public final class Timestamp
         // 0001-01-01T00:00:00.000Z, the Date.get*() methods should return values for
         // 0000-12-31T16:00:00.000Z;  however, Date.getYear() incorrectly returns a value for year 1 (-1899)
         // in this scenario. The following if/else block compensates for this bug:
-        int currentRawOffset = TimeZone.getDefault().getRawOffset();
-        if(currentRawOffset < 0 && MINIMUM_ALLOWED_TIMESTAMP_IN_MILLIS - currentRawOffset > millis) {
+        int currentOffset = -date.getTimezoneOffset() * 60 * 1000;
+        if(currentOffset < 0 && MINIMUM_ALLOWED_TIMESTAMP_IN_MILLIS - currentOffset > millis) {
             this._year = 0;
         } else {
             this._year = checkAndCastYear(date.getYear() + 1900);

--- a/src/software/amazon/ion/Timestamp.java
+++ b/src/software/amazon/ion/Timestamp.java
@@ -289,8 +289,8 @@ public final class Timestamp
         // In Pacific Standard Time (offset -08:00), for a Date constructed with an epoch time equivalent to
         // 0001-01-01T00:00:00.000Z, the Date.get*() methods should return values for
         // 0000-12-31T16:00:00.000Z;  however, Date.getYear() incorrectly returns a value for year 1 (-1899)
-        // in this scenario. The following if/else block compensates for this bug:
-        int currentOffset = -date.getTimezoneOffset() * 60 * 1000;
+        // in this scenario. The following if/else block compensates for this bug.
+        int currentOffset = TimeZone.getDefault().getOffset(date.getTime());
         if(currentOffset < 0 && MINIMUM_ALLOWED_TIMESTAMP_IN_MILLIS - currentOffset > millis) {
             this._year = 0;
         } else {

--- a/test/software/amazon/ion/TimestampTest.java
+++ b/test/software/amazon/ion/TimestampTest.java
@@ -864,7 +864,7 @@ public class TimestampTest
      * Regression test for https://github.com/amzn/ion-java/issues/160
      */
     @Test
-    public void testNewTimestampFromLongYearOneRegressionBug()
+    public void testNewTimestampFromYearOneRegressionBug()
     {
         // This is the same as the private field Timestamp.MINIMUM_ALLOWED_TIMESTAMP_IN_MILLIS
         final long MINIMUM_TIMESTAMP_MILLIS = -62135769600000L;
@@ -887,23 +887,24 @@ public class TimestampTest
                 Timestamp minimumTimestampFromMillis = Timestamp.forMillis(MINIMUM_TIMESTAMP_MILLIS, 0);
                 assertEquals(MINIMUM_TIMESTAMP, minimumTimestampFromMillis);
 
-                // This will be the latest millisecond in which the bug with `java.util.Date` can happen
-                Timestamp maximumTimestampWithBug =
-                    Timestamp.forMillis(MINIMUM_TIMESTAMP_MILLIS - tz.getRawOffset(), 0);
-                assertEquals(1, maximumTimestampWithBug.getYear());
+                // Only perform further assertions on timezones with negative offsets because positive
+                // offsets create millisecond values that are less than Timestamp.MINIMUM_ALLOWED_TIMESTAMP_IN_MILLIS
+                if (tz.getRawOffset() < 0) {
+                    // This will be the latest millisecond in which the bug with `java.util.Date` can happen
+                    Timestamp maximumTimestampWithBug =
+                        Timestamp.forMillis(MINIMUM_TIMESTAMP_MILLIS - tz.getRawOffset(), 0);
+                    assertEquals(1, maximumTimestampWithBug.getYear());
 
-                // Test one millisecond after, just to be sure.
-                Timestamp timestampPlusOne =
-                    Timestamp.forMillis(MINIMUM_TIMESTAMP_MILLIS - tz.getRawOffset() + 1, 0);
-                assertEquals(1, timestampPlusOne.getYear());
+                    // Test one millisecond after, just to be sure.
+                    Timestamp timestampPlusOne =
+                        Timestamp.forMillis(MINIMUM_TIMESTAMP_MILLIS - tz.getRawOffset() + 1, 0);
+                    assertEquals(1, timestampPlusOne.getYear());
 
-                // Don't attempt to test this last case since it would create a timestamp that is before year 1.
-                if(tz.getRawOffset() >= 0) break;
-
-                // Also test one milliscond before, just to be sure.
-                Timestamp timestampMinusOne =
-                    Timestamp.forMillis(MINIMUM_TIMESTAMP_MILLIS - tz.getRawOffset() - 1L, 0);
-                assertEquals(1, timestampMinusOne.getYear());
+                    // Also test one milliscond before, just to be sure.
+                    Timestamp timestampMinusOne =
+                        Timestamp.forMillis(MINIMUM_TIMESTAMP_MILLIS - tz.getRawOffset() - 1L, 0);
+                    assertEquals(1, timestampMinusOne.getYear());
+                }
             }
         } finally {
             // Have to set the TimeZone back to its original value so as not to effect other tests.

--- a/test/software/amazon/ion/TimestampTest.java
+++ b/test/software/amazon/ion/TimestampTest.java
@@ -866,11 +866,11 @@ public class TimestampTest
     @Test
     public void testNewTimestampFromYearOneRegressionBug()
     {
-        // This is the same as the private field Timestamp.MINIMUM_ALLOWED_TIMESTAMP_IN_MILLIS
-        final long MINIMUM_TIMESTAMP_MILLIS = -62135769600000L;
         // This is the minimum timestamp instantiating by parsing a timestamp string,
         // which is not effected by the `java.util.Date` bug.
         final Timestamp MINIMUM_TIMESTAMP = Timestamp.valueOf("0001-01-01T00:00:00.000Z");
+        // This is the same as the private field Timestamp.MINIMUM_ALLOWED_TIMESTAMP_IN_MILLIS
+        final long MINIMUM_TIMESTAMP_MILLIS = MINIMUM_TIMESTAMP.getMillis();
         // Save the original timezone since we modify it below.
         final TimeZone originalTimeZone = TimeZone.getDefault();
 
@@ -885,7 +885,7 @@ public class TimestampTest
                 // since `java.util.Date` references the default TimeZone when calculating the values for its
                 // date field accessor methods (i.e. Date.get*()).
                 Timestamp minimumTimestampFromMillis = Timestamp.forMillis(MINIMUM_TIMESTAMP_MILLIS, 0);
-                assertEquals(MINIMUM_TIMESTAMP, minimumTimestampFromMillis);
+                assertEquals(1, minimumTimestampFromMillis.getYear());
 
                 // Only perform further assertions on timezones with negative offsets because positive
                 // offsets create millisecond values that are less than Timestamp.MINIMUM_ALLOWED_TIMESTAMP_IN_MILLIS


### PR DESCRIPTION
https://github.com/amzn/ion-java/issues/164

I realized a bit later that `TimeZone.getRawOffset()` is unaffected by daylight savings time and the safest offset we can access is that what is returned by `java.util.date.getTimeZoneOffset()`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
