### PR TITLE
Produces an error for a struct field that has no value

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderTextRawX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextRawX.java
@@ -183,7 +183,7 @@ abstract class IonReaderTextRawX
         // now patch up the differences between these 4 states handling of tokens vs before_annotation_datagram
         actions[STATE_BEFORE_ANNOTATION_CONTAINED][IonTokenConstsX.TOKEN_EOF]            = 0;
         actions[STATE_BEFORE_ANNOTATION_CONTAINED][IonTokenConstsX.TOKEN_CLOSE_PAREN]    = ACTION_FINISH_CONTAINER;
-        actions[STATE_BEFORE_ANNOTATION_CONTAINED][IonTokenConstsX.TOKEN_CLOSE_BRACE]    = ACTION_FINISH_CONTAINER;
+        actions[STATE_BEFORE_ANNOTATION_CONTAINED][IonTokenConstsX.TOKEN_CLOSE_BRACE]    = 0;
         actions[STATE_BEFORE_ANNOTATION_CONTAINED][IonTokenConstsX.TOKEN_CLOSE_SQUARE]   = ACTION_FINISH_CONTAINER;
 
         actions[STATE_BEFORE_ANNOTATION_SEXP][IonTokenConstsX.TOKEN_EOF]                 = 0;

--- a/test/software/amazon/ion/streaming/ReaderTest.java
+++ b/test/software/amazon/ion/streaming/ReaderTest.java
@@ -329,7 +329,6 @@ public class ReaderTest
           "'''c}}b'''",
           "'''c\\'''ob'''",
 
-          "",
           "Zm9v",
     };
 

--- a/test/software/amazon/ion/streaming/ReaderTest.java
+++ b/test/software/amazon/ion/streaming/ReaderTest.java
@@ -319,17 +319,18 @@ public class ReaderTest
 
 
     private String[] LOB_DATA = {
-          "\"\"",
-          "\"clob\"",
+          "{{\"\"}}",
+          "{{\"clob\"}}",
 
-          "''''''",
-          "''' '''",
-          "'''clob'''",
-          "'''c}ob'''",
-          "'''c}}b'''",
-          "'''c\\'''ob'''",
+          "{{''''''}}",
+          "{{''' '''}}",
+          "{{'''clob'''}}",
+          "{{'''c}ob'''}}",
+          "{{'''c}}b'''}}",
+          "{{'''c\\'''ob'''}}",
 
-          "Zm9v",
+          "{{}}",
+          "{{Zm9v}}",
     };
 
     private void testSkippingLob(String containerPrefix,


### PR DESCRIPTION
*Issue:* #186 

*Description of changes:*
* updates ion-tests submodule to include a new bad/structWithIncompleteField.ion test
* fixes lexer state transitions such that an error is produced when a `}` is found where a value is expected
* removes lob test cases for values `[1, { c: } }` and `{a: 1, b: { c: } }`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
