### PR TITLE
Make IllegalStateException() more descriptive

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderBinarySystemX.java
+++ b/src/com/amazon/ion/impl/IonReaderBinarySystemX.java
@@ -15,7 +15,6 @@
 
 package com.amazon.ion.impl;
 
-import com.amazon.ion.IonSystem;
 import static com.amazon.ion.IonType.SYMBOL;
 import static com.amazon.ion.SymbolTable.UNKNOWN_SYMBOL_ID;
 
@@ -296,14 +295,19 @@ class IonReaderBinarySystemX
         return _v.getDouble();
     }
 
-    public int intValue()
+    private void checkIsIntApplicableType()
     {
         if (_value_type != IonType.INT &&
-            _value_type != IonType.DECIMAL &&
-            _value_type != IonType.FLOAT)
+          _value_type != IonType.DECIMAL &&
+          _value_type != IonType.FLOAT)
         {
-            throw new IllegalStateException();
+          throw new IllegalStateException("Unexpected value type: " + _value_type);
         }
+    }
+
+    public int intValue()
+    {
+        checkIsIntApplicableType();
 
         prepare_value(AS_TYPE.int_value);
         return _v.getInt();
@@ -311,12 +315,7 @@ class IonReaderBinarySystemX
 
     public long longValue()
     {
-        if (_value_type != IonType.INT &&
-            _value_type != IonType.DECIMAL &&
-            _value_type != IonType.FLOAT)
-        {
-            throw new IllegalStateException();
-        }
+        checkIsIntApplicableType();
 
         prepare_value(AS_TYPE.long_value);
         return _v.getLong();
@@ -324,12 +323,7 @@ class IonReaderBinarySystemX
 
     public BigInteger bigIntegerValue()
     {
-        if (_value_type != IonType.INT &&
-            _value_type != IonType.DECIMAL &&
-            _value_type != IonType.FLOAT)
-        {
-            throw new IllegalStateException();
-        }
+        checkIsIntApplicableType();
 
         if (_value_is_null) {
             return null;
@@ -386,7 +380,7 @@ class IonReaderBinarySystemX
 
     public String stringValue()
     {
-        if (! IonType.isText(_value_type)) throw new IllegalStateException();
+        if (! IonType.isText(_value_type)) throw new IllegalStateException("Unexpected value type: " + _value_type);
         if (_value_is_null) return null;
 
         if (_value_type == SYMBOL) {
@@ -407,7 +401,7 @@ class IonReaderBinarySystemX
 
     public SymbolToken symbolValue()
     {
-        if (_value_type != SYMBOL) throw new IllegalStateException();
+        if (_value_type != SYMBOL) throw new IllegalStateException("Unexpected value type: " + _value_type);
         if (_value_is_null) return null;
 
         int sid = getSymbolId();
@@ -419,7 +413,7 @@ class IonReaderBinarySystemX
 
     int getSymbolId()
     {
-        if (_value_type != SYMBOL) throw new IllegalStateException();
+        if (_value_type != SYMBOL) throw new IllegalStateException("Unexpected value type: " + _value_type);
         if (_value_is_null) throw new NullValueException();
 
         prepare_value(AS_TYPE.int_value);

--- a/src/com/amazon/ion/impl/IonReaderTextRawX.java
+++ b/src/com/amazon/ion/impl/IonReaderTextRawX.java
@@ -1338,7 +1338,7 @@ if (depth == debugging_depth) {
         case SEXP:
             break;
         default:
-            throw new IllegalStateException();
+            throw new IllegalStateException("Unexpected value type: " + _value_type);
         }
 
         int new_state = get_state_at_container_start(_value_type);
@@ -1382,7 +1382,7 @@ if (depth == debugging_depth) {
             case DATAGRAM:
                 break;
             default:
-                throw new IllegalStateException();
+                throw new IllegalStateException("Unexpected value type: " + _value_type);
             }
         }
         catch (IOException e) {

--- a/src/com/amazon/ion/impl/IonReaderTextSystemX.java
+++ b/src/com/amazon/ion/impl/IonReaderTextSystemX.java
@@ -512,14 +512,19 @@ class IonReaderTextSystemX
         return _v.getDouble();
     }
 
-    public int intValue()
+    private void checkIsIntApplicableType()
     {
         if (_value_type != IonType.INT &&
-            _value_type != IonType.DECIMAL &&
-            _value_type != IonType.FLOAT)
+          _value_type != IonType.DECIMAL &&
+          _value_type != IonType.FLOAT)
         {
-            throw new IllegalStateException();
+          throw new IllegalStateException("Unexpected value type: " + _value_type);
         }
+    }
+
+    public int intValue()
+    {
+        checkIsIntApplicableType();
 
         load_or_cast_cached_value(AS_TYPE.int_value);
         return _v.getInt();
@@ -527,12 +532,7 @@ class IonReaderTextSystemX
 
     public long longValue()
     {
-        if (_value_type != IonType.INT &&
-            _value_type != IonType.DECIMAL &&
-            _value_type != IonType.FLOAT)
-        {
-            throw new IllegalStateException();
-        }
+        checkIsIntApplicableType();
 
         load_or_cast_cached_value(AS_TYPE.long_value);
         return _v.getLong();
@@ -541,12 +541,7 @@ class IonReaderTextSystemX
     @Override
     public BigInteger bigIntegerValue()
     {
-        if (_value_type != IonType.INT &&
-            _value_type != IonType.DECIMAL &&
-            _value_type != IonType.FLOAT)
-        {
-            throw new IllegalStateException();
-        }
+        checkIsIntApplicableType();
 
         load_or_cast_cached_value(AS_TYPE.bigInteger_value);
         if (_v.isNull()) return null;
@@ -583,7 +578,7 @@ class IonReaderTextSystemX
 
     public final String stringValue()
     {
-        if (! IonType.isText(_value_type)) throw new IllegalStateException();
+        if (! IonType.isText(_value_type)) throw new IllegalStateException("Unexpected value type: " + _value_type);
         if (_v.isNull()) return null;
 
         load_or_cast_cached_value(AS_TYPE.string_value);
@@ -665,7 +660,7 @@ class IonReaderTextSystemX
 
     public SymbolToken symbolValue()
     {
-        if (_value_type != IonType.SYMBOL) throw new IllegalStateException();
+        if (_value_type != IonType.SYMBOL) throw new IllegalStateException("Unexpected value type: " + _value_type);
         if (_v.isNull()) return null;
 
         load_or_cast_cached_value(AS_TYPE.string_value);

--- a/src/com/amazon/ion/impl/_Private_IonWriterBase.java
+++ b/src/com/amazon/ion/impl/_Private_IonWriterBase.java
@@ -431,7 +431,7 @@ public abstract class _Private_IonWriterBase
                 if (_debug_on) System.out.print(")");
                 break;
             default:
-                throw new IllegalStateException();
+                throw new IllegalStateException("Unknown value type: " + type);
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I started to use Amazon ION and got first exceptions from users: 

```
Caused by: java.lang.IllegalStateException
	at com.amazon.ion.impl.IonReaderBinarySystemX.stringValue(IonReaderBinarySystemX.java:389)
```

From this error message (empty) not clear what was the current value type. Indeed, application itself can report more descriptive error message (because context aware), but still it is better if ION will throw `IllegalStateException` with some message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
