### PR TITLE
Ignores pseudo-IVMs as expected by the specification

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderTextRawX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextRawX.java
@@ -944,7 +944,7 @@ abstract class IonReaderTextRawX
             case ACTION_LOAD_SCALAR:
                 if (t == IonTokenConstsX.TOKEN_SYMBOL_IDENTIFIER) {
                     sb = token_contents_load(t);
-                    int _value_keyword = IonTokenConstsX.keyword(sb, 0, sb.length());
+                    _value_keyword = IonTokenConstsX.keyword(sb, 0, sb.length());
                     switch (_value_keyword) {
                     case IonTokenConstsX.KEYWORD_NULL:
                     {

--- a/src/software/amazon/ion/impl/IonReaderTextUserX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextUserX.java
@@ -146,8 +146,11 @@ class IonReaderTextUserX
                         {
                             if (ION_1_0.equals(version))
                             {
-                                symbol_table_reset();
-                                push_symbol_table(_system_symtab);
+                                if (_value_keyword != IonTokenConstsX.KEYWORD_sid)
+                                {
+                                    symbol_table_reset();
+                                    push_symbol_table(_system_symtab);
+                                }
                                 _has_next_called = false;
                             }
                             else

--- a/test/software/amazon/ion/TestUtils.java
+++ b/test/software/amazon/ion/TestUtils.java
@@ -139,7 +139,6 @@ public class TestUtils
             , "bad/utf8/surrogate_2.ion"                    // TODO amzn/ion-java#105
             , "bad/utf8/surrogate_4.ion"                    // TODO amzn/ion-java#105
             , "equivs/paddedInts.10n"                       // TODO amzn/ion-java#54
-            , "equivs/nonIVMNoOps.ion"                      // TODO amzn/ion-java#114
             , "good/subfieldVarUInt32bit.ion"               // TODO amzn/ion-java#62
             , "good/utf16.ion"                              // TODO amzn/ion-java#61
             , "good/utf32.ion"                              // TODO amzn/ion-java#61


### PR DESCRIPTION
*Issues:* #88, #114

*Description of changes:*  top-level values such as `'$ion_1_0'` and `$2` were previously incorrectly processed as IVMs.  Such values are now ignored, which is the expected behavior per the Ion specification.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
