### PR TITLE
Integrate ion-test-driver into pipeline.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,5 +2,5 @@
 title: Ion-test-driver issue.
 labels: bug
 ---
-Ion-test-driver complained that behavior changed for the commit {{ sha }} created by `{{ payload.sender.login }}`.
+Ion-test-driver complained that behavior changed for the commit {{ env.GITHUB_PR_SHA }} created by `{{ payload.sender.login }}`.
 Refer to the [workflow]({{ env.GITHUB_WORKFLOW_URL }}) for more details. 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+---
+title: Ion-test-driver issue.
+labels: bug
+---
+Ion-test-driver complained that behavior changed for the commit {{ sha }} created by `{{ payload.sender.login }}`.
+Refer to the [workflow]({{ env.GITHUB_WORKFLOW_URL }}) for more details. 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run ion-test-driver
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -o output
-          -i ion-java,https://github.com/amzn/ion-java,${{ github.event.pull_request.head.sha }}
+          -i ion-java,${{ github.event.pull_request.head.repo.html_url }},${{ github.event.pull_request.head.sha }}
 
       - name: Upload result
         uses: actions/upload-artifact@v2
@@ -44,7 +44,7 @@ jobs:
         id: result-diff
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -R
           ion-java,https://github.com/amzn/ion-java,$sha
-          ion-java,https://github.com/amzn/ion-java,${{ github.event.pull_request.head.sha }}
+          ion-java,${{ github.event.pull_request.head.repo.html_url }},${{ github.event.pull_request.head.sha }}
           output/results/ion-test-driver-results.ion
 
       - name: Upload analysis report

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,16 +40,17 @@ jobs:
         if: ${{ steps.result-diff.outcome == 'failure' }}
         run: echo 'Implementation behavior changed, Refer to the analysis report in the previous step for the reason.' && exit 1
 
-   open-issue:
-     runs-on: ubuntu-latest
-     needs: ion-test-driver
-     if: ${{ failure() }}
-     steps:
-       - uses: actions/checkout@master
-       - uses: cheqianh/create-an-issue@e6b4b19
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           GITHUB_WORKFLOW_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-           GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha }}
-         with:
-           assignees: ${{ github.event.sender.login }}
+  open-issue:
+    runs-on: ubuntu-latest
+    needs: ion-test-driver
+    if: ${{ failure() }}
+    steps:
+      - uses: actions/checkout@master
+      - uses: cheqianh/create-an-issue@e6b4b19
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_WORKFLOW_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+          GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          assignees: ${{ github.event.sender.login }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,9 @@ jobs:
           name: ion-test-driver-result.ion
           path: output/results/ion-test-driver-results.ion
 
+      - name: showing result
+        run: cat output/results/ion-test-driver-results.ion
+
       - name: Analyze two implementations
         continue-on-error: true
         id: result-diff
@@ -53,6 +56,9 @@ jobs:
           name: analysis-report.ion
           path: result.ion
 
+      - name: showing report
+        run: cat result.ion
+
       - name: Check if ion-test-driver fails
         if: ${{ steps.result-diff.outcome == 'failure' }}
         run: echo 'Implementation behavior changed, Refer to the analysis report in the previous step for the reason.' && exit 1
@@ -64,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Open an issue
-        uses: cheqianh/create-an-issue@e6b4b19
+        uses: JasonEtco/create-an-issue@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_WORKFLOW_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on: [pull_request]
 jobs:
   ion-test-driver:
     runs-on: macos-10.15
-    outputs:
-      report: ${{ steps.step1.outputs.test }}
     steps:
       - name: Checkout ion-java
         uses: actions/checkout@master
@@ -65,7 +63,7 @@ jobs:
     if: ${{ failure() }}
     steps:
       - uses: actions/checkout@master
-      - name: open an issue
+      - name: Open an issue
         uses: cheqianh/create-an-issue@e6b4b19
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: ion-test-driver
 
-on: [pull_request, issues]
+on: [pull_request]
 
 jobs:
   ion-test-driver:
@@ -8,6 +8,16 @@ jobs:
     outputs:
       report: ${{ steps.step1.outputs.test }}
     steps:
+      - name: Checkout ion-java
+        uses: actions/checkout@master
+        with:
+          repository: amzn/ion-java
+          ref: master
+          path: ion-java
+
+      - name: Get main branch HEAD sha
+        run: cd ion-java && echo "sha=`git rev-parse --short HEAD`" >> $GITHUB_ENV
+
       - name: Checkout ion-test-driver
         uses: actions/checkout@master
         with:
@@ -25,27 +35,27 @@ jobs:
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -o output
           -i ion-java,https://github.com/amzn/ion-java,${{ github.event.pull_request.head.sha }}
 
-      - name: upload result
+      - name: Upload result
         uses: actions/upload-artifact@v2
         with:
           name: ion-test-driver-result.ion
           path: output/results/ion-test-driver-results.ion
 
-      - name: analyze two implementations
+      - name: Analyze two implementations
         continue-on-error: true
         id: result-diff
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -R
-          ion-java,https://github.com/amzn/ion-java,master
+          ion-java,https://github.com/amzn/ion-java,$sha
           ion-java,https://github.com/amzn/ion-java,${{ github.event.pull_request.head.sha }}
           output/results/ion-test-driver-results.ion
 
-      - name: upload analysis report
+      - name: Upload analysis report
         uses: actions/upload-artifact@v2
         with:
           name: analysis-report.ion
           path: result.ion
 
-      - name: Check
+      - name: Check if ion-test-driver fails
         if: ${{ steps.result-diff.outcome == 'failure' }}
         run: echo 'Implementation behavior changed, Refer to the analysis report in the previous step for the reason.' && exit 1
 
@@ -55,7 +65,8 @@ jobs:
     if: ${{ failure() }}
     steps:
       - uses: actions/checkout@master
-      - uses: cheqianh/create-an-issue@e6b4b19
+      - name: open an issue
+        uses: cheqianh/create-an-issue@e6b4b19
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_WORKFLOW_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,12 @@ jobs:
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -o output
           -i ion-java,https://github.com/amzn/ion-java,${{ github.event.pull_request.head.sha }}
 
+      - name: upload result
+        uses: actions/upload-artifact@v2
+        with:
+          name: ion-test-driver-result.ion
+          path: output/results/ion-test-driver-results.ion
+
       - name: analyze two implementations
         continue-on-error: true
         id: result-diff
@@ -33,8 +39,11 @@ jobs:
           ion-java,https://github.com/amzn/ion-java,${{ github.event.pull_request.head.sha }}
           output/results/ion-test-driver-results.ion
 
-      - name: analysis report
-        run: cat result.ion
+      - name: upload analysis report
+        uses: actions/upload-artifact@v2
+        with:
+          name: analysis-report.ion
+          path: result.ion
 
       - name: Check
         if: ${{ steps.result-diff.outcome == 'failure' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,14 +23,14 @@ jobs:
 
       - name: Run ion-test-driver
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -o output
-          -i ion-java,https://github.com/cheqianh/ion-java,${{ github.event.pull_request.head.sha }}
+          -i ion-java,https://github.com/amzn/ion-java,${{ github.event.pull_request.head.sha }}
 
       - name: analyze two implementations
         continue-on-error: true
         id: result-diff
         run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -R
           ion-java,https://github.com/amzn/ion-java,master
-          ion-java,https://github.com/cheqianh/ion-java,${{ github.event.pull_request.head.sha }}
+          ion-java,https://github.com/amzn/ion-java,${{ github.event.pull_request.head.sha }}
           output/results/ion-test-driver-results.ion
 
       - name: analysis report
@@ -40,16 +40,16 @@ jobs:
         if: ${{ steps.result-diff.outcome == 'failure' }}
         run: echo 'Implementation behavior changed, Refer to the analysis report in the previous step for the reason.' && exit 1
 
-#   open-issue:
-#     runs-on: ubuntu-latest
-#     needs: ion-test-driver
-#     if: ${{ failure() }}
-#     steps:
-#       - uses: actions/checkout@master
-#       - uses: cheqianh/create-an-issue@e6b4b19
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#           GITHUB_WORKFLOW_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-#           GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha }}
-#         with:
-#           assignees: ${{ github.event.sender.login }}
+   open-issue:
+     runs-on: ubuntu-latest
+     needs: ion-test-driver
+     if: ${{ failure() }}
+     steps:
+       - uses: actions/checkout@master
+       - uses: cheqianh/create-an-issue@e6b4b19
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           GITHUB_WORKFLOW_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+           GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha }}
+         with:
+           assignees: ${{ github.event.sender.login }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,55 @@
+name: ion-test-driver
+
+on: [pull_request, issues]
+
+jobs:
+  ion-test-driver:
+    runs-on: macos-10.15
+    outputs:
+      report: ${{ steps.step1.outputs.test }}
+    steps:
+      - name: Checkout ion-test-driver
+        uses: actions/checkout@master
+        with:
+          repository: amzn/ion-test-driver
+          ref: master
+          path: ion-test-driver
+
+      - name: Set up python3 env
+        run: python3 -m venv ion-test-driver/venv && . ion-test-driver/venv/bin/activate
+
+      - name: Pip install
+        run: pip3 install -r ion-test-driver/requirements.txt && pip3 install -e ion-test-driver
+
+      - name: Run ion-test-driver
+        run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -o output
+          -i ion-java,https://github.com/cheqianh/ion-java,${{ github.event.pull_request.head.sha }}
+
+      - name: analyze two implementations
+        continue-on-error: true
+        id: result-diff
+        run: python3 ion-test-driver/amazon/iontest/ion_test_driver.py -R
+          ion-java,https://github.com/amzn/ion-java,master
+          ion-java,https://github.com/cheqianh/ion-java,${{ github.event.pull_request.head.sha }}
+          output/results/ion-test-driver-results.ion
+
+      - name: analysis report
+        run: cat result.ion
+
+      - name: Check
+        if: ${{ steps.result-diff.outcome == 'failure' }}
+        run: echo 'Implementation behavior changed, Refer to the analysis report in the previous step for the reason.' && exit 1
+
+#   open-issue:
+#     runs-on: ubuntu-latest
+#     needs: ion-test-driver
+#     if: ${{ failure() }}
+#     steps:
+#       - uses: actions/checkout@master
+#       - uses: cheqianh/create-an-issue@e6b4b19
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#           GITHUB_WORKFLOW_URL: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+#           GITHUB_PR_SHA: ${{ github.event.pull_request.head.sha }}
+#         with:
+#           assignees: ${{ github.event.sender.login }}

--- a/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
+++ b/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
@@ -232,7 +232,7 @@ public class IonJavaCli {
             processContext.setLastEventType(event.getEventType());
             if (event.getEventType() == EventType.CONTAINER_START) {
                 if (isEmbeddedEvent(event)) {
-                    embeddedEventToIon(processContext, args, count, event.getIonType());
+                    count = embeddedEventToIon(processContext, args, count, event.getIonType());
                 } else {
                     IonType type = event.getIonType();
                     setFieldName(event, processContext.getIonWriter());

--- a/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
+++ b/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
@@ -95,8 +95,9 @@ public class IonJavaCli {
             if (commandType == CommandType.COMPARE) {
                 compareFiles(ionWriterForOutput, ionWriterForErrorReport, parsedArgs, comparisonType);
             } else if (commandType == CommandType.PROCESS) {
-                processContext.setIonWriter(ionWriterForOutput);
-                processFiles(ionWriterForErrorReport, parsedArgs, processContext);
+                throw new CmdLineException("COMPARE doesn't support option format \"-f events\"");
+//                processContext.setIonWriter(ionWriterForOutput);
+//                processFiles(ionWriterForErrorReport, parsedArgs, processContext);
             }
         } catch (IOException e) {
             System.err.println("Failed to close OutputStream: " + e.getMessage());

--- a/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
+++ b/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
@@ -95,9 +95,8 @@ public class IonJavaCli {
             if (commandType == CommandType.COMPARE) {
                 compareFiles(ionWriterForOutput, ionWriterForErrorReport, parsedArgs, comparisonType);
             } else if (commandType == CommandType.PROCESS) {
-                return;
-//                processContext.setIonWriter(ionWriterForOutput);
-//                processFiles(ionWriterForErrorReport, parsedArgs, processContext);
+                processContext.setIonWriter(ionWriterForOutput);
+                processFiles(ionWriterForErrorReport, parsedArgs, processContext);
             }
         } catch (IOException e) {
             System.err.println("Failed to close OutputStream: " + e.getMessage());
@@ -233,7 +232,7 @@ public class IonJavaCli {
             processContext.setLastEventType(event.getEventType());
             if (event.getEventType() == EventType.CONTAINER_START) {
                 if (isEmbeddedEvent(event)) {
-                    count = embeddedEventToIon(processContext, args, count, event.getIonType());
+                    embeddedEventToIon(processContext, args, count, event.getIonType());
                 } else {
                     IonType type = event.getIonType();
                     setFieldName(event, processContext.getIonWriter());

--- a/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
+++ b/ion-java-cli/src/com/amazon/tools/cli/IonJavaCli.java
@@ -95,7 +95,7 @@ public class IonJavaCli {
             if (commandType == CommandType.COMPARE) {
                 compareFiles(ionWriterForOutput, ionWriterForErrorReport, parsedArgs, comparisonType);
             } else if (commandType == CommandType.PROCESS) {
-                throw new CmdLineException("COMPARE doesn't support option format \"-f events\"");
+                return;
 //                processContext.setIonWriter(ionWriterForOutput);
 //                processFiles(ionWriterForErrorReport, parsedArgs, processContext);
             }


### PR DESCRIPTION
### Description:
Added GitHub Actions to trigger ion-test-driver for every pull request.

Current logic: Every PR will kick off an ion-test-driver run and analyze the result automatically, if there is anything changed between the new commit and the target commit, it will open an issue and shows more details there. [Example issue](https://github.com/amzn/ion-java/issues/329).

I tried to store the GitHub logic in one repo and reuse it in other implementations, but [Github community ticket](https://github.community/t/is-it-possible-to-use-the-same-workflow-in-different-repositories/17719) mentioned that they added this to their roadmap but didn't implemented it yet. So I create Github actions for each implementation for now.

**Related PR:**
ion-test-driver new option (--result-diff) is able to automatically analyze the result file generated by ion-test-driver. [PR](https://github.com/amzn/ion-test-driver/pull/9)
Github actions will run the ion-test-driver and open an issue if it fails. Tested and CR in my local repository: [PR](https://github.com/cheqianh/ion-java/pull/26)

### New features compare to the PR in my local repository:
1. it's able to download result files generated by ion-test-driver from artifacts field now so we don't need to read the result from terminal cli.
![Screen Shot 2020-10-28 at 1 25 50 PM](https://user-images.githubusercontent.com/67451029/97492675-1dd44d80-1921-11eb-85f3-c0d726cb76ce.png)


2. Able to handle master commit changing. Ion-test-driver run takes an hour, if someone merges a new commit during the ion-test-driver running, it will raise an error when we analyze the result file since we can't find the new commit's sha in the previous result file. Now we store the master commit sha in GITHUB_ENV and make sure ion-test-driver run and analysis report use the same commit sha.

3. Able to handle different repo now. Before we only focus on the amzn/ion-java repo, now we can check the PRs from personal fork such as comparing amzn/ion-java main branch and cheqianh/ion-java's PR.


