### PR TITLE
Fixes manifest main class and CLI -- options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
               com.amazon.ion.*,
             </Export-Package>
             <!-- This can be used to retrieve the compiled JarInfo. -->
-            <Main-Class>com.amazon.ion.impl.PrivateCommandLine</Main-Class>
+            <Main-Class>com.amazon.ion.impl._Private_CommandLine</Main-Class>
             <!-- Add these properties to the manifest so they may be retrieved at runtime. -->
             <Ion-Java-Build-Time>${build.time}</Ion-Java-Build-Time>
             <Ion-Java-Project-Version>${project.version}</Ion-Java-Project-Version>

--- a/src/com/amazon/ion/impl/_Private_CommandLine.java
+++ b/src/com/amazon/ion/impl/_Private_CommandLine.java
@@ -91,10 +91,10 @@ public final class _Private_CommandLine
             }
         }
         if (arg.startsWith("--") && arg.length() > 2) {
-            if (arg.equals("help")) {
+            if (arg.equals("--help")) {
                 return argid_HELP;
             }
-            if (arg.equals("version")) {
+            if (arg.equals("--version")) {
                 return argid_VERSION;
             }
         }


### PR DESCRIPTION
resolves #240

Tested manually since the CLI is not testable without refactoring 
 
```
$ java -jar target/ion-java-1.5.0-SNAPSHOT.jar --version
Fixes manifest main class and CLI -- options

{
  version:"1.5.0-SNAPSHOT",
  build_time:2019-05-16T10:17:43-07:00
}

~/workplace/ion-java cli_fix-240*
$ java -jar target/ion-java-1.5.0-SNAPSHOT.jar --help
ion-java -- Copyright (c) 2007-2019 Amazon.com
usage: java -jar <jar> <options>
options:
version		prints current version entry
help		prints this helpful message

~/workplace/ion-java cli_fix-240*
$ java -jar target/ion-java-1.5.0-SNAPSHOT.jar -v

{
  version:"1.5.0-SNAPSHOT",
  build_time:2019-05-16T10:17:43-07:00
}

~/workplace/ion-java cli_fix-240*
$ java -jar target/ion-java-1.5.0-SNAPSHOT.jar -h
ion-java -- Copyright (c) 2007-2019 Amazon.com
usage: java -jar <jar> <options>
options:
version		prints current version entry
help		prints this helpful message

~/workplace/ion-java cli_fix-240*
$ java -jar target/ion-java-1.5.0-SNAPSHOT.jar
ion-java -- Copyright (c) 2007-2019 Amazon.com
usage: java -jar <jar> <options>
options:
version		prints current version entry
help		prints this helpful message

~/workplace/ion-java cli_fix-240*
$ java -jar target/ion-java-1.5.0-SNAPSHOT.jar -i
ion-java -- Copyright (c) 2007-2019 Amazon.com
usage: java -jar <jar> <options>
options:
version		prints current version entry
help		prints this helpful message

null
arg[0] "-i" is unrecognized or invalid.

~/workplace/ion-java cli_fix-240*
$ java -jar target/ion-java-1.5.0-SNAPSHOT.jar --invalid
ion-java -- Copyright (c) 2007-2019 Amazon.com
usage: java -jar <jar> <options>
options:
version		prints current version entry
help		prints this helpful message

null
arg[0] "--invalid" is unrecognized or invalid.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
