### PR TITLE
Bump JDK version requirement from 5 to 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
     <build.year>${maven.build.timestamp}</build.year>
-    <jdkVersion>1.6</jdkVersion>
+    <jdkVersion>1.8</jdkVersion>
   </properties>
 
   <dependencies>
@@ -272,7 +272,7 @@
     <profile>
       <id>release</id>
       <properties>
-        <jdkVersion>1.5</jdkVersion>
+        <jdkVersion>1.8</jdkVersion>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
*Description of changes:* `ion-java` currently uses JDK version 5. This PR modernizes it by requiring version 8, which is the oldest release that (by some definitions) is not well beyond EOL. It also configures Maven to use JDK version 8 instead of version 6.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
