### PR TITLE
Removes oraclejdk10 from build list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ jdk:
   - openjdk11
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
   - oraclejdk11


### PR DESCRIPTION
Oracle JDK 10 was deprecated and fails travis builds example:
https://travis-ci.org/amzn/ion-java/jobs/442398169

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
