### PR TITLE
OpenJDK11 javadoc fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.10.3</version>
+        <configuration>
+          <source>8</source>
+        </configuration>
         <reportSets>
           <reportSet>
             <configuration>

--- a/src/software/amazon/ion/IonSystem.java
+++ b/src/software/amazon/ion/IonSystem.java
@@ -650,8 +650,8 @@ public interface IonSystem
 
     /**
      * Creates a new datagram, bootstrapped with imported symbol tables.
-     * Generally an application will use this to aquire a datagram, then adds
-     * values to it, then calls {@link IonDatagram#getBytes(byte[])}
+     * Generally an application will use this to acquire a datagram, then adds
+     * values to it, then calls {@link IonDatagram#getBytes()}
      * (or similar) to extract binary data.
      *
      * @param imports the set of shared symbol tables to import.

--- a/src/software/amazon/ion/ValueFactory.java
+++ b/src/software/amazon/ion/ValueFactory.java
@@ -254,6 +254,11 @@ public interface ValueFactory
      * Constructs a new {@code list} with the given child.
      *
      * @param child the initial child of the new list.
+     * <p>
+     * <b>This method is temporary</b> until "newList(Collection)" is
+     * removed.  It's sole purpose is to avoid the doomed attempt to add all
+     * of the parameter's children to the new list; that will always throw
+     * {@link ContainedValueException}.
      *
      * @throws NullPointerException if {@code child} is null.
      * @throws IllegalArgumentException if {@code child} is an {@link IonDatagram}.
@@ -354,6 +359,11 @@ public interface ValueFactory
 
     /**
      * Constructs a new {@code sexp} with the given child.
+     * <p>
+     * <b>This method is temporary</b> until "newSexp(Collection)" is
+     * removed.  It's sole purpose is to avoid the doomed attempt to add all
+     * of the parameter's children to the new sequence; that will always throw
+     * {@link ContainedValueException}.
      *
      * @param child the initial child of the new sexp.
      *

--- a/src/software/amazon/ion/ValueFactory.java
+++ b/src/software/amazon/ion/ValueFactory.java
@@ -354,11 +354,6 @@ public interface ValueFactory
 
     /**
      * Constructs a new {@code sexp} with the given child.
-     * <p>
-     * <b>This method is temporary</b> until {@link #newSexp(Collection)} is
-     * removed.  It's sole purpose is to avoid the doomed attempt to add all
-     * of the parameter's children to the new sequence; that will always throw
-     * {@link ContainedValueException}.
      *
      * @param child the initial child of the new sexp.
      *

--- a/src/software/amazon/ion/ValueFactory.java
+++ b/src/software/amazon/ion/ValueFactory.java
@@ -252,11 +252,6 @@ public interface ValueFactory
 
     /**
      * Constructs a new {@code list} with the given child.
-     * <p>
-     * <b>This method is temporary</b> until {@link #newList(Collection)} is
-     * removed.  It's sole purpose is to avoid the doomed attempt to add all
-     * of the parameter's children to the new list; that will always throw
-     * {@link ContainedValueException}.
      *
      * @param child the initial child of the new list.
      *


### PR DESCRIPTION
The log of this [failed travis buid](https://travis-ci.org/amzn/ion-java/jobs/486874734) shows:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  49.094 s
[INFO] Finished at: 2019-02-01T15:30:47-08:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.7.1:site (default-site) on project ion-java: Error generating maven-javadoc-plugin:2.10.3:javadoc-no-fork report:
[ERROR] Exit code: 1 - javadoc: error - The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module.
[ERROR] /Users/dlurton/projects/ion-java2/src/software/amazon/ion/IonSystem.java:654: warning - Tag @link: reference not found: IonDatagram#getBytes(byte[])
[ERROR] /Users/dlurton/projects/ion-java2/src/software/amazon/ion/ValueFactory.java:256: warning - Tag @link: reference not found: #newList(Collection)
[ERROR] /Users/dlurton/projects/ion-java2/src/software/amazon/ion/ValueFactory.java:363: warning - Tag @link: reference not found: #newSexp(Collection)
```

There are 4 distinct errors, 3 of them are legitimate javadoc errors.   I fixed these errors by hand.

The 4th is about `The code being documented uses modules but the packages defined in http://docs.oracle.com/javase/8/docs/api/ are in the unnamed module`, which seems strange since that's part of the Java standard library.  A quick bit of search-fu yields [this bug in the OpenJDK bug tracker](https://bugs.openjdk.java.net/browse/JDK-8212233) which identifies a work-around that involves manually specifying the java version to the javadoc generator.