### PR TITLE
Removes unnecessary synchronization from IonSystemLite.getLoader.

### DIFF
--- a/src/software/amazon/ion/impl/lite/IonSystemLite.java
+++ b/src/software/amazon/ion/impl/lite/IonSystemLite.java
@@ -140,7 +140,7 @@ final class IonSystemLite
         return _catalog;
     }
 
-    public synchronized IonLoader getLoader()
+    public IonLoader getLoader()
     {
         return _loader;
     }


### PR DESCRIPTION
*Description of changes:*

Removes the synchronization, which is unnecessary because:
* The `_loader `member field is final, so the reference cannot change.
* Implementations of `IonLoader` are required to be threadsafe.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
