### PR TITLE
Avoids calling WriteBuffer.finish() if the writer is closed

### DIFF
--- a/src/software/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/software/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -1432,6 +1432,10 @@ import software.amazon.ion.Timestamp;
 
     public void finish() throws IOException
     {
+        if (closed)
+        {
+            return;
+        }
         if (!containers.isEmpty())
         {
             throw new IllegalStateException("Cannot finish within container: " + containers);
@@ -1478,7 +1482,6 @@ import software.amazon.ion.Timestamp;
         {
             return;
         }
-        closed = true;
         try
         {
             try
@@ -1497,6 +1500,7 @@ import software.amazon.ion.Timestamp;
         }
         finally
         {
+            closed = true;
             if (streamCloseMode == StreamCloseMode.CLOSE)
             {
                 // release the stream

--- a/test/software/amazon/ion/impl/bin/IonRawBinaryWriterTest.java
+++ b/test/software/amazon/ion/impl/bin/IonRawBinaryWriterTest.java
@@ -180,6 +180,15 @@ public class IonRawBinaryWriterTest extends Assert
     };
 
     @Test
+    public void testFinishOnClose() throws IOException
+    {
+        // verify data is flushed if a writer is closed prior to calling finish()
+        writer.writeNull();
+        writer.close();
+        assertValue("null.null");
+    }
+
+    @Test
     public void testNullNull() throws Exception
     {
         writer.writeNull();


### PR DESCRIPTION
Issue #174 

Modifies IonRawBinaryWriter.flush() so WriteBuffer.finish() is not called when the writer is closed, thus avoiding the exception case introduced by #171.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
