### PR TITLE
Fixing memleak when auto detecting gzipped bytes

### DIFF
--- a/src/software/amazon/ion/IonLoader.java
+++ b/src/software/amazon/ion/IonLoader.java
@@ -105,10 +105,15 @@ public interface IonLoader
 
 
     /**
+     * <p>
      * Loads a block of Ion data into a single datagram,
      * detecting whether it's text or binary data.
+     * </p>
+     *
      * <p>
-     * This method will auto-detect and uncompress GZIPped Ion data.
+     * This method will auto-detect and decompress GZIPped Ion data. <strong>WARNING:</strong> this feature is
+     * deprecated and will be removed in subsequent releases.
+     *</p>
      *
      * @param ionData may be either Ion binary data, or UTF-8 Ion text.
      * <em>This method assumes ownership of the array</em> and may modify it at
@@ -119,6 +124,9 @@ public interface IonLoader
      *
      * @throws NullPointerException if <code>ionData</code> is null.
      * @throws IonException if there's a syntax error in the Ion content.
+     *
+     * @deprecated auto-detecting of and decompression GZIPped Ion data will be removed in subsequent releases. Use
+     * {@link IonLoader#load(InputStream)} with a {@link java.util.zip.GZIPInputStream} instead for GZIP data
      */
     public IonDatagram load(byte[] ionData)
         throws IonException;
@@ -129,11 +137,17 @@ public interface IonLoader
      * detecting whether it's text or binary data.
      * <p>
      * The specified stream remains open after this method returns.
+     * </p>
+     *
      * <p>
-     * This method will auto-detect and uncompress GZIPped Ion data.
+     * This method will auto-detect and decompress GZIPped Ion data. <strong>WARNING:</strong> this feature is
+     * deprecated and will be removed in subsequent releases.
+     * </p>
+     *
      * <p>
      * Because this library performs its own buffering, it's recommended that
      * you avoid adding additional buffering to the given stream.
+     * </p>
      *
      * @param ionData the stream from which to read Ion data.
      *
@@ -144,6 +158,9 @@ public interface IonLoader
      * @throws IonException if there's a syntax error in the Ion content.
      * @throws IOException if reading from the specified input stream results
      * in an <code>IOException</code>.
+     *
+     * @deprecated auto-detecting of and decompression GZIPped Ion data will be removed in subsequent releases. Use a
+     * {@link java.util.zip.GZIPInputStream} to process GZIPped Ion data
      */
     public IonDatagram load(InputStream ionData)
         throws IonException, IOException;

--- a/src/software/amazon/ion/IonSystem.java
+++ b/src/software/amazon/ion/IonSystem.java
@@ -20,6 +20,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.util.Date;
 import java.util.Iterator;
+import software.amazon.ion.impl.lite.ReaderIterator;
 import software.amazon.ion.system.IonSystemBuilder;
 import software.amazon.ion.system.IonTextWriterBuilder;
 
@@ -204,25 +205,37 @@ public interface IonSystem
 
 
     /**
+     * <p>
      * Creates an iterator over a stream of Ion text data.
      * Values returned by the iterator have no container.
+     * </p>
+     *
      * <p>
      * The iterator will automatically consume Ion system IDs and local symbol
      * tables; they will not be returned by the iterator.
+     * </p>
+     *
      * <p>
      * If the input source throws an {@link IOException} during iteration, it
      * will be wrapped in an {@link IonException}. See documentation there for
      * tips on how to recover the cause.
+     * </p>
+     *
      * <p>
      * This method is suitable for use over unbounded streams with a reasonable
      * schema.
+     * </p>
+     *
      * <p>
      * Applications should generally use {@link #iterate(InputStream)}
      * whenever possible, since this library has much faster UTF-8 decoding
      * than the Java IO framework.
+     * </p>
+     *
      * <p>
      * Because this library performs its own buffering, it's recommended that
      * you avoid adding additional buffering to the given stream.
+     * </p>
      *
      * @param ionText a stream of Ion text data.  The caller is responsible for
      * closing the Reader after iteration is complete.
@@ -232,38 +245,55 @@ public interface IonSystem
      * @throws NullPointerException if <code>ionText</code> is null.
      * @throws IonException if the source throws {@link IOException}.
      */
-    public Iterator<IonValue> iterate(Reader ionText);
+    public ReaderIterator iterate(Reader ionText);
 
 
     /**
+     * <p>
      * Creates an iterator over a stream of Ion data,
      * detecting whether it's text or binary data.
      * Values returned by the iterator have no container.
+     * </p>
+     *
      * <p>
      * The iterator will automatically consume Ion system IDs and local symbol
      * tables; they will not be returned by the iterator.
+     * </p>
+     *
      * <p>
      * If the input source throws an {@link IOException} during iteration, it
      * will be wrapped in an {@link IonException}. See documentation there for
      * tips on how to recover the cause.
+     * </p>
+     *
      * <p>
      * This method is suitable for use over unbounded streams with a reasonable
      * schema.
+     * </p>
+     *
      * <p>
-     * This method will auto-detect and uncompress GZIPped Ion data.
+     * This method will auto-detect and decompress GZIPped Ion data. <strong>WARNING:</strong>
+     * this feature is deprecated and will be removed in subsequent releases.
+     * </p>
+     *
      * <p>
      * Because this library performs its own buffering, it's recommended that
      * you avoid adding additional buffering to the given stream.
+     * </p>
      *
      * @param ionData a stream of Ion data.  The caller is responsible for
      * closing the InputStream after iteration is complete.
      *
-     * @return a new iterator instance.
+     * @return a new ReaderIterator instance. <strong>WARNING:</strong> This instance
+     * must be closed by the client to avoid memory leaks when dealing with GZIPped Ion data.
      *
      * @throws NullPointerException if <code>ionData</code> is null.
      * @throws IonException if the source throws {@link IOException}.
+     *
+     * @deprecated auto-detecting of and decompression GZIPped Ion data
+     * will be removed in subsequent releases.
      */
-    public Iterator<IonValue> iterate(InputStream ionData);
+    public ReaderIterator iterate(InputStream ionData);
 
 
     /**
@@ -279,28 +309,37 @@ public interface IonSystem
      *
      * @throws NullPointerException if <code>ionText</code> is null.
      */
-    public Iterator<IonValue> iterate(String ionText);
+    public ReaderIterator iterate(String ionText);
 
 
     /**
+     * <p>
      * Creates an iterator over Ion data.
      * Values returned by the iterator have no container.
+     * </p>
      * <p>
      * The iterator will automatically consume Ion system IDs and local symbol
      * tables; they will not be returned by the iterator.
+     * </p>
      * <p>
-     * This method will auto-detect and uncompress GZIPped Ion data.
+     * This method will auto-detect and decompress GZIPped Ion data. <strong>WARNING:</strong>
+     * this feature is deprecated and will be removed in subsequent releases.
+     * </p>
      *
      * @param ionData may be either Ion binary data or (UTF-8) Ion text, or
      * GZIPped Ion data.
      * <em>This method assumes ownership of the array</em> and may modify it at
      * will.
      *
-     * @return a new iterator instance.
+     * @return a new ReaderIterator instance. <strong>WARNING:</strong> This instance
+     * must be closed by the client to avoid memory leaks when dealing with GZIPped Ion data.
      *
      * @throws NullPointerException if <code>ionData</code> is null.
+     *
+     * @deprecated auto-detecting of and decompression GZIPped Ion data
+     * will be removed in subsequent releases.
      */
-    public Iterator<IonValue> iterate(byte[] ionData);
+    public ReaderIterator iterate(byte[] ionData);
 
 
     /**
@@ -320,9 +359,14 @@ public interface IonSystem
 
 
     /**
-     * Extracts a single value from Ion text or binary data.
      * <p>
-     * This method will auto-detect and uncompress GZIPped Ion data.
+     * Extracts a single value from Ion text or binary data.
+     * </p>
+     *
+     * <p>
+     * This method will auto-detect and decompress GZIPped Ion data. <strong>WARNING:</strong>
+     * this feature is deprecated and will be removed in subsequent releases.
+     * </p>
      *
      * @param ionData may be either Ion binary data or (UTF-8) Ion text, or
      * GZIPped Ion data.
@@ -336,6 +380,9 @@ public interface IonSystem
      * values.
      * @throws IonException if the data does not contain exactly one user
      * value.
+     *
+     * @deprecated auto-detecting of and decompression GZIPped Ion data
+     * will be removed in subsequent releases.
      */
     public IonValue singleValue(byte[] ionData);
 
@@ -364,22 +411,35 @@ public interface IonSystem
     public IonReader newReader(String ionText);
 
     /**
+     * <p>
      * Creates an new {@link IonReader} instance over a block of Ion data,
      * detecting whether it's text or binary data.
+     * </p>
+     *
      * <p>
-     * This method will auto-detect and uncompress GZIPped Ion data.
+     * This method will auto-detect and decompress GZIPped Ion data. <strong>WARNING:</strong>
+     * this feature is deprecated and will be removed in subsequent releases.
+     * </p>
      *
      * @param ionData may be either Ion binary data, or UTF-8 Ion text.
      * The reader retains a reference to the array, so its data must not be
      * modified while the reader is active.
+     *
+     * @deprecated auto-detecting of and decompression GZIPped Ion data
+     * will be removed in subsequent releases.
      */
     public IonReader newReader(byte[] ionData);
 
     /**
+     * <p>
      * Creates an new {@link IonReader} instance over a block of Ion data,
      * detecting whether it's text or binary data.
+     * </p>
+     *
      * <p>
-     * This method will auto-detect and uncompress GZIPped Ion data.
+     * This method will auto-detect and decompress GZIPped Ion data. <strong>WARNING:</strong>
+     * this feature is deprecated and will be removed in subsequent releases.
+     * </p>
      *
      * @param ionData is used only within the range of bytes starting at
      * {@code offset} for {@code len} bytes.
@@ -389,17 +449,26 @@ public interface IonSystem
      * @param offset must be non-negative and less than {@code ionData.length}.
      * @param len must be non-negative and {@code offset+len} must not exceed
      * {@code ionData.length}.
+     *
+     * @deprecated auto-detecting of and decompression GZIPped Ion data
+     * will be removed in subsequent releases.
      */
     public IonReader newReader(byte[] ionData, int offset, int len);
 
     /**
+     * <p>
      * Creates a new {@link IonReader} instance over a stream of Ion data,
      * detecting whether it's text or binary data.
+     *
      * <p>
-     * This method will auto-detect and uncompress GZIPped Ion data.
+     * This method will auto-detect and decompress GZIPped Ion data. <strong>WARNING:</strong>
+     * this feature is deprecated and will be removed in subsequent releases.
+     * </p>
+     *
      * <p>
      * Because this library performs its own buffering, it's recommended that
      * you avoid adding additional buffering to the given stream.
+     * </p>
      *
      * @param ionData must not be null.
      *
@@ -407,6 +476,9 @@ public interface IonSystem
      * Callers must call {@link IonReader#close()} when finished with it.
      *
      * @throws IonException if the source throws {@link IOException}.
+     *
+     * @deprecated auto-detecting of and decompression GZIPped Ion data
+     * will be removed in subsequent releases.
      */
     public IonReader newReader(InputStream ionData);
 

--- a/src/software/amazon/ion/impl/lite/IonLoaderLite.java
+++ b/src/software/amazon/ion/impl/lite/IonLoaderLite.java
@@ -122,21 +122,34 @@ final class IonLoaderLite
 
     public IonDatagram load(byte[] ionData) throws IonException
     {
+        IonReader reader = null;
         try {
-            IonReader reader = makeReader(_catalog, ionData, 0, ionData.length, _lstFactory);
+            reader = makeReader(_catalog, ionData, 0, ionData.length, _lstFactory);
             IonDatagramLite datagram = load_helper(reader);
             return datagram;
         }
         catch (IOException e) {
             throw new IonException(e);
         }
+        finally
+        {
+            if (reader != null) {
+                try {
+                    reader.close();
+                }
+                catch (IOException e) {
+                    throw new IonException(e);
+                }
+            }
+        }
     }
 
     public IonDatagram load(InputStream ionData)
         throws IonException, IOException
     {
+        IonReader reader = null;
         try {
-            IonReader reader = makeReader(_catalog, ionData, _lstFactory);
+            reader = makeReader(_catalog, ionData, _lstFactory);
             IonDatagramLite datagram = load_helper(reader);
             return datagram;
         }
@@ -144,6 +157,11 @@ final class IonLoaderLite
             IOException io = e.causeOfType(IOException.class);
             if (io != null) throw io;
             throw e;
+        }
+        finally {
+            if (reader != null) {
+                reader.close();
+            }
         }
     }
 

--- a/src/software/amazon/ion/impl/lite/ReaderIterator.java
+++ b/src/software/amazon/ion/impl/lite/ReaderIterator.java
@@ -1,0 +1,79 @@
+package software.amazon.ion.impl.lite;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import software.amazon.ion.IonException;
+import software.amazon.ion.IonReader;
+import software.amazon.ion.IonType;
+import software.amazon.ion.IonValue;
+import software.amazon.ion.SymbolTable;
+
+/**
+ * An IonReader based IonValue iterator. It closes the reader when there are no
+ * more values to iterate over.
+ */
+public class ReaderIterator
+    implements Iterator<IonValue>, Closeable
+{
+    private final IonReader reader;
+    private final IonSystemLite system;
+    private IonType next;
+
+    protected ReaderIterator(IonSystemLite system, IonReader reader)
+    {
+        this.reader = reader;
+        this.system = system;
+    }
+
+    public boolean hasNext()
+    {
+        if (next == null) {
+            next = reader.next();
+        }
+
+        boolean hasNext = next != null;
+
+        if (!hasNext) {
+            try {
+                close();
+            }
+            catch (IOException e) {
+                throw new IonException(e);
+            }
+        }
+
+        return hasNext;
+    }
+
+    public IonValue next()
+    {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        SymbolTable symtab = reader.getSymbolTable();
+
+        // make an ion value from our reader
+        // We already called reader.next() inside hasNext() above
+        IonValueLite value = system.newValue(reader);
+
+        // we've used up the value now, force a reader.next() the next time through
+        next = null;
+
+        value.setSymbolTable(symtab);
+
+        return value;
+    }
+
+    public void remove()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    public void close() throws IOException
+    {
+        reader.close();
+    }
+}


### PR DESCRIPTION
Correctly closes the created IonReader in order to free the memory
allocated outside the heap by GzipInputStream.

For methods that return an iterator changed the signature to
return a ReaderIterator which is `Closeable` permitting users to
close the iterator. This iterator also closes itself when there are
no more values next to return.

The gzip auto detect functionality should be removed from this package
as it is an orthogonal concern to reading/writing Ion data. Right now
our API has to close streams created by users to guaranteed that the
internal wrapped Gzip stream is correctly closed.

https://github.com/amzn/ion-java/issues/198

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
