### PR TITLE
WriteBuffer truncation fix

### DIFF
--- a/src/software/amazon/ion/impl/bin/WriteBuffer.java
+++ b/src/software/amazon/ion/impl/bin/WriteBuffer.java
@@ -1071,9 +1071,10 @@ import java.util.List;
     /** Write the entire buffer to output stream. */
     public void writeTo(final OutputStream out) throws IOException
     {
-        for (final Block block : blocks)
+        for (int i = 0; i <= index; i++)
         {
-            out.write(block.data, 0, block.limit);
+	    Block block = blocks.get(i);
+	    out.write(block.data, 0, block.limit);
         }
     }
 

--- a/test/software/amazon/ion/impl/bin/WriteBufferTest.java
+++ b/test/software/amazon/ion/impl/bin/WriteBufferTest.java
@@ -915,4 +915,12 @@ public class WriteBufferTest
         buf.writeBytes("DOO".getBytes("UTF-8"));
         assertBuffer("ARGLEFOOBARGLEDOO".getBytes("UTF-8"));
     }
+
+    @Test
+    public void testTruncate() throws IOException
+    {
+        buf.writeBytes("ARGLEFOOBARGLEDOO".getBytes("UTF-8"));
+        buf.truncate(3);
+        assertBuffer("ARG".getBytes("UTF-8"));
+    }
 }


### PR DESCRIPTION
Calls to `WriteBuffer#truncate(long)` modify an internal `index` value that tracks the last block in the buffer that contains data to write. Our current implementation of `WriteBuffer#writeTo(OutputStream)` ignores the `index` value and writes the contents of all allocated blocks to the `OutputStream`.

In cases where multiple blocks have been allocated and `truncate()` should cause one or more to be ignored, this bug results in unparsable data. This problem is relatively rare, but it can happen when writing a very large (>32kb) local symbol table at the head of a stream.

*Description of changes:*
1. `WriteBuffer#writeTo(OutputStream)` has been modified to only write the contents of blocks `[0, index]`.
2. A new unit test has been added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
