### PR TITLE
Empty ordered structs now cause an exception.

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderBinaryRawX.java
+++ b/src/software/amazon/ion/impl/IonReaderBinaryRawX.java
@@ -494,6 +494,9 @@ abstract class IonReaderBinaryRawX
                 // special case of an ordered struct, it gets the
                 // otherwise impossible to have length of 1
                 len = readVarUInt();
+                if (len == 0) {
+                    throwErrorAt("Structs flagged as having ordered keys must contain at least one key/value pair.");
+                }
                 start_of_value = _input.getPosition();
             }
         }

--- a/test/software/amazon/ion/TestUtils.java
+++ b/test/software/amazon/ion/TestUtils.java
@@ -131,7 +131,6 @@ public class TestUtils
         new FileIsNot(
              "bad/clobWithNullCharacter.ion"                // TODO amzn/ion-java#43
             , "bad/clobWithNonAsciiCharacter.ion"           // TODO amzn/ion-java#99
-            , "bad/structOrderedEmpty.10n"                  // TODO amzn/ion-java#100
             , "bad/emptyAnnotatedInt.10n"                   // TODO amzn/ion-java#55
             , "bad/timestamp/timestampNegativeFraction.10n" // TODO amzn/ion-java#102
             , "bad/utf8/surrogate_5.ion"                    // TODO amzn/ion-java#60


### PR DESCRIPTION
Fixes #100. When reading a binary struct that is flagged as having ordered keys, the reader now enforces that the struct cannot be empty.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
