### PR TITLE
Fixes bug #318 in the binary reader's implementation of IonReader.getBytes.

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderBinaryRawX.java
+++ b/src/com/amazon/ion/impl/IonReaderBinaryRawX.java
@@ -737,16 +737,12 @@ abstract class IonReaderBinaryRawX
         if (offset < 0 || len < 0) {
             throw new IllegalArgumentException();
         }
-        int value_len = byteSize(); // again validation
-        if (_value_lob_remaining > len) {
-            len = _value_lob_remaining;
-        }
         if (len < 1) {
             return 0;
         }
         int read_len;
         try {
-            read_len = read(buffer, offset, value_len);
+            read_len = read(buffer, offset, len);
             _value_lob_remaining -= read_len;
         }
         catch (IOException e) {

--- a/test/com/amazon/ion/streaming/ReaderTest.java
+++ b/test/com/amazon/ion/streaming/ReaderTest.java
@@ -372,6 +372,28 @@ public class ReaderTest
     }
 
     @Test
+    public void testReadLobUsingGetBytes() throws Exception
+    {
+        if (!myReaderMaker.sourceIsBinary()) {
+            // TODO text implements getBytes() differently: https://github.com/amzn/ion-java/issues/319
+            return;
+        }
+        String data = "{{\"abcdefghijklmnopqrstuvwxyz\"}}";
+        byte[] partialBuffer = new byte[10];
+        read(data);
+        assertEquals(IonType.CLOB, in.next());
+        int remaining = in.byteSize();
+        assertEquals(26, remaining);
+        StringBuilder value = new StringBuilder();
+        while (remaining > 0) {
+            int bytesRead = in.getBytes(partialBuffer, 0, partialBuffer.length);
+            remaining -= bytesRead;
+            value.append(new String(partialBuffer, 0, bytesRead, "UTF-8"));
+        }
+        assertEquals("abcdefghijklmnopqrstuvwxyz", value.toString());
+    }
+
+    @Test
     public void testGetSymbolTableBeforeFirstValue()
     {
         read("123");


### PR DESCRIPTION
*Issue #, if available:*
#318 

*Description of changes:*
Fixes incremental reads and adds a test. When I created #318 I didn't notice that the branch in `readBytes` is actually redundant due to these lines `getBytes` (where `byteSize()` returns `_value_lob_remaining`):

```java
        int value_len = byteSize(); // again validation
        if (value_len > len) {
            value_len = len;
        }
```

NOTE: the test is skipped for text readers due to #319.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
