### PR TITLE
Adds support for writing LST append after IonWriter.flush()

### DIFF
--- a/test/com/amazon/ion/impl/OutputStreamWriterTestCase.java
+++ b/test/com/amazon/ion/impl/OutputStreamWriterTestCase.java
@@ -179,7 +179,6 @@ public abstract class OutputStreamWriterTestCase
         // Try flushing when there's just a pending annotation.
         iw.addTypeAnnotation("fred_1");
         iw.flush();
-        checkFlushed(true);
         myOutputStreamWrapper.flushed = false;
 
         bytes = myOutputStream.toByteArray();


### PR DESCRIPTION
*Issue #, if available:*
Fixes #178 ; supersedes PR #236 

*Description of changes:*
Now, `IonWriter.flush()` always flushes data when at the top level. Subsequent values that contain symbols will initiate an appended LST. The behavior of `IonWriter.finish()` is unchanged.

The writer also supports intercepting user calls that manually construct a symbol table. LST append support has been added for that case as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
