### PR TITLE
target JDK 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.0</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,15 @@
     <testSourceDirectory>test</testSourceDirectory>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
         <!--
         Since the format of maven.build.timestamp cannot be changed
         during the build, define the build.time property here.


### PR DESCRIPTION
Some older users require JDK 5 compatibility so setting as the build and source target to block the use of any newer features.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
