### PR TITLE
Avoids repetitive reallocation of PooledBlockAllocatorProvider in _PrivateIon_HashTrampoline.

### DIFF
--- a/src/com/amazon/ion/impl/bin/_PrivateIon_HashTrampoline.java
+++ b/src/com/amazon/ion/impl/bin/_PrivateIon_HashTrampoline.java
@@ -28,10 +28,12 @@ import java.io.IOException;
 @Deprecated
 public class _PrivateIon_HashTrampoline
 {
+    private static final PooledBlockAllocatorProvider ALLOCATOR_PROVIDER = new PooledBlockAllocatorProvider();
+    
     public static IonWriter newIonWriter(ByteArrayOutputStream baos) throws IOException
     {
         return new IonRawBinaryWriter(
-                new PooledBlockAllocatorProvider(),
+                ALLOCATOR_PROVIDER,
                 _Private_IonManagedBinaryWriterBuilder.DEFAULT_BLOCK_SIZE,
                 baos,
                 AbstractIonWriter.WriteValueOptimization.NONE,


### PR DESCRIPTION
*Description of changes:*
This expensive to instantiate. Luckily, it's a thread-safe pool that can be treated as a singleton.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
