### PR TITLE
fixes getMillis() and getDecimalMillis() behavior for Timestamps cons…

### DIFF
--- a/test/software/amazon/ion/TimestampTest.java
+++ b/test/software/amazon/ion/TimestampTest.java
@@ -2886,6 +2886,12 @@ public class TimestampTest
         cal2.setTime(date);
         Timestamp t2 = Timestamp.forCalendar(cal2);
 
+        assertEquals(t1.getMillis(), date.getTime());
+        assertEquals(t2.getMillis(), date.getTime());
+
+        assertEquals(BigDecimal.valueOf(t1.getMillis()), t1.getDecimalMillis());
+        assertEquals(BigDecimal.valueOf(t2.getMillis()), t2.getDecimalMillis());
+
         assertEquals(t1.getMillis(), t2.getMillis());
         assertEquals(t1.getDecimalMillis(), t2.getDecimalMillis());
     }

--- a/test/software/amazon/ion/TimestampTest.java
+++ b/test/software/amazon/ion/TimestampTest.java
@@ -30,6 +30,7 @@ import static software.amazon.ion.impl.PrivateUtils.UTC;
 
 import java.math.BigDecimal;
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -2868,6 +2869,25 @@ public class TimestampTest
     public void testGetMillisWithLargeScaleBigDecimal()
     {
         Timestamp.forMillis(LARGE_SCALE_DECIMAL, PST_OFFSET).getMillis();
+    }
+
+    @Test
+    public void testMillisIsIndepedentOfOffset() throws ParseException {
+        DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        Date date = format.parse("2010-06-29T23:20:00+0000");
+
+        Calendar cal1 = Calendar.getInstance();
+        cal1.setTimeZone(TimeZone.getTimeZone("GMT+00:00"));
+        cal1.setTime(date);
+        Timestamp t1 = Timestamp.forCalendar(cal1);
+
+        Calendar cal2 = Calendar.getInstance();
+        cal2.setTimeZone(TimeZone.getTimeZone("GMT+02:00"));
+        cal2.setTime(date);
+        Timestamp t2 = Timestamp.forCalendar(cal2);
+
+        assertEquals(t1.getMillis(), t2.getMillis());
+        assertEquals(t1.getDecimalMillis(), t2.getDecimalMillis());
     }
 
     @Test


### PR DESCRIPTION
…tructed via forCalendar()

If the incoming Calendar has an offset from UTC, Timestamp rolls the hours and minutes of its internal Calendar instance such that the fields represent a UTC time, with the side-effect of *changing the instant (ms) the Calendar represents* resulting in wrong values being returned by `Timestamp.getMillis()` and `Timestamp.getDecimalMillis()`.

The changes proposed here calculate a _calendarCompensationOffsetMs so that `getMillis()` and `getDecimalMillis()` can return the correct instant.

Resolves #212 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
