### PR TITLE
Gzip memleak fix

### DIFF
--- a/src/software/amazon/ion/IonLoader.java
+++ b/src/software/amazon/ion/IonLoader.java
@@ -163,19 +163,14 @@ public interface IonLoader
      * detecting whether it's text or binary data.
      * <p>
      * The specified reader remains open after this method returns.
-     * <p>
-     * This method will auto-detect and uncompress GZIPped Ion data.
-     * <p>
+     * </p>
      *
-     * @param reader readers used to read either Ion binary, Ion text or GZIPped Ion data.
+     * @param reader @param reader source of the Ion data to load.
      *
      * @return a datagram containing all the values on the reader; not null.
      *
-     * @throws NullPointerException if <code>ionData</code> is null.
+     * @throws NullPointerException if <code>reader</code> is null.
      * @throws IonException if there's a syntax error in the Ion content.
-     * @throws IOException if reading from the specified input stream results
-     * in an <code>IOException</code>.
      */
-    public IonDatagram load(IonReader reader)
-            throws IonException, IOException;
+    public IonDatagram load(IonReader reader) throws IonException;
 }

--- a/src/software/amazon/ion/IonLoader.java
+++ b/src/software/amazon/ion/IonLoader.java
@@ -125,6 +125,11 @@ public interface IonLoader
 
 
     /**
+     * <p>
+     * <strong>WARNING: Will cause a memory leak when reading a gzipped stream, use
+     * {@link IonLoader#load(IonReader)} instead.</strong>
+     * </p>
+     *
      * Loads an entire stream of Ion data into a single datagram,
      * detecting whether it's text or binary data.
      * <p>
@@ -144,7 +149,33 @@ public interface IonLoader
      * @throws IonException if there's a syntax error in the Ion content.
      * @throws IOException if reading from the specified input stream results
      * in an <code>IOException</code>.
+     *
+     * @deprecated Will cause a memory leak when reading a gzipped stream.
+     * Use {@link IonLoader#load(IonReader)} instead.
      */
+    @Deprecated
     public IonDatagram load(InputStream ionData)
         throws IonException, IOException;
+
+
+    /**
+     * Loads an entire stream of Ion data into a single datagram,
+     * detecting whether it's text or binary data.
+     * <p>
+     * The specified reader remains open after this method returns.
+     * <p>
+     * This method will auto-detect and uncompress GZIPped Ion data.
+     * <p>
+     *
+     * @param reader readers used to read either Ion binary, Ion text or GZIPped Ion data.
+     *
+     * @return a datagram containing all the values on the reader; not null.
+     *
+     * @throws NullPointerException if <code>ionData</code> is null.
+     * @throws IonException if there's a syntax error in the Ion content.
+     * @throws IOException if reading from the specified input stream results
+     * in an <code>IOException</code>.
+     */
+    public IonDatagram load(IonReader reader)
+            throws IonException, IOException;
 }

--- a/src/software/amazon/ion/IonSystem.java
+++ b/src/software/amazon/ion/IonSystem.java
@@ -327,11 +327,8 @@ public interface IonSystem
      * The iterator will automatically consume Ion system IDs and local symbol
      * tables; they will not be returned by the iterator.
      * </p>
-     * <p>
-     * This method will auto-detect and uncompress GZIPped Ion data.
-     * </p>
      *
-     * @param reader readers used to read either Ion binary, Ion text or GZIPped Ion data.
+     * @param reader source of the Ion data to iterate over.
      *
      * @return a new iterator instance.
      *

--- a/src/software/amazon/ion/IonSystem.java
+++ b/src/software/amazon/ion/IonSystem.java
@@ -236,6 +236,11 @@ public interface IonSystem
 
 
     /**
+     * <p>
+     * <strong>WARNING: Will cause a memory leak when reading a gzipped stream, use
+     * {@link IonSystem#iterate(IonReader)} instead.</strong>
+     * </p>
+     *
      * Creates an iterator over a stream of Ion data,
      * detecting whether it's text or binary data.
      * Values returned by the iterator have no container.
@@ -262,9 +267,12 @@ public interface IonSystem
      *
      * @throws NullPointerException if <code>ionData</code> is null.
      * @throws IonException if the source throws {@link IOException}.
+     *
+     * @deprecated Will cause a memory leak when reading a gzipped stream.
+     * Use {@link IonSystem#iterate(IonReader)} instead.
      */
+    @Deprecated
     public Iterator<IonValue> iterate(InputStream ionData);
-
 
     /**
      * Creates an iterator over a string containing Ion text data.
@@ -281,8 +289,12 @@ public interface IonSystem
      */
     public Iterator<IonValue> iterate(String ionText);
 
-
     /**
+     * <p>
+     * <strong>WARNING: Will cause a memory leak when reading a gzipped byte[], use
+     * {@link IonSystem#iterate(IonReader)} instead.</strong>
+     * </p>
+     *
      * Creates an iterator over Ion data.
      * Values returned by the iterator have no container.
      * <p>
@@ -299,9 +311,33 @@ public interface IonSystem
      * @return a new iterator instance.
      *
      * @throws NullPointerException if <code>ionData</code> is null.
+     *
+     * @deprecated Will cause a memory leak when reading a gzipped byte[].
+     * Use {@link IonSystem#iterate(IonReader)} instead.
      */
+    @Deprecated
     public Iterator<IonValue> iterate(byte[] ionData);
 
+    /**
+     * <p>
+     * Creates an iterator over Ion data.
+     * Values returned by the iterator have no container.
+     * </p>
+     * <p>
+     * The iterator will automatically consume Ion system IDs and local symbol
+     * tables; they will not be returned by the iterator.
+     * </p>
+     * <p>
+     * This method will auto-detect and uncompress GZIPped Ion data.
+     * </p>
+     *
+     * @param reader readers used to read either Ion binary, Ion text or GZIPped Ion data.
+     *
+     * @return a new iterator instance.
+     *
+     * @throws NullPointerException if <code>reader</code> is null.
+     */
+    public Iterator<IonValue> iterate(IonReader reader);
 
     /**
      * Extracts a single value from Ion text data.

--- a/src/software/amazon/ion/impl/PrivateIonSystem.java
+++ b/src/software/amazon/ion/impl/PrivateIonSystem.java
@@ -45,12 +45,7 @@ public interface PrivateIonSystem
      */
     public Iterator<IonValue> systemIterate(Reader ionText);
 
-    public Iterator<IonValue> systemIterate(byte[] ionData);
-
-    /**
-     * TODO Must correct amzn/ion-java#14 before exposing this or using from public API.
-     */
-    public Iterator<IonValue> systemIterate(InputStream ionData);
+    public Iterator<IonValue> systemIterate(IonReader reader);
 
     public IonReader newSystemReader(Reader ionText);
 

--- a/src/software/amazon/ion/impl/lite/IonLoaderLite.java
+++ b/src/software/amazon/ion/impl/lite/IonLoaderLite.java
@@ -122,14 +122,19 @@ final class IonLoaderLite
 
     public IonDatagram load(byte[] ionData) throws IonException
     {
+        IonReader reader = makeReader(_catalog, ionData, 0, ionData.length, _lstFactory);
         try {
-            IonReader reader = makeReader(_catalog, ionData, 0, ionData.length, _lstFactory);
-            IonDatagramLite datagram = load_helper(reader);
-            return datagram;
+            return load(reader);
         }
-        catch (IOException e) {
-            throw new IonException(e);
+        finally {
+            try {
+                reader.close();
+            }
+            catch (IOException e) {
+                throw new IonException(e);
+            }
         }
+
     }
 
     public IonDatagram load(InputStream ionData)
@@ -137,8 +142,7 @@ final class IonLoaderLite
     {
         try {
             IonReader reader = makeReader(_catalog, ionData, _lstFactory);
-            IonDatagramLite datagram = load_helper(reader);
-            return datagram;
+            return load(reader);
         }
         catch (IonException e) {
             IOException io = e.causeOfType(IOException.class);
@@ -147,4 +151,14 @@ final class IonLoaderLite
         }
     }
 
+    public IonDatagram load(IonReader reader) throws IonException
+    {
+        try {
+            IonDatagramLite datagram = load_helper(reader);
+            return datagram;
+        }
+        catch (IOException e) {
+            throw new IonException(e);
+        }
+    }
 }

--- a/src/software/amazon/ion/impl/lite/IonSystemLite.java
+++ b/src/software/amazon/ion/impl/lite/IonSystemLite.java
@@ -180,8 +180,7 @@ final class IonSystemLite
     public Iterator<IonValue> iterate(InputStream ionData)
     {
         IonReader reader = makeReader(_catalog, ionData, _lstFactory);
-        ReaderIterator iterator = new ReaderIterator(this, reader);
-        return iterator;
+        return iterate(reader);
     }
 
     public Iterator<IonValue> iterate(String ionText)
@@ -194,6 +193,11 @@ final class IonSystemLite
     public Iterator<IonValue> iterate(byte[] ionData)
     {
         IonReader reader = makeReader(_catalog, ionData, _lstFactory);
+        return iterate(reader);
+    }
+
+    public Iterator<IonValue> iterate(IonReader reader)
+    {
         ReaderIterator iterator = new ReaderIterator(this, reader);
         return iterator;
     }
@@ -494,8 +498,19 @@ final class IonSystemLite
 
     public IonValue singleValue(byte[] ionData)
     {
-        Iterator<IonValue> it = iterate(ionData);
-        return singleValue(it);
+        IonReader reader = newReader(ionData);
+        try {
+            Iterator<IonValue> it = iterate(reader);
+            return singleValue(it);
+        }
+        finally {
+            try {
+                reader.close();
+            }
+            catch (IOException e) {
+                throw new IonException(e);
+            }
+        }
     }
 
     protected IonSymbolLite newSystemIdSymbol(String ionVersionMarker)
@@ -756,16 +771,9 @@ final class IonSystemLite
         return PrivateUtils.iterate(this, ir);
     }
 
-    public Iterator<IonValue> systemIterate(InputStream ionData)
+    public Iterator<IonValue> systemIterate(IonReader reader)
     {
-        IonReader ir = newSystemReader(ionData);
-        return PrivateUtils.iterate(this, ir);
-    }
-
-    public Iterator<IonValue> systemIterate(byte[] ionData)
-    {
-        IonReader ir = newSystemReader(ionData);
-        return PrivateUtils.iterate(this, ir);
+        return PrivateUtils.iterate(this, reader);
     }
 
 

--- a/src/software/amazon/ion/impl/lite/IonSystemLite.java
+++ b/src/software/amazon/ion/impl/lite/IonSystemLite.java
@@ -179,6 +179,7 @@ final class IonSystemLite
 
     public Iterator<IonValue> iterate(InputStream ionData)
     {
+        // This method causes a memory leak when reading a gzipped stream, see deprecation notice.
         IonReader reader = makeReader(_catalog, ionData, _lstFactory);
         return iterate(reader);
     }
@@ -192,6 +193,7 @@ final class IonSystemLite
 
     public Iterator<IonValue> iterate(byte[] ionData)
     {
+        // This method causes a memory leak when reading a gzipped stream, see deprecation notice.
         IonReader reader = makeReader(_catalog, ionData, _lstFactory);
         return iterate(reader);
     }

--- a/test/software/amazon/ion/BinaryByteArrayIteratorSystemProcessingTest.java
+++ b/test/software/amazon/ion/BinaryByteArrayIteratorSystemProcessingTest.java
@@ -41,6 +41,6 @@ public class BinaryByteArrayIteratorSystemProcessingTest
     @Override
     protected Iterator<IonValue> systemIterate()
     {
-        return system().systemIterate(myBytes);
+        return system().systemIterate(system().newSystemReader(myBytes));
     }
 }

--- a/test/software/amazon/ion/BinaryStreamIteratorSystemProcessingTest.java
+++ b/test/software/amazon/ion/BinaryStreamIteratorSystemProcessingTest.java
@@ -45,6 +45,6 @@ public class BinaryStreamIteratorSystemProcessingTest
     @Override
     protected Iterator<IonValue> systemIterate()
     {
-        return system().systemIterate(myStream);
+        return system().systemIterate(system().newSystemReader(myStream));
     }
 }

--- a/test/software/amazon/ion/IonSystemTest.java
+++ b/test/software/amazon/ion/IonSystemTest.java
@@ -341,4 +341,83 @@ public class IonSystemTest
         checkGzipDetection(binaryBytes);
         checkGzipDetection(gzipBinaryBytes);
     }
+
+    private byte[] toBinaryIon(String text) throws IOException
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonReader ionReader = system().newReader(text);
+        IonWriter ionWriter = system().newBinaryWriter(out);
+        ionWriter.writeValues(ionReader);
+        ionWriter.close();
+        return out.toByteArray();
+    }
+
+    @Test
+    public void singleValueTextGzip() throws IOException
+    {
+        String ionText = "1234";
+        byte[] textBytes = PrivateUtils.utf8(ionText);
+        byte[] gzipTextBytes = gzip(textBytes);
+        IonInt ionValue = (IonInt) system().singleValue(gzipTextBytes);
+
+        assertEquals(1234, ionValue.intValue());
+    }
+
+    @Test
+    public void singleValueBinaryGzip() throws IOException
+    {
+        String ionText = "1234";
+        byte[] binaryIon = toBinaryIon(ionText);
+        byte[] gzipBytes = gzip(binaryIon);
+
+        IonInt ionValue = (IonInt) system().singleValue(gzipBytes);
+
+        assertEquals(1234, ionValue.intValue());
+    }
+
+    @Test
+    public void iterateReader()
+    {
+        String ionText = "1 2 3 4";
+        IonReader ionReader = system().newReader(ionText);
+
+        Iterator<IonValue> iterate = system().iterate(ionReader);
+
+        assertTrue(iterate.hasNext());
+        assertEquals(1, ((IonInt) iterate.next()).intValue());
+
+        assertTrue(iterate.hasNext());
+        assertEquals(2, ((IonInt) iterate.next()).intValue());
+
+        assertTrue(iterate.hasNext());
+        assertEquals(3, ((IonInt) iterate.next()).intValue());
+
+        assertTrue(iterate.hasNext());
+        assertEquals(4, ((IonInt) iterate.next()).intValue());
+
+        assertFalse(iterate.hasNext());
+    }
+
+    @Test
+    public void systemIterateReader()
+    {
+        String ionText = "1 2 3 4";
+        IonReader ionReader = system().newSystemReader(ionText);
+
+        Iterator<IonValue> iterate = system().systemIterate(ionReader);
+
+        assertTrue(iterate.hasNext());
+        assertEquals(1, ((IonInt) iterate.next()).intValue());
+
+        assertTrue(iterate.hasNext());
+        assertEquals(2, ((IonInt) iterate.next()).intValue());
+
+        assertTrue(iterate.hasNext());
+        assertEquals(3, ((IonInt) iterate.next()).intValue());
+
+        assertTrue(iterate.hasNext());
+        assertEquals(4, ((IonInt) iterate.next()).intValue());
+
+        assertFalse(iterate.hasNext());
+    }
 }

--- a/test/software/amazon/ion/IonSystemTest.java
+++ b/test/software/amazon/ion/IonSystemTest.java
@@ -349,6 +349,7 @@ public class IonSystemTest
         IonWriter ionWriter = system().newBinaryWriter(out);
         ionWriter.writeValues(ionReader);
         ionWriter.close();
+        ionReader.close();
         return out.toByteArray();
     }
 
@@ -369,14 +370,13 @@ public class IonSystemTest
         String ionText = "1234";
         byte[] binaryIon = toBinaryIon(ionText);
         byte[] gzipBytes = gzip(binaryIon);
-
         IonInt ionValue = (IonInt) system().singleValue(gzipBytes);
 
         assertEquals(1234, ionValue.intValue());
     }
 
     @Test
-    public void iterateReader()
+    public void iterateReader() throws IOException
     {
         String ionText = "1 2 3 4";
         IonReader ionReader = system().newReader(ionText);
@@ -396,10 +396,12 @@ public class IonSystemTest
         assertEquals(4, ((IonInt) iterate.next()).intValue());
 
         assertFalse(iterate.hasNext());
+
+        ionReader.close();
     }
 
     @Test
-    public void systemIterateReader()
+    public void systemIterateReader() throws IOException
     {
         String ionText = "1 2 3 4";
         IonReader ionReader = system().newSystemReader(ionText);
@@ -419,5 +421,7 @@ public class IonSystemTest
         assertEquals(4, ((IonInt) iterate.next()).intValue());
 
         assertFalse(iterate.hasNext());
+
+        ionReader.close();
     }
 }

--- a/test/software/amazon/ion/TextByteArrayIteratorSystemProcessingTest.java
+++ b/test/software/amazon/ion/TextByteArrayIteratorSystemProcessingTest.java
@@ -40,6 +40,6 @@ public class TextByteArrayIteratorSystemProcessingTest
     @Override
     protected Iterator<IonValue> systemIterate()
     {
-        return system().systemIterate(myBytes);
+        return system().systemIterate(system().newSystemReader(myBytes));
     }
 }

--- a/test/software/amazon/ion/TextStreamIteratorSystemProcessingTest.java
+++ b/test/software/amazon/ion/TextStreamIteratorSystemProcessingTest.java
@@ -45,6 +45,6 @@ public class TextStreamIteratorSystemProcessingTest
     @Override
     protected Iterator<IonValue> systemIterate()
     {
-        return system().systemIterate(myStream);
+        return system().systemIterate(system().newSystemReader(myStream));
     }
 }

--- a/test/software/amazon/ion/impl/IonWriterTestCase.java
+++ b/test/software/amazon/ion/impl/IonWriterTestCase.java
@@ -810,7 +810,7 @@ public abstract class IonWriterTestCase
         throws Exception
     {
         byte[] data = outputByteArray();
-        Iterator<IonValue> it = system().systemIterate(data);
+        Iterator<IonValue> it = system().systemIterate(system().newSystemReader(data));
         return it;
     }
 


### PR DESCRIPTION
This commit addresses the memleak caused by auto detecting and uncompressing gzipped ion data by either:
* Fixing the issue when possible, example IonSystem#singleValue
* Deprecating methods where a fix is not feasible providing a safe
alternative, example IonSystem#iterate(InputStream)

The alternative method takes in an IonReader which the user is
responsible for closing. IonReader will close all used resources
including the Gzip stream used to decompress which is hidden from users
in the unsafe deprecated methods.

Issues:
* https://github.com/amzn/ion-java/issues/210
* https://github.com/amzn/ion-java/issues/198

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
