### PR TITLE
Improves read performance of streams that use LST append with a large number of symbols.

### DIFF
--- a/src/com/amazon/ion/impl/LocalSymbolTable.java
+++ b/src/com/amazon/ion/impl/LocalSymbolTable.java
@@ -64,11 +64,16 @@ class LocalSymbolTable
                                           boolean alreadyInStruct)
         {
             List<String> symbolsList = new ArrayList<String>();
+            SymbolTable currentSymbolTable = reader.getSymbolTable();
             LocalSymbolTableImports imports = readLocalSymbolTable(reader,
                                                                    catalog,
                                                                    alreadyInStruct,
                                                                    symbolsList,
-                                                                   reader.getSymbolTable());
+                                                                   currentSymbolTable);
+            if (imports == null) {
+                // This was an LST append, so the existing symbol table was updated.
+                return currentSymbolTable;
+            }
             return new LocalSymbolTable(imports, symbolsList);
         }
 
@@ -201,11 +206,21 @@ class LocalSymbolTable
         }
     }
 
+    /**
+     * Parses the symbol table at the reader's current position.
+     * @param reader the reader from which to parse the symbol table.
+     * @param catalog the catalog from which to resolve shared symbol table imports.
+     * @param isOnStruct true if the reader is already positioned on the symbol table struct; otherwise, false.
+     * @param symbolsListOut list into which local symbols declared by the parsed symbol table will be deposited.
+     * @param currentSymbolTable the symbol table currently active in the stream.
+     * @return a new LocalSymbolTableImports instance, or null if this was an LST append. If null, `currentSymbolTable`
+     *   continues to be the active symbol table.
+     */
     protected static LocalSymbolTableImports readLocalSymbolTable(IonReader reader,
                                                                   IonCatalog catalog,
                                                                   boolean isOnStruct,
                                                                   List<String> symbolsListOut,
-                                                                  SymbolTable symbolTable)
+                                                                  SymbolTable currentSymbolTable)
     {
         if (! isOnStruct)
         {
@@ -223,14 +238,11 @@ class LocalSymbolTable
 
         List<SymbolTable> importsList = new ArrayList<SymbolTable>();
         importsList.add(reader.getSymbolTable().getSystemSymbolTable());
-        // Isolate the newly-declared symbols because they must be added after any symbols declared
-        // by the previous symbol table if this is an appending local symbol table, but the 'imports' and
-        // 'symbols' declarations can occur in any order.
-        List<String> newSymbols = new ArrayList<String>();
 
         IonType fieldType;
         boolean foundImportList = false;
         boolean foundLocalSymbolList = false;
+        boolean isAppend = false;
         while ((fieldType = reader.next()) != null)
         {
             if (reader.isNullValue()) continue;
@@ -275,7 +287,7 @@ class LocalSymbolTable
                                 text = null;
                             }
 
-                            newSymbols.add(text);
+                            symbolsListOut.add(text);
                         }
                         reader.stepOut();
                     }
@@ -291,18 +303,9 @@ class LocalSymbolTable
                     {
                         prepImportsList(importsList, reader, catalog);
                     }
-                    else if (fieldType == IonType.SYMBOL)
+                    else if (fieldType == IonType.SYMBOL && ION_SYMBOL_TABLE.equals(reader.stringValue()))
                     {
-                        // trying to import the current table
-                        if(symbolTable.isLocalTable() && ION_SYMBOL_TABLE.equals(reader.stringValue()))
-                        {
-                            SymbolTable currentSymbolTable = reader.getSymbolTable();
-                            importsList.addAll(Arrays.asList(currentSymbolTable.getImportedTables()));
-                            Iterator<String> currentSymbols = currentSymbolTable.iterateDeclaredSymbolNames();
-                            while (currentSymbols.hasNext()) {
-                                symbolsListOut.add(currentSymbols.next());
-                            }
-                        }
+                        isAppend = true;
                     }
                     break;
                 }
@@ -313,9 +316,16 @@ class LocalSymbolTable
                 }
             }
         }
-
         reader.stepOut();
-        symbolsListOut.addAll(newSymbols);
+        if (isAppend && currentSymbolTable.isLocalTable()) {
+            // Because the current symbol table is a local symbol table (i.e. not the system symbol table), it can
+            // be appended in-place.
+            LocalSymbolTable currentLocalSymbolTable = (LocalSymbolTable) currentSymbolTable;
+            for (String newSymbol : symbolsListOut) {
+                currentLocalSymbolTable.putSymbol(newSymbol);
+            }
+            return null;
+        }
         return new LocalSymbolTableImports(importsList);
     }
 

--- a/src/com/amazon/ion/impl/LocalSymbolTableAsStruct.java
+++ b/src/com/amazon/ion/impl/LocalSymbolTableAsStruct.java
@@ -62,11 +62,16 @@ class LocalSymbolTableAsStruct
                                           boolean alreadyInStruct)
         {
             List<String> symbolsList = new ArrayList<String>();
+            SymbolTable currentSymbolTable = reader.getSymbolTable();
             LocalSymbolTableImports imports = readLocalSymbolTable(reader,
                                                                    catalog,
                                                                    alreadyInStruct,
                                                                    symbolsList,
-                                                                   reader.getSymbolTable());
+                                                                   currentSymbolTable);
+            if (imports == null) {
+                // This was an LST append, so the existing symbol table was updated.
+                return currentSymbolTable;
+            }
             return new LocalSymbolTableAsStruct(imageFactory, imports, symbolsList);
         }
 

--- a/test/com/amazon/ion/impl/IonWriterTestCase.java
+++ b/test/com/amazon/ion/impl/IonWriterTestCase.java
@@ -824,23 +824,9 @@ public abstract class IonWriterTestCase
         iw.close();
 
         IonDatagram dg = reload();
-        if (myOutputForm == OutputForm.BINARY && iw instanceof _Private_IonManagedWriter && myLstAppendEnabled) {
-            // Note: LST append will only be implemented in the "new" binary writer (which implements
-            // _Private_IonMangedWriter)
-            // Should have:  IVM SYMTAB hey SYMTAB_APPEND now
-            assertEquals(5, dg.systemSize());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(1)).getTypeAnnotations()[0]);
-            assertEquals("hey", ((IonSymbol) dg.systemGet(2)).stringValue());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(3)).getTypeAnnotations()[0]);
-            assertEquals("now", ((IonSymbol) dg.systemGet(4)).stringValue());
-        }
-        else {
-            // Should have:  IVM SYMTAB hey SYMTAB_APPEND now
-            assertEquals(4, dg.systemSize());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(1)).getTypeAnnotations()[0]);
-            assertEquals("hey", ((IonSymbol) dg.systemGet(2)).stringValue());
-            assertEquals("now", ((IonSymbol) dg.systemGet(3)).stringValue());
-        }
+        assertEquals(2, dg.size());
+        assertEquals("hey", ((IonSymbol) dg.get(0)).stringValue());
+        assertEquals("now", ((IonSymbol) dg.get(1)).stringValue());
     }
 
     Iterator<IonValue> systemIterateOutput()

--- a/test/com/amazon/ion/impl/bin/IonManagedBinaryWriterTest.java
+++ b/test/com/amazon/ion/impl/bin/IonManagedBinaryWriterTest.java
@@ -224,23 +224,9 @@ public class IonManagedBinaryWriterTest extends IonRawBinaryWriterTest
         assertNull(reader.next());
 
         IonDatagram dg = system().getLoader().load(writer.getBytes());
-        if (lstAppendMode.isEnabled())
-        {
-            // Should be IVM SYMTAB taco SYMTAB burrito
-            assertEquals(5, dg.systemSize());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(1)).getTypeAnnotations()[0]);
-            assertEquals("taco", ((IonSymbol) dg.systemGet(2)).stringValue());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(3)).getTypeAnnotations()[0]);
-            assertEquals("burrito", ((IonSymbol) dg.systemGet(4)).stringValue());
-        }
-        else
-        {
-            // Should be IVM SYMTAB taco burrito
-            assertEquals(4, dg.systemSize());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(1)).getTypeAnnotations()[0]);
-            assertEquals("taco", ((IonSymbol) dg.systemGet(2)).stringValue());
-            assertEquals("burrito", ((IonSymbol) dg.systemGet(3)).stringValue());
-        }
+        assertEquals(2, dg.size());
+        assertEquals("taco", ((IonSymbol) dg.get(0)).stringValue());
+        assertEquals("burrito", ((IonSymbol) dg.get(1)).stringValue());
     }
 
     @Test
@@ -304,23 +290,9 @@ public class IonManagedBinaryWriterTest extends IonRawBinaryWriterTest
         assertNull(reader.next());
 
         IonDatagram dg = system().getLoader().load(writer.getBytes());
-        if (lstAppendMode.isEnabled())
-        {
-            // Should be IVM SYMTAB taco SYMTAB burrito
-            assertEquals(5, dg.systemSize());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(1)).getTypeAnnotations()[0]);
-            assertEquals("taco", ((IonSymbol) dg.systemGet(2)).stringValue());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(3)).getTypeAnnotations()[0]);
-            assertEquals("burrito", ((IonSymbol) dg.systemGet(4)).stringValue());
-        }
-        else
-        {
-            // Should be IVM SYMTAB taco burrito
-            assertEquals(4, dg.systemSize());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(1)).getTypeAnnotations()[0]);
-            assertEquals("taco", ((IonSymbol) dg.systemGet(2)).stringValue());
-            assertEquals("burrito", ((IonSymbol) dg.systemGet(3)).stringValue());
-        }
+        assertEquals(2, dg.size());
+        assertEquals("taco", ((IonSymbol) dg.get(0)).stringValue());
+        assertEquals("burrito", ((IonSymbol) dg.get(1)).stringValue());
     }
 
     @Test
@@ -349,23 +321,9 @@ public class IonManagedBinaryWriterTest extends IonRawBinaryWriterTest
         assertNull(reader.next());
 
         IonDatagram dg = system().getLoader().load(writer.getBytes());
-        if (lstAppendMode.isEnabled())
-        {
-            // Should be IVM SYMTAB taco SYMTAB burrito
-            assertEquals(5, dg.systemSize());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(1)).getTypeAnnotations()[0]);
-            assertEquals("taco", ((IonSymbol) dg.systemGet(2)).stringValue());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(3)).getTypeAnnotations()[0]);
-            assertEquals("burrito", ((IonSymbol) dg.systemGet(4)).stringValue());
-        }
-        else
-        {
-            // Should be IVM SYMTAB taco burrito
-            assertEquals(4, dg.systemSize());
-            assertEquals("$ion_symbol_table", ((IonStruct) dg.systemGet(1)).getTypeAnnotations()[0]);
-            assertEquals("taco", ((IonSymbol) dg.systemGet(2)).stringValue());
-            assertEquals("burrito", ((IonSymbol) dg.systemGet(3)).stringValue());
-        }
+        assertEquals(2, dg.size());
+        assertEquals("taco", ((IonSymbol) dg.get(0)).stringValue());
+        assertEquals("burrito", ((IonSymbol) dg.get(1)).stringValue());
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*

Before this change, each LST append caused the reader to copy all of the symbols from its current LocalSymbolTable into a new LocalSymbolTable instance and throw the old one away before appending the new symbols. This is tremendously wasteful and becomes noticeable as the number of symbols in the stream increases.

To demonstrate this, I started with a 6.4GB stream of binary Ion containing 98,000 unique symbols and over 11,000 LST appends. I then re-wrote the stream with equivalent structure, but using only 49,000 unique symbols (i.e. after 49,000 unique symbols, the next unique symbol from the original stream was written with lowest local SID, the next unique symbol assigned the next-lowest SID, etc.). I did the same with 6,000 unique symbols (1/16 the original number of symbols). I then benchmarked a fully-materialized deep read of each stream before and after this change, with results summarized in the following chart.

![lst-perf](https://user-images.githubusercontent.com/7432835/91786772-347a5480-ebbd-11ea-8301-3679f0f947b6.jpg)

While the difference is almost not noticeable at only 6,000 symbols, at 49,000 symbols the change provides a 42.5% speedup and 45.7% reduction in heap usage. At 98,000 symbols, the benefit increases to a 55.7% speedup and 71.1% reduction in heap usage. After the change, there is no longer a significant slowdown caused by increasing the number of symbols in the stream.

This required a change in the assumptions made by a few unit tests. As previously described, before this change an LST append always resulted in the creation of a brand new LocalSymbolTable. This allowed tests to use the DOM to access all of the local symbol tables declared in the stream, even LST appends. After this change, appended LSTs are folded into the current symbol table, so the DOM does not maintain a record of every LST append boundary that occurred in the stream. This change does not affect the ability of the DOM to correctly represent streams that contained LST append, nor does it affect its ability to allow users to mutate an IonDatagram by adding new symbols to it.

NOTE: The codecov/project check failed for no apparent reason, while the Travis and codecov/patch checks succeeded. This happened on #304 too, which indicates to me that there is a problem with that check.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
