### PR TITLE
Replaces Timestamp internals with Calendar.

### DIFF
--- a/src/software/amazon/ion/Timestamp.java
+++ b/src/software/amazon/ion/Timestamp.java
@@ -223,7 +223,6 @@ public final class Timestamp
     private static Calendar calendarFromMillis(long millis, Integer localOffset) {
         Calendar calendar = new GregorianCalendar(PrivateUtils.UTC);
         calendar.clear();
-        calendar.setLenient(false);
         calendar.setTimeInMillis(millis);
         if (localOffset != null) {
             calendar.set(Calendar.ZONE_OFFSET, localOffset * 60 * 1000);
@@ -379,7 +378,6 @@ public final class Timestamp
     {
         _calendar = new GregorianCalendar(PrivateUtils.UTC);
         _calendar.clear();
-        _calendar.setLenient(false);
         boolean dayPrecision = false;
 
         switch (p) {
@@ -527,7 +525,6 @@ public final class Timestamp
             throw new IllegalArgumentException("Calendar has no fields set");
         }
         _calendar = (Calendar) cal.clone();
-        _calendar.setLenient(false);
         setFieldsFromCalendar(precision, true, APPLY_OFFSET_YES);
     }
 

--- a/src/software/amazon/ion/Timestamp.java
+++ b/src/software/amazon/ion/Timestamp.java
@@ -1095,12 +1095,13 @@ public final class Timestamp
      * Returns a Timestamp that represents the point in time that is
      * {@code millis} milliseconds from the epoch, with a given local offset.
      * A default {@link GregorianCalendar} will be used to perform any
-     * arithmetic operations on the resulting Timestamp. NOTE: this means
-     * that providing a number of milliseconds that was produced using a
-     * different calendar system may result in a Timestamp that represents a
-     * different point in time than the one that originally produced the
-     * milliseconds. In this case, {@link #forCalendar(Calendar)} should be
-     * used instead.
+     * arithmetic operations on the resulting Timestamp.
+     * <p>
+     * <strong>NOTE:</strong> this means that providing a number of milliseconds
+     * that was produced using a different calendar system may result in a Timestamp
+     * that represents a different point in time than the one that originally
+     * produced the milliseconds. In this case, {@link #forCalendar(Calendar)} should
+     * be used instead.
      * <p>
      * The resulting Timestamp will be precise to the millisecond.
      *
@@ -1122,13 +1123,13 @@ public final class Timestamp
      * {@code millis} milliseconds (including any fractional
      * milliseconds) from the epoch, with a given local offset.
      * A default {@link GregorianCalendar} will be used to perform any
-     * arithmetic operations on the resulting Timestamp. NOTE: this means
-     * that providing a number of milliseconds that was produced using a
-     * different calendar system may result in a Timestamp that represents a
-     * different point in time than the one that originally produced the
-     * milliseconds. In this case, {@link #forCalendar(Calendar)} should be
-     * used instead.
-     *
+     * arithmetic operations on the resulting Timestamp.
+     * <p>
+     * <strong>NOTE:</strong> this means that providing a number of milliseconds
+     * that was produced using a different calendar system may result in a Timestamp
+     * that represents a different point in time than the one that originally
+     * produced the milliseconds. In this case, {@link #forCalendar(Calendar)} should
+     * be used instead.
      * <p>
      * The resulting Timestamp will be precise to the second if {@code millis}
      * doesn't contain information that is more granular than seconds.
@@ -1948,19 +1949,7 @@ public final class Timestamp
         } else {
             newFraction = millis;
         }
-        Timestamp ts = this;
-        do {
-            int incrementalSeconds;
-            if (seconds > Integer.MAX_VALUE) {
-                incrementalSeconds = Integer.MAX_VALUE;
-            } else if (seconds < Integer.MIN_VALUE) {
-                incrementalSeconds = Integer.MIN_VALUE;
-            } else {
-                incrementalSeconds = (int)seconds;
-            }
-            ts = ts.addSecond(incrementalSeconds);
-            seconds -= incrementalSeconds;
-        } while (seconds != 0);
+        Timestamp ts = addSecond(seconds);
         ts._fraction = newFraction;
         return ts;
     }
@@ -1983,6 +1972,29 @@ public final class Timestamp
         }
         timestamp._precision = _precision.includes(precision) ? timestamp._precision : precision;
         return timestamp;
+    }
+
+    /**
+     * Returns a timestamp relative to this one by the given number of seconds.
+     * Uses this Timestamp's configured Calendar to perform the arithmetic.
+     *
+     * @param seconds a number of seconds.
+     */
+    private final Timestamp addSecond(long seconds) {
+        Timestamp ts = this;
+        do {
+            int incrementalSeconds;
+            if (seconds > Integer.MAX_VALUE) {
+                incrementalSeconds = Integer.MAX_VALUE;
+            } else if (seconds < Integer.MIN_VALUE) {
+                incrementalSeconds = Integer.MIN_VALUE;
+            } else {
+                incrementalSeconds = (int)seconds;
+            }
+            ts = ts.addSecond(incrementalSeconds);
+            seconds -= incrementalSeconds;
+        } while (seconds != 0);
+        return ts;
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
#136 
#160 
#163 
#165

*Description of changes:*
Removes Timestamp's `_year`, `_month`, `day`, `hour`, `minute`, and `second` internal fields in favor of an internal Calendar. This allows us to shift responsibility for the arithmetic (especially leap year calculations) to Calendar. Timestamp still must manually track fractional seconds and local offsets. Users who want to use a non-standard Calendar system to back their Timestamps may do so using `Timestamp.forCalendar`. Timestamp remains externally immutable--there is no way for the user to access the internal Calendar and arithmetic methods always clone the calendar before performing their operations.

The changes to `TimestampTest.testAdd*` are to support the behavioral fix discussed in #136. Additional tests were added to provide coverage for the other issues discussed above. All other tests remain the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
