### PR TITLE
Fixes a bug that could cause an infinite loop when an IonValue was modified while being read with the tree reader.

### DIFF
--- a/src/com/amazon/ion/IonSystem.java
+++ b/src/com/amazon/ion/IonSystem.java
@@ -485,6 +485,10 @@ public interface IonSystem
      * model. Typically this is used to iterate over a collection, such as an
      * {@link IonStruct}.
      *
+     * The given value and its children, if any, must not be modified until after
+     * the IonReader constructed by this method is closed. Violating this
+     * constraint results in undefined behavior.
+     *
      * @param value must not be null.
      */
     public IonReader newReader(IonValue value);

--- a/src/com/amazon/ion/impl/IonReaderTreeSystem.java
+++ b/src/com/amazon/ion/impl/IonReaderTreeSystem.java
@@ -497,6 +497,7 @@ class IonReaderTreeSystem
                         _next_idx = ii+1;
                         break;
                     }
+                    ii++;
                 }
             }
             // if there anything left?

--- a/src/com/amazon/ion/system/IonReaderBuilder.java
+++ b/src/com/amazon/ion/system/IonReaderBuilder.java
@@ -253,6 +253,10 @@ public class IonReaderBuilder
      * {@link IonReader} instance over an {@link IonValue} data model. Typically
      * this is used to iterate over a collection, such as an {@link IonStruct}.
      *
+     * The given value and its children, if any, must not be modified until after
+     * the IonReader constructed by this method is closed. Violating this
+     * constraint results in undefined behavior.
+     *
      * @param value must not be null.
      *
      * @see IonSystem#newReader(IonValue)

--- a/test/com/amazon/ion/impl/TreeReaderTest.java
+++ b/test/com/amazon/ion/impl/TreeReaderTest.java
@@ -92,4 +92,21 @@ public class TreeReaderTest
         check().next().fieldName((String)null).type(IonType.NULL);
         assertTopLevel(in, /* inStruct */ false);
     }
+
+    @Test
+    public void testModificationDuringRead()
+    {
+        IonList list = system().newEmptyList();
+        list.add().newString("abc");
+        list.add().newString("def");
+        in = system().newReader(list);
+        assertEquals(IonType.LIST, in.next());
+        in.stepIn();
+        assertEquals(IonType.STRING, in.next());
+        // Violate the contract by modifying the value.
+        list.remove(0);
+        // Since the value was modified while it was being written, the result of the following is undefined. But
+        // one thing is for sure: it should not cause an infinite loop.
+        in.next();
+    }
 }


### PR DESCRIPTION
*Description of changes:*
Caused by failure to update the loop condition.

Also added a note to the tree reader construction methods to state that behavior is undefined if the value is modified concurrently. The tree reader implementation is not designed to support this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
