### PR TITLE
Optimizations for reading binary strings.

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderBinaryRawX.java
+++ b/src/com/amazon/ion/impl/IonReaderBinaryRawX.java
@@ -1206,7 +1206,7 @@ abstract class IonReaderBinaryRawX
     {
         // If the string we're reading is small enough to fit in our reusable buffer, we can avoid the overhead
         // of looping and bounds checking.
-        if (numberOfBytes < utf8InputBuffer.array().length) {
+        if (numberOfBytes <= utf8InputBuffer.capacity()) {
             return readStringWithReusableBuffer(numberOfBytes);
         }
 
@@ -1296,7 +1296,7 @@ abstract class IonReaderBinaryRawX
         utf8CharsetDecoder.reset();
         CoderResult coderResult = utf8CharsetDecoder.decode(utf8InputBuffer, utf8DecodingBuffer, true);
         if (coderResult.isError()) {
-            throw new IonException("Illegal value encountered while validating UTF-8 data in input stream.");
+            throw new IonException("Illegal value encountered while validating UTF-8 data in input stream. " + coderResult.toString());
         }
         utf8DecodingBuffer.flip();
         return utf8DecodingBuffer.toString();

--- a/test/com/amazon/ion/impl/IonReaderBinaryRawStringTest.java
+++ b/test/com/amazon/ion/impl/IonReaderBinaryRawStringTest.java
@@ -1,0 +1,97 @@
+package com.amazon.ion.impl;
+
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.Timestamp;
+import com.amazon.ion.system.IonBinaryWriterBuilder;
+import com.amazon.ion.system.IonReaderBuilder;
+import com.amazon.ion.util.RepeatInputStream;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.math.BigDecimal;
+
+import static com.amazon.ion.impl._Private_IonConstants.BINARY_VERSION_MARKER_1_0;
+import static org.junit.Assert.assertEquals;
+
+public class IonReaderBinaryRawStringTest {
+
+    @Test
+    public void testReadShortStrings() throws Exception {
+        // This test constructs some strings with non-ascii text that are short enough to fit in
+        // IonBinaryReaderRawX's reusable decoding buffers and then round-trips them.
+
+        String adage = "Brevity is the soul of wit. \uD83D\uDE02"; // Laughing face with tears
+        String observation = "What's the deal with airline food? \u2708\uFE0F\uD83C\uDF7D️"; // Airplane/fork+knife+plate
+        String litotes = "Not bad. \uD83D\uDC4D"; // Thumbs up
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonWriter writer = IonBinaryWriterBuilder.standard().build(out);
+
+        writer.writeString(adage);
+        writer.writeString(observation);
+        writer.writeString(litotes);
+        writer.close();
+
+        byte[] data = out.toByteArray();
+
+        IonReader reader = IonReaderBuilder.standard().build(data);
+        reader.next();
+        assertEquals(adage, reader.stringValue());
+        reader.next();
+        assertEquals(observation, reader.stringValue());
+        reader.next();
+        assertEquals(litotes, reader.stringValue());
+    }
+
+    @Test
+    public void testReadLargeStrings() throws Exception {
+        // This test constructs some strings with non-ascii text that are large enough to exceed the size
+        // of IonBinaryReaderRawX's reusable decoding buffers and then round-trips them.
+
+        String verse = "\uD83C\uDFB6 This is the song that never ends\n" // Musical notes emoji
+                + "\uD83C\uDFB5 Yes it goes on and on, my friends!\n"
+                + "\uD83C\uDFB6 Some people started singing it not knowing what it was\n"
+                + "\uD83C\uDFB5 And they'll continue singing it forever just because...\n";
+
+        final int numberOfVerses = 1024;
+
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < numberOfVerses; i++) {
+            stringBuilder.append(verse);
+        }
+        String longSong = stringBuilder.toString();
+
+        for (int i = 0; i < numberOfVerses; i++) {
+            stringBuilder.append(verse);
+        }
+        String longerSong = stringBuilder.toString();
+
+        for (int i = 0; i < numberOfVerses; i++) {
+            stringBuilder.append(verse);
+        }
+        String longestSong = stringBuilder.toString();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IonWriter writer = IonBinaryWriterBuilder.standard().build(out);
+
+        writer.writeString(longSong);
+        writer.writeString(longerSong);
+        writer.writeString(longestSong);
+        writer.close();
+
+        byte[] songData = out.toByteArray();
+
+        IonReader reader = IonReaderBuilder.standard().build(songData);
+        reader.next();
+        assertEquals(longSong, reader.stringValue());
+        reader.next();
+        assertEquals(longerSong, reader.stringValue());
+        reader.next();
+        assertEquals(longestSong, reader.stringValue());
+    }
+}


### PR DESCRIPTION
## Description of changes

This PR optimizes the process by which the binary `IonReader` reads `string`s.

### Performance change summary

#### Reading small strings
When decoding strings that are small enough to fit in the reusable decoding buffer:

&nbsp; | Time Required | GC Time
| ----------- | :--------------: | :---------: |
| Before | 615.351 ± 34.344 ms/op | 273ms | 
| After | 380.573 ± 11.136   ms/op | 185ms | 
| &nbsp; | 38.15% faster | 32.23% lower |

#### Reading big strings

&nbsp; | Time Required | GC Time
| ----------- | :--------------: | :---------: |
| Before | 867.368 ± 21.804 ms/op | 82ms | 
| After | 466.461 ± 21.796 ms/op | 54ms | 
| &nbsp; | 46.22% faster | 34.15% lower |

### Details

In order to read a `string` of length `n`, the old version of `IonBinaryReaderRawX#readString` will:
* Allocate and zero out a `char[]` of length `n` to store decoded `char`s.
* Read each byte from the data source individually, requiring `n` calls to `read()` and `n` end-of-file checks.
* Use our hand-written utf-8 decoder to turn the bytes being read into `char`s and eventually a `String`.

The new version created by this PR will:
* Use a reusable `CharBuffer` to store decoded `char`s if the `string` being read is small enough.
* Read the `string` into a reusable buffer in pages of up to 4096 bytes, requiring `n/4096` calls to `read(buffer)` and `n/4096` end-of-file checks. For most strings, only a single read+check will be required.
* Use Java's standard `CharsetDecoder` class to perform utf-8 decoding.

### Benchmarks \[[source](https://gist.github.com/zslayton/dedabd7078c3a7e4ab96cfb55b36f594)\]

#### Small Strings

This test creates 2.5 million strings that are **small enough to fit in the reader's reusable decoding buffer** and writes them to a `byte []` as binary Ion. The timed portion of the benchmark reads each string in the stream.

**before**
```
Benchmark                                Mode  Cnt          Score          Error   Units
read                                       ss   20        615.351 ±       34.344   ms/op
read:Heap usage                            ss   20        889.843 ±       20.990      MB
read:·gc.churn.{PS Eden Space}             ss   20        867.668 ±       55.462  MB/sec
read:·gc.churn.{PS Eden Space}.norm        ss   20  909816332.578 ± 58156173.178    B/op
read:·gc.churn.{PS Old Gen}                ss   20            ≈ 0                 MB/sec
read:·gc.churn.{PS Old Gen}.norm           ss   20            ≈ 0                   B/op
read:·gc.churn.{PS Survivor Space}         ss   20          0.028 ±        0.023  MB/sec
read:·gc.churn.{PS Survivor Space}.norm    ss   20      29597.107 ±    23865.736    B/op
read:·gc.count                             ss   20         60.000                 counts
read:·gc.time                              ss   20        273.000                     ms
```

**after**
```
Benchmark                                Mode  Cnt          Score          Error   Units
read                                       ss   20        380.573 ±       11.136   ms/op
read:Heap usage                            ss   20        863.260 ±        9.357      MB
read:·gc.churn.{PS Eden Space}             ss   20        684.124 ±       35.296  MB/sec
read:·gc.churn.{PS Eden Space}.norm        ss   20  717356058.885 ± 37010139.278    B/op
read:·gc.churn.{PS Old Gen}                ss   20            ≈ 0                 MB/sec
read:·gc.churn.{PS Old Gen}.norm           ss   20            ≈ 0                   B/op
read:·gc.churn.{PS Survivor Space}         ss   20          0.008 ±        0.022  MB/sec
read:·gc.churn.{PS Survivor Space}.norm    ss   20       8749.936 ±    23386.456    B/op
read:·gc.count                             ss   20         40.000                 counts
read:·gc.time                              ss   20        185.000                     ms
```

#### Big Strings


This test creates 20,000 strings that are **too big to fit in the reader's reusable decoding buffer** and writes them to a `byte []` as binary Ion. The timed portion of the benchmark reads each string in the stream.

**before**
```
Benchmark                                Mode  Cnt          Score          Error   Units
read                                       ss   20        867.368 ±       21.804   ms/op
read:Heap usage                            ss   20       1143.081 ±       11.483      MB
read:·gc.churn.{PS Eden Space}             ss   20        544.001 ±       16.853  MB/sec
read:·gc.churn.{PS Eden Space}.norm        ss   20  570426378.431 ± 17671260.123    B/op
read:·gc.churn.{PS Old Gen}                ss   20            ≈ 0                 MB/sec
read:·gc.churn.{PS Old Gen}.norm           ss   20            ≈ 0                   B/op
read:·gc.churn.{PS Survivor Space}         ss   20            ≈ 0                 MB/sec
read:·gc.churn.{PS Survivor Space}.norm    ss   20            ≈ 0                   B/op
read:·gc.count                             ss   20         20.000                 counts
read:·gc.time                              ss   20         82.000                     ms
```

**after**
```
Benchmark                                Mode  Cnt          Score           Error   Units
read                                       ss   20        466.461 ±        21.796   ms/op
read:Heap usage                            ss   20       1396.696 ±       217.578      MB
read:·gc.churn.{PS Eden Space}             ss   20        483.291 ±       432.141  MB/sec
read:·gc.churn.{PS Eden Space}.norm        ss   20  506766941.853 ± 453132888.558    B/op
read:·gc.churn.{PS Old Gen}                ss   20            ≈ 0                  MB/sec
read:·gc.churn.{PS Old Gen}.norm           ss   20            ≈ 0                    B/op
read:·gc.churn.{PS Survivor Space}         ss   20            ≈ 0                  MB/sec
read:·gc.churn.{PS Survivor Space}.norm    ss   20            ≈ 0                    B/op
read:·gc.count                             ss   20         10.000                  counts
read:·gc.time                              ss   20         54.000                      ms
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
