### PR TITLE
Sets LocalSymbolTable's initial map size to avoid guaranteed resizing within the constructor.

### DIFF
--- a/src/com/amazon/ion/impl/LocalSymbolTable.java
+++ b/src/com/amazon/ion/impl/LocalSymbolTable.java
@@ -168,7 +168,10 @@ class LocalSymbolTable
         myFirstLocalSid = myImportsList.getMaxId() + 1;
 
         // Copy locally declared symbols to mySymbolsMap
-        mySymbolsMap = new HashMap<String, Integer>();
+        // The initial size is chosen so that resizing is avoided. The default load factor is 0.75. Resizing
+        // could also be avoided by setting the initial size to mySymbolsCount and setting the load factor to
+        // 1.0, but this would lead to more hash collisions.
+        mySymbolsMap = new HashMap<String, Integer>((int) Math.ceil(mySymbolsCount / 0.75));
         buildSymbolsMap();
     }
 


### PR DESCRIPTION
*Description of changes:*
Before this change, invocations of this LST constructor that provided more than 12 symbols were guaranteed to require at least one HashMap resize before the constructor returns. After this change, no HashMap resizes will occur before the constructor returns.

For a large sample of binary Ion containing lots of symbols, this improved read performance by about 10%.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
