### PR TITLE
IonSequenceLite#retainAll javadoc fix and tests

### DIFF
--- a/src/software/amazon/ion/IonDatagram.java
+++ b/src/software/amazon/ion/IonDatagram.java
@@ -238,19 +238,6 @@ public interface IonDatagram
      */
     public void makeNull();
 
-
-    /**
-     * This inherited method is not yet supported by datagrams.
-     * <p>
-     * Vote for SIM issue amzn/ion-java#49 if you need this.
-     *
-     * @throws UnsupportedOperationException at every call.
-     *
-     * @see <a href="https://github.com/amzn/ion-java/issues/49">amzn/ion-java#49</a>
-     */
-    public boolean retainAll(Collection<?> c);
-
-
     public IonDatagram clone()
         throws UnknownSymbolException;
 }

--- a/test/software/amazon/ion/impl/lite/BaseIonSequenceLiteTest.java
+++ b/test/software/amazon/ion/impl/lite/BaseIonSequenceLiteTest.java
@@ -1,0 +1,67 @@
+package software.amazon.ion.impl.lite;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import org.junit.Test;
+import software.amazon.ion.IonSequence;
+import software.amazon.ion.IonSystem;
+import software.amazon.ion.IonValue;
+import software.amazon.ion.ReadOnlyValueException;
+import software.amazon.ion.system.IonSystemBuilder;
+
+public abstract class BaseIonSequenceLiteTest {
+
+    protected static final IonSystem SYSTEM = IonSystemBuilder.standard().build();
+
+    protected abstract IonSequence newEmptySequence();
+
+    @Test
+    public void retainAll() {
+        final IonSequence sequence = newEmptySequence();
+        final ArrayList<IonValue> toRetain = new ArrayList<IonValue>();
+
+        final IonValue retainedValue = SYSTEM.newInt(1);
+        sequence.add(retainedValue);
+        toRetain.add(retainedValue);
+
+        final IonValue toRemoveValue = SYSTEM.newInt(2);
+        sequence.add(toRemoveValue);
+
+        assertTrue(sequence.retainAll(toRetain));
+
+        assertEquals(1, sequence.size());
+        assertTrue(sequence.contains(retainedValue));
+        assertFalse(sequence.contains(toRemoveValue));
+    }
+
+    @Test
+    public void retainAllUsesReferenceEquality() {
+        final IonSequence sequence = newEmptySequence();
+        final ArrayList<IonValue> toRetain = new ArrayList<IonValue>();
+
+        final IonValue value = SYSTEM.newInt(1);
+        sequence.add(value);
+
+        final IonValue equalValue = SYSTEM.newInt(1);
+        toRetain.add(equalValue);
+
+        assertEquals(equalValue, value);
+        assertNotSame(equalValue, value);
+
+        assertTrue(sequence.retainAll(toRetain));
+        assertEquals(0, sequence.size());
+    }
+
+    @Test(expected = ReadOnlyValueException.class)
+    public void retainAllReadOnly() {
+        final IonSequence sequence = newEmptySequence();
+        sequence.makeReadOnly();
+
+        sequence.retainAll(Collections.emptyList());
+    }
+}

--- a/test/software/amazon/ion/impl/lite/IonDatagramLiteTest.java
+++ b/test/software/amazon/ion/impl/lite/IonDatagramLiteTest.java
@@ -1,0 +1,10 @@
+package software.amazon.ion.impl.lite;
+
+import software.amazon.ion.IonSequence;
+
+public class IonDatagramLiteTest extends BaseIonSequenceLiteTest {
+    @Override
+    protected IonSequence newEmptySequence() {
+        return SYSTEM.newDatagram();
+    }
+}

--- a/test/software/amazon/ion/impl/lite/IonListLiteTest.java
+++ b/test/software/amazon/ion/impl/lite/IonListLiteTest.java
@@ -1,0 +1,10 @@
+package software.amazon.ion.impl.lite;
+
+import software.amazon.ion.IonSequence;
+
+public class IonListLiteTest extends BaseIonSequenceLiteTest {
+    @Override
+    protected IonSequence newEmptySequence() {
+        return SYSTEM.newDatagram();
+    }
+}

--- a/test/software/amazon/ion/impl/lite/IonListLiteTest.java
+++ b/test/software/amazon/ion/impl/lite/IonListLiteTest.java
@@ -5,6 +5,6 @@ import software.amazon.ion.IonSequence;
 public class IonListLiteTest extends BaseIonSequenceLiteTest {
     @Override
     protected IonSequence newEmptySequence() {
-        return SYSTEM.newDatagram();
+        return SYSTEM.newEmptyList();
     }
 }

--- a/test/software/amazon/ion/impl/lite/IonSexpLiteTest.java
+++ b/test/software/amazon/ion/impl/lite/IonSexpLiteTest.java
@@ -5,6 +5,6 @@ import software.amazon.ion.IonSequence;
 public class IonSexpLiteTest extends BaseIonSequenceLiteTest {
     @Override
     protected IonSequence newEmptySequence() {
-        return SYSTEM.newDatagram();
+        return SYSTEM.newEmptySexp();
     }
 }

--- a/test/software/amazon/ion/impl/lite/IonSexpLiteTest.java
+++ b/test/software/amazon/ion/impl/lite/IonSexpLiteTest.java
@@ -1,0 +1,10 @@
+package software.amazon.ion.impl.lite;
+
+import software.amazon.ion.IonSequence;
+
+public class IonSexpLiteTest extends BaseIonSequenceLiteTest {
+    @Override
+    protected IonSequence newEmptySequence() {
+        return SYSTEM.newDatagram();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amzn/ion-java/issues/179
https://github.com/amzn/ion-java/issues/49

*Description of changes:*
Adds unit tests for all `IonSequenceLite` implementations and fixes `IonDatagram` javadoc. The method remove from `IonDatagram` interface is inherited from `IonSequence` and works as described in its javadoc so no need to have it in `IonDatagram` as well 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
