### PR TITLE
Timestamp fractional seconds outside of [0, 1) now cause an exception.

### DIFF
--- a/src/software/amazon/ion/impl/IonReaderBinaryRawX.java
+++ b/src/software/amazon/ion/impl/IonReaderBinaryRawX.java
@@ -1115,12 +1115,12 @@ abstract class IonReaderBinaryRawX
         year  = readVarUInt();
         Precision p = Precision.YEAR; // our lowest significant option
 
-        // now we look for hours and minutes
+        // now we look for months
         if (_local_remaining > 0) {
             month = readVarUInt();
             p = Precision.MONTH;
 
-            // now we look for hours and minutes
+            // now we look for days
             if (_local_remaining > 0) {
                 day   = readVarUInt();
                 p = Precision.DAY; // our lowest significant option
@@ -1136,6 +1136,12 @@ abstract class IonReaderBinaryRawX
                         if (_local_remaining > 0) {
                             // now we read in our actual "milliseconds since the epoch"
                             frac = readDecimal(_local_remaining);
+                            if (frac.compareTo(BigDecimal.ZERO) < 0 || frac.compareTo(BigDecimal.ONE) >= 0) {
+                                throwErrorAt(
+                                    "The fractional seconds value in a timestamp must be greater than or "
+                                        + "equal to zero and less than one."
+                                );
+                            }
                         }
                     }
                 }

--- a/test/software/amazon/ion/TestUtils.java
+++ b/test/software/amazon/ion/TestUtils.java
@@ -132,7 +132,6 @@ public class TestUtils
              "bad/clobWithNullCharacter.ion"                // TODO amzn/ion-java#43
             , "bad/clobWithNonAsciiCharacter.ion"           // TODO amzn/ion-java#99
             , "bad/emptyAnnotatedInt.10n"                   // TODO amzn/ion-java#55
-            , "bad/timestamp/timestampNegativeFraction.10n" // TODO amzn/ion-java#102
             , "bad/utf8/surrogate_5.ion"                    // TODO amzn/ion-java#60
             , "bad/utf8/surrogate_1.ion"                    // TODO amzn/ion-java#105
             , "bad/utf8/surrogate_2.ion"                    // TODO amzn/ion-java#105


### PR DESCRIPTION
Fixes #102.

Timestamps whose fractional seconds are outside of the range 0 (inclusive) to 1 (exclusive) will now cause an exception to be thrown.

The original issue indicated that the spec itself needed to be updated to clarify this. However, it already states:

> The fractional seconds’ value is coefficient * 10 ^ exponent. **It must be greater than or equal to zero and less than 1.**

(emphasis mine) which I think is pretty clear.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
