### PR TITLE
Add IonSystem#singleValue(byte[], int, int)

### DIFF
--- a/src/com/amazon/ion/IonSystem.java
+++ b/src/com/amazon/ion/IonSystem.java
@@ -373,6 +373,27 @@ public interface IonSystem
      */
     public IonValue singleValue(byte[] ionData);
 
+    /**
+     * Extracts a single value from Ion text or binary data.
+     * <p>
+     * This method will auto-detect and uncompress GZIPped Ion data.
+     *
+     * @param ionData is used only within the range of bytes starting at
+     * {@code offset} for {@code len} bytes.
+     * The data in that range may be either Ion binary data, or UTF-8 Ion text.
+     * @param offset must be non-negative and less than {@code ionData.length}.
+     * @param len must be non-negative and {@code offset+len} must not exceed
+     *
+     * @return the first (and only) user value in the data; not null.
+     *
+     * @throws NullPointerException if {@code ionData} is null.
+     * @throws UnexpectedEofException if the data doesn't contain any user
+     * values.
+     * @throws IonException if the data does not contain exactly one user
+     * value.
+     */
+    public IonValue singleValue(byte[] ionData, int offset, int len);
+
 
     //-------------------------------------------------------------------------
     // IonReader creation

--- a/src/com/amazon/ion/impl/lite/IonSystemLite.java
+++ b/src/com/amazon/ion/impl/lite/IonSystemLite.java
@@ -523,7 +523,12 @@ final class IonSystemLite
 
     public IonValue singleValue(byte[] ionData)
     {
-        IonReader reader = newReader(ionData);
+        return singleValue(ionData, 0, ionData.length);
+    }
+
+    @Override
+    public IonValue singleValue(byte[] ionData, int offset, int len) {
+        IonReader reader = newReader(ionData, offset, len);
         try {
             Iterator<IonValue> it = iterate(reader);
             return singleValue(it);


### PR DESCRIPTION
When ion object resides in the middle of bytearray, this helper
method would help to extract it without memory copy overhead.

Issue #256

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
