### PR TITLE
fixing gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,6 @@ tmp*
 ### Eclipse ###
 
 .metadata
-bin/
-tmp/
 *.tmp
 *.bak
 *.swp


### PR DESCRIPTION
bin/ and tmp/ can match relative paths, e.g. com/amazon/ion/impl/bin

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
