### PR TITLE
Revert "Adds a space after a fieldname's colon when pretty-printing (…

### DIFF
--- a/src/com/amazon/ion/impl/IonWriterSystemText.java
+++ b/src/com/amazon/ion/impl/IonWriterSystemText.java
@@ -366,9 +366,6 @@ class IonWriterSystemText
             SymbolToken sym = assumeFieldNameSymbol();
             writeFieldNameToken(sym);
             _output.appendAscii(':');
-            if (_options.isPrettyPrintOn()) {
-                _output.appendAscii(' ');
-            }
             clearFieldName();
             followingLongString = false;
         }

--- a/test/com/amazon/ion/impl/IonMarkupWriterTest.java
+++ b/test/com/amazon/ion/impl/IonMarkupWriterTest.java
@@ -54,7 +54,7 @@ public class IonMarkupWriterTest extends IonTestCase {
             "%n<beforeAnnotations STRUCT><beforeEachAnnotation STRUCT>abcd" +
             "<afterEachAnnotation STRUCT>::<afterAnnotations STRUCT><beforeData" +
             " STRUCT>{<afterStepIn STRUCT>%n  <beforeFieldName SEXP>hello" +
-            "<afterFieldName SEXP>: <beforeData SEXP>(<afterStepIn SEXP>%n    " +
+            "<afterFieldName SEXP>:<beforeData SEXP>(<afterStepIn SEXP>%n    " +
             "<beforeData SYMBOL>sexp<afterData SYMBOL><beforeSeparator SEXP>" +
             "%n    <afterSeparator SEXP><beforeData INT>1<afterData INT>" +
             "<beforeSeparator SEXP>%n    <afterSeparator SEXP><beforeData INT>2" +
@@ -62,12 +62,12 @@ public class IonMarkupWriterTest extends IonTestCase {
             "<beforeData STRING>\"str\"<afterData STRING><beforeStepOut SEXP>%n  " +
             ")<afterData SEXP><beforeSeparator STRUCT>,%n  " +
             "<afterSeparator STRUCT><beforeFieldName LIST>list<afterFieldName " +
-            "LIST>: <beforeData LIST>[<afterStepIn LIST>%n    <beforeData " +
+            "LIST>:<beforeData LIST>[<afterStepIn LIST>%n    <beforeData " +
             "DECIMAL>3.2<afterData DECIMAL><beforeSeparator LIST>,%n    " +
             "<afterSeparator LIST><beforeData FLOAT>3.2e0<afterData FLOAT>" +
             "<beforeStepOut LIST>%n  ]<afterData LIST><beforeSeparator STRUCT>" +
             ",%n  <afterSeparator STRUCT><beforeFieldName BLOB>blob" +
-            "<afterFieldName BLOB>: <beforeAnnotations BLOB>" +
+            "<afterFieldName BLOB>:<beforeAnnotations BLOB>" +
             "<beforeEachAnnotation BLOB>annot<afterEachAnnotation BLOB>::" +
             "<afterAnnotations BLOB><beforeData BLOB>" +
             "{{ T25lIEJpZyBGYXQgVGVzdCBCbG9iIEZvciBZb3VyIFBsZWFzdXJl }}" +

--- a/test/com/amazon/ion/impl/TextWriterTest.java
+++ b/test/com/amazon/ion/impl/TextWriterTest.java
@@ -287,14 +287,14 @@ public class TextWriterTest
                 "%n" +
                 "'''looong'''%n" +
                 "{%n" +
-                "  a: '''looong''',%n" +
-                "  b: \"hello\",%n" +
-                "  c: '''hello\n" +
+                        "  a:'''looong''',%n" +
+                "  b:\"hello\",%n" +
+                "  c:'''hello\n" +
                         "nurse''',%n" +
-                "  d: '''what\\'s\n" +
+                        "  d:'''what\\'s\n" +
                         "up\n" +
                         "doc'''%n" +
-                "}"
+                        "}"
             ),
             dg
         );


### PR DESCRIPTION
…#289)"

This reverts commit 5d62f9ab6ee912f2812071fcec9454bd17c3d134.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
