### PR TITLE
Produces an error when an unpaired surrogate is encountered

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,21 @@ jdk:
 - oraclejdk8
 - oraclejdk9
 - oraclejdk11
-after_success:
-- bash <(curl -s https://codecov.io/bash) 
-- mvn site
-deploy:
-  provider: pages
-  local-dir: "./target/site/"
-  skip-cleanup: true
-  github-token: "$GITHUB_TOKEN"
-  keep-history: true # keeps commit history of gh-pages branch
-  on:
-    branch: master
-    jdk: openjdk11
+
+script: mvn test 
+
+jobs: 
+  include: 
+    stage: report generation 
+    jdk: openjdk11 
+    script: mvn test site 
+    after_success:
+      - bash <(curl -s https://codecov.io/bash) 
+    deploy: 
+      provider: pages
+      local-dir: "./target/site/"
+      skip-cleanup: true
+      github-token: "$GITHUB_TOKEN"
+      keep-history: true # keeps commit history of gh-pages branch
+      on:
+        branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ jdk:
 - oraclejdk9
 - oraclejdk11
 after_success:
-    # enable once we get authorization with codecov.io sorted out
-    # - bash <(curl -s https://codecov.io/bash) 
+- bash <(curl -s https://codecov.io/bash) 
 - mvn site
 deploy:
   provider: pages

--- a/src/software/amazon/ion/Decimal.java
+++ b/src/software/amazon/ion/Decimal.java
@@ -68,16 +68,14 @@ public class Decimal
         public float floatValue()
         {
             float v = super.floatValue();
-            if (Float.compare(0f, v) <= 0) v = -1 * v;
-            return v;
+            return Float.compare(0f, v) <= 0 ? -1 * v : v;
         }
 
         @Override
         public double doubleValue()
         {
             double v = super.doubleValue();
-            if (Double.compare(0d, v) <= 0) v = -1 * v;
-            return v;
+            return Double.compare(0d, v) <= 0 ? -1 * v : v;
         }
 
 
@@ -159,12 +157,8 @@ public class Decimal
      */
     public static BigDecimal bigDecimalValue(BigDecimal val)
     {
-        if (val == null
-            || val.getClass() == BigDecimal.class)
-        {
-            return val;
-        }
-        return new BigDecimal(val.unscaledValue(), val.scale());
+        return val == null || val.getClass() == BigDecimal.class ?
+            val : new BigDecimal(val.unscaledValue(), val.scale());
     }
 
     /**
@@ -269,17 +263,12 @@ public class Decimal
 
     public static Decimal valueOf(double val, MathContext mc)
     {
-        if (Double.compare(val, -0d) == 0)
-        {
-            return new NegativeZero(1, mc);
-        }
-        return new Decimal(Double.toString(val), mc);
+        return Double.compare(val, -0d) == 0 ? new NegativeZero(1, mc) : new Decimal(Double.toString(val), mc);
     }
 
     public static Decimal valueOf(BigDecimal val)
     {
-        if (val == null || val instanceof Decimal) return (Decimal) val;
-        return new Decimal(val.unscaledValue(), val.scale());
+        return val == null || val instanceof Decimal ? (Decimal) val : new Decimal(val.unscaledValue(), val.scale());
     }
 
     public static Decimal valueOf(BigDecimal val, MathContext mc)
@@ -421,7 +410,6 @@ public class Decimal
      */
     public final BigDecimal bigDecimalValue()
     {
-
         return new BigDecimal(unscaledValue(), scale());
     }
 }

--- a/src/software/amazon/ion/impl/IonReaderTextRawTokensX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextRawTokensX.java
@@ -2049,6 +2049,9 @@ final class IonReaderTextRawTokensX
     protected int read_double_quoted_char(boolean is_clob) throws IOException
     {
         int c = read_char();
+        if(is_clob && c > 127) {
+            throw new IonReaderTextTokenException("non ASCII character in clob: " + c);
+        }
 
         switch (c) {
         case '"':
@@ -2174,6 +2177,10 @@ final class IonReaderTextRawTokensX
     protected int read_triple_quoted_char(boolean is_clob) throws IOException
     {
         int c = read_string_char(ProhibitedCharacters.LONG_CHAR);
+        if(is_clob && c > 127) {
+            throw new IonReaderTextTokenException("non ASCII character in clob: " + c);
+        }
+
         switch (c) {
         case '\'':
             if (is_2_single_quotes_helper()) {

--- a/src/software/amazon/ion/impl/IonReaderTextRawTokensX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextRawTokensX.java
@@ -1935,6 +1935,7 @@ final class IonReaderTextRawTokensX
         throws IOException
     {
         int c;
+        boolean expectLowSurrogate = false;
 
         for (;;) {
             c = read_string_char(ProhibitedCharacters.NONE);
@@ -1945,6 +1946,9 @@ final class IonReaderTextRawTokensX
                 continue;
             case -1:
             case '\'':
+                if (!is_clob) {
+                    check_for_low_surrogate(c, expectLowSurrogate);
+                }
                 return c;
             // new line normalization and counting is handled in read_char
             case CharacterSequence.CHAR_SEQ_NEWLINE_SEQUENCE_1:
@@ -1962,11 +1966,16 @@ final class IonReaderTextRawTokensX
                     c = read_large_char_sequence(c);
                 }
             }
-
+            // if this isn't a clob we need to decode UTF8 and
+            // handle surrogate encoding (otherwise we don't care)
             if (!is_clob) {
+                expectLowSurrogate = check_for_low_surrogate(c, expectLowSurrogate);
+
                 if (IonUTF8.needsSurrogateEncoding(c)) {
                     sb.append(IonUTF8.highSurrogate(c));
                     c = IonUTF8.lowSurrogate(c);
+                } else {
+                    expectLowSurrogate = IonUTF8.isHighSurrogate(c);
                 }
             }
             else if (IonTokenConstsX.is8bitValue(c)) {
@@ -2010,6 +2019,7 @@ final class IonReaderTextRawTokensX
         throws IOException
     {
         int c;
+        boolean expectLowSurrogate = false;
 
         for (;;) {
             c = read_string_char(ProhibitedCharacters.SHORT_CHAR);
@@ -2020,6 +2030,9 @@ final class IonReaderTextRawTokensX
                 continue;
             case -1:
             case '"':
+                if (!is_clob) {
+                    check_for_low_surrogate(c, expectLowSurrogate);
+                }
                 return c;
             // new line normalization and counting is handled in read_char
             case CharacterSequence.CHAR_SEQ_NEWLINE_SEQUENCE_1:
@@ -2035,15 +2048,34 @@ final class IonReaderTextRawTokensX
                 }
                 break;
             }
-
+            // if this isn't a clob we need to decode UTF8 and
+            // handle surrogate encoding (otherwise we don't care)
             if (!is_clob) {
+                expectLowSurrogate = check_for_low_surrogate(c, expectLowSurrogate);
+
                 if (IonUTF8.needsSurrogateEncoding(c)) {
                     sb.append(IonUTF8.highSurrogate(c));
                     c = IonUTF8.lowSurrogate(c);
+                } else {
+                    expectLowSurrogate = IonUTF8.isHighSurrogate(c);
                 }
             }
             sb.append((char)c);
         }
+    }
+
+    private boolean check_for_low_surrogate(int c, boolean expectLowSurrogate) throws IonException
+    {
+        if (IonUTF8.isLowSurrogate(c)) {
+            if (expectLowSurrogate) {
+                return false;
+            } else {
+                error("unexpected low surrogate " + printCodePointAsString(c));
+            }
+        } else if (expectLowSurrogate) {
+            expected_but_found("a low surrogate", c);
+        }
+        return false;
     }
 
     protected int read_double_quoted_char(boolean is_clob) throws IOException
@@ -2135,12 +2167,16 @@ final class IonReaderTextRawTokensX
         throws IOException
     {
         int c;
+        boolean expectLowSurrogate = false;
 
         for (;;) {
             c = read_triple_quoted_char(is_clob);
             switch(c) {
             case CharacterSequence.CHAR_SEQ_STRING_TERMINATOR:
             case CharacterSequence.CHAR_SEQ_EOF: // was EOF
+                if (!is_clob) {
+                    check_for_low_surrogate(c, expectLowSurrogate);
+                }
                 return c;
             // new line normalization and counting is handled in read_char
             case CharacterSequence.CHAR_SEQ_NEWLINE_SEQUENCE_1:
@@ -2157,7 +2193,11 @@ final class IonReaderTextRawTokensX
             case CharacterSequence.CHAR_SEQ_ESCAPED_NEWLINE_SEQUENCE_1:
             case CharacterSequence.CHAR_SEQ_ESCAPED_NEWLINE_SEQUENCE_2:
             case CharacterSequence.CHAR_SEQ_ESCAPED_NEWLINE_SEQUENCE_3:
+                continue;
             case CharacterSequence.CHAR_SEQ_STRING_NON_TERMINATOR:
+                if (!is_clob) {
+                    expectLowSurrogate = check_for_low_surrogate(c, expectLowSurrogate);
+                }
                 continue;
             default:
                 break;
@@ -2165,9 +2205,13 @@ final class IonReaderTextRawTokensX
             // if this isn't a clob we need to decode UTF8 and
             // handle surrogate encoding (otherwise we don't care)
             if (!is_clob) {
+                expectLowSurrogate = check_for_low_surrogate(c, expectLowSurrogate);
+
                 if (IonUTF8.needsSurrogateEncoding(c)) {
                     sb.append(IonUTF8.highSurrogate(c));
                     c = IonUTF8.lowSurrogate(c);
+                } else {
+                    expectLowSurrogate = IonUTF8.isHighSurrogate(c);
                 }
             }
             sb.append((char)c);

--- a/src/software/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/software/amazon/ion/impl/IonReaderTextSystemX.java
@@ -849,6 +849,7 @@ class IonReaderTextSystemX
         int c = -1;
 
         switch (_lob_token) {
+        // BLOB
         case IonTokenConstsX.TOKEN_OPEN_DOUBLE_BRACE:
             while (len-- > 0) {
                 c = _scanner.read_base64_byte();
@@ -856,6 +857,7 @@ class IonReaderTextSystemX
                 buffer[offset++] = (byte)c;
             }
             break;
+        // CLOB
         case IonTokenConstsX.TOKEN_STRING_DOUBLE_QUOTE:
             while (len-- > 0) {
                 c = _scanner.read_double_quoted_char(true);
@@ -868,10 +870,11 @@ class IonReaderTextSystemX
                     }
                     break;
                 }
-                assert(c >= 0 && c <= UNSIGNED_BYTE_MAX_VALUE);
+                assert(c <= UNSIGNED_BYTE_MAX_VALUE);
                 buffer[offset++] = (byte)c;
             }
             break;
+        // CLOB 
         case IonTokenConstsX.TOKEN_STRING_TRIPLE_QUOTE:
             while (len-- > 0) {
                 c = _scanner.read_triple_quoted_char(true);

--- a/test/software/amazon/ion/BadIonTest.java
+++ b/test/software/amazon/ion/BadIonTest.java
@@ -18,10 +18,12 @@ import static software.amazon.ion.TestUtils.GLOBAL_SKIP_LIST;
 import static software.amazon.ion.TestUtils.testdataFiles;
 
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
 import org.junit.Test;
-import software.amazon.ion.IonDatagram;
-import software.amazon.ion.IonException;
 import software.amazon.ion.impl.PrivateUtils;
 import software.amazon.ion.junit.Injected.Inject;
 
@@ -75,7 +77,15 @@ public class BadIonTest
             }
             catch (IonException e)
             {
-                assert myTestFile.getPath().contains("bad/utf8") || myTestFile.getPath().contains("bad\\utf8");
+                // checks that test failed because of bad UTF-8 data
+                final CharBuffer buffer = CharBuffer.allocate(1024);
+                final CharsetEncoder utf8Encoder = Charset.forName("UTF-8").newEncoder();
+
+                final FileReader fileReader = new FileReader(myTestFile);
+                while(fileReader.read(buffer) != -1){
+                    assert utf8Encoder.canEncode(buffer);
+                }
+
                 return;
             }
 

--- a/test/software/amazon/ion/SystemProcessingTestCase.java
+++ b/test/software/amazon/ion/SystemProcessingTestCase.java
@@ -804,9 +804,6 @@ public abstract class SystemProcessingTestCase
 
                 ionData = "'''" + high + low + "'''";
                 checkString(FERMATA, "\"\\U0001d110\"", ionData);
-
-                ionData = "'''" + high + "''' '''" + low + "'''";
-                checkString(FERMATA, "\"\\U0001d110\"", ionData);
             }
         }
     }

--- a/test/software/amazon/ion/TestUtils.java
+++ b/test/software/amazon/ion/TestUtils.java
@@ -131,15 +131,6 @@ public class TestUtils
         new FileIsNot(
              "bad/clobWithNullCharacter.ion"                // TODO amzn/ion-java#43
             , "bad/emptyAnnotatedInt.10n"                   // TODO amzn/ion-java#55
-            , "bad/utf8/surrogate_1.ion"                    // TODO amzn/ion-java#105
-            , "bad/utf8/surrogate_2.ion"                    // TODO amzn/ion-java#105
-            , "bad/utf8/surrogate_4.ion"                    // TODO amzn/ion-java#105
-            , "bad/utf8/surrogate_5.ion"                    // TODO amzn/ion-java#60
-            , "bad/utf8/surrogate_6.ion"                    // TODO amzn/ion-java#105
-            , "bad/utf8/surrogate_7.ion"                    // TODO amzn/ion-java#105
-            , "bad/utf8/surrogate_8.ion"                    // TODO amzn/ion-java#105
-            , "bad/utf8/surrogate_9.ion"                    // TODO amzn/ion-java#105
-            , "bad/utf8/surrogate_10.ion"                   // TODO amzn/ion-java#105
             , "equivs/paddedInts.10n"                       // TODO amzn/ion-java#54
             , "good/subfieldVarUInt32bit.ion"               // TODO amzn/ion-java#62
             , "good/utf16.ion"                              // TODO amzn/ion-java#61

--- a/test/software/amazon/ion/TestUtils.java
+++ b/test/software/amazon/ion/TestUtils.java
@@ -130,12 +130,16 @@ public class TestUtils
     public static final FilenameFilter GLOBAL_SKIP_LIST =
         new FileIsNot(
              "bad/clobWithNullCharacter.ion"                // TODO amzn/ion-java#43
-            , "bad/clobWithNonAsciiCharacter.ion"           // TODO amzn/ion-java#99
             , "bad/emptyAnnotatedInt.10n"                   // TODO amzn/ion-java#55
-            , "bad/utf8/surrogate_5.ion"                    // TODO amzn/ion-java#60
             , "bad/utf8/surrogate_1.ion"                    // TODO amzn/ion-java#105
             , "bad/utf8/surrogate_2.ion"                    // TODO amzn/ion-java#105
             , "bad/utf8/surrogate_4.ion"                    // TODO amzn/ion-java#105
+            , "bad/utf8/surrogate_5.ion"                    // TODO amzn/ion-java#60
+            , "bad/utf8/surrogate_6.ion"                    // TODO amzn/ion-java#105
+            , "bad/utf8/surrogate_7.ion"                    // TODO amzn/ion-java#105
+            , "bad/utf8/surrogate_8.ion"                    // TODO amzn/ion-java#105
+            , "bad/utf8/surrogate_9.ion"                    // TODO amzn/ion-java#105
+            , "bad/utf8/surrogate_10.ion"                   // TODO amzn/ion-java#105
             , "equivs/paddedInts.10n"                       // TODO amzn/ion-java#54
             , "good/subfieldVarUInt32bit.ion"               // TODO amzn/ion-java#62
             , "good/utf16.ion"                              // TODO amzn/ion-java#61


### PR DESCRIPTION
*Issue* #105 

*Description of changes:*

Produces an error when an unpaired surrogate is encountered, in accordance with http://www.unicode.org/faq/utf_bom.html#utf16-7:  

> Unpaired surrogates are invalid in UTFs. These include any value in the range D800<sub>16</sub> to DBFF<sub>16</sub> not followed by a value in the range DC00<sub>16</sub> to DFFF<sub>16</sub>, or any value in the range DC00<sub>16</sub> to DFFF<sub>16</sub> not preceded by a value in the range D800<sub>16</sub> to D<sub>BFF16</sub>.

In accordance with the [Strings and Clobs](https://amzn.github.io/ion-docs/docs/stringclob.html) portion of the Ion Specification, splitting an escaped surrogate pair across multiple long strings (such as `'''\uD800''' '''\uDC00'''`) is invalid Ion.  Test logic that expects such values to be valid has been removed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
