### PR TITLE
Manually specify the trusty distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: java
+dist: trusty
 jdk:
   - openjdk8
   - openjdk9


### PR DESCRIPTION
[Travis CI changed the default distro from trusty to xenial](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) back in April.  They also [disabled OracleJDK8 in xenial](https://github.com/travis-ci/travis-ci/issues/10290).  This breaks the build for us since OracleJDK8 is in our build matrix.

This change manually specifies `trusty` as our preferred distribution and seems to make the build succeed reliably.