### PR TITLE
Removes @Override annotation not allowed by old JDK versions.

### DIFF
--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -597,7 +597,6 @@ import java.util.NoSuchElementException;
         this.containers        = new RecyclingStack<ContainerInfo>(
             10,
             new RecyclingStack.ElementFactory<ContainerInfo>() {
-                @Override
                 public ContainerInfo newElement() {
                     return new ContainerInfo();
                 }


### PR DESCRIPTION
*Description of changes:*

JDK 5 won't compile `@Override` annotations on methods that implement an interface.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
