### PR TITLE
Catches exception of unkown sid bigger than INT_MAX.

### DIFF
--- a/src/com/amazon/ion/impl/IonTokenConstsX.java
+++ b/src/com/amazon/ion/impl/IonTokenConstsX.java
@@ -519,7 +519,6 @@ final class IonTokenConstsX
         } catch (Exception e) {
             throw new IonException(String.format("Unable to parse SID %s", digits), e);
         }
-
     }
 
     static public int keyword(CharSequence word, int start_word, int end_word)

--- a/src/com/amazon/ion/impl/IonTokenConstsX.java
+++ b/src/com/amazon/ion/impl/IonTokenConstsX.java
@@ -518,7 +518,7 @@ final class IonTokenConstsX
         try {
             return Integer.parseInt(digits);
         } catch (Exception e) {
-            throw new UnknownSymbolException(digits);
+            throw new IonException(String.format("Unable to parse SID %s", digits), e);
         }
 
     }

--- a/src/com/amazon/ion/impl/IonTokenConstsX.java
+++ b/src/com/amazon/ion/impl/IonTokenConstsX.java
@@ -517,7 +517,7 @@ final class IonTokenConstsX
 
         try {
             return Integer.parseInt(digits);
-        } catch(Exception e) {
+        } catch (Exception e) {
             throw new UnknownSymbolException(digits);
         }
 

--- a/src/com/amazon/ion/impl/IonTokenConstsX.java
+++ b/src/com/amazon/ion/impl/IonTokenConstsX.java
@@ -17,7 +17,6 @@ package com.amazon.ion.impl;
 
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonType;
-import com.amazon.ion.UnknownSymbolException;
 import com.amazon.ion.impl._Private_ScalarConversions.CantConvertException;
 
 

--- a/src/com/amazon/ion/impl/IonTokenConstsX.java
+++ b/src/com/amazon/ion/impl/IonTokenConstsX.java
@@ -17,6 +17,7 @@ package com.amazon.ion.impl;
 
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonType;
+import com.amazon.ion.UnknownSymbolException;
 import com.amazon.ion.impl._Private_ScalarConversions.CantConvertException;
 
 
@@ -513,7 +514,13 @@ final class IonTokenConstsX
         assert length > 1;
 
         String digits = sidToken.subSequence(1, length).toString();
-        return Integer.parseInt(digits);
+
+        try {
+            return Integer.parseInt(digits);
+        } catch(Exception e) {
+            throw new UnknownSymbolException(digits);
+        }
+
     }
 
     static public int keyword(CharSequence word, int start_word, int end_word)

--- a/test/com/amazon/ion/LoaderTest.java
+++ b/test/com/amazon/ion/LoaderTest.java
@@ -168,9 +168,8 @@ public class LoaderTest
         // it's supposed to throw an IonException since sid is greater than INT_MAX.
         try {
             IonSymbol value = (IonSymbol) loadOneValue(text);
+            Assert.fail("Expected IonException to be thrown.");
         } catch (IonException ignore) { /* expected to reach here */ }
-
-        Assert.fail("Expected IonException to be thrown.");
     }
 
     private static class FailingInputStream extends InputStream

--- a/test/com/amazon/ion/LoaderTest.java
+++ b/test/com/amazon/ion/LoaderTest.java
@@ -171,7 +171,6 @@ public class LoaderTest
         } catch (IonException ignore) { /* expected to reach here */ }
     }
 
-
     private static class FailingInputStream extends InputStream
     {
         final int len;

--- a/test/com/amazon/ion/LoaderTest.java
+++ b/test/com/amazon/ion/LoaderTest.java
@@ -160,6 +160,17 @@ public class LoaderTest
         checkInt(123, value);
     }
 
+    @Test
+    public void testLargeSidSymbol()
+    {
+        String text = "$11111111111111";
+
+        // it's supposed to throw an IonException since sid is greater than INT_MAX.
+        try {
+            IonSymbol value = (IonSymbol) loadOneValue(text);
+        } catch (IonException ignore) { /* expected to reach here */ }
+    }
+
 
     private static class FailingInputStream extends InputStream
     {

--- a/test/com/amazon/ion/LoaderTest.java
+++ b/test/com/amazon/ion/LoaderTest.java
@@ -169,6 +169,8 @@ public class LoaderTest
         try {
             IonSymbol value = (IonSymbol) loadOneValue(text);
         } catch (IonException ignore) { /* expected to reach here */ }
+
+        Assert.fail("Expected IonException to be thrown.");
     }
 
     private static class FailingInputStream extends InputStream


### PR DESCRIPTION
### Description:

For a file with text: `$33333333333333`, ion-java raise NumberFormatException exception instead of IonException.

The issue happens when we call the [hasNext()](https://github.com/amzn/ion-java/blob/30536fbee0cf93d7b21c1702cf4ba6df6a58965e/src/com/amazon/ion/impl/IonReaderTextRawX.java#L486) method. When we decode a SID that is bigger than INT_MAX, it will raise NumberFormatException in [parseInt method](https://github.com/amzn/ion-java/blob/30536fbee0cf93d7b21c1702cf4ba6df6a58965e/src/com/amazon/ion/impl/IonTokenConstsX.java#L516). 

hasNext() method is called before other logic (e.g. SymbolToken validate method), so I think we can just add a try...catch here.

### Test:

**unit test:**
`Tests passed: 23159, ignored: 391 of 23550 tests - 30 s 635 ms`


**manually test:**
For the file with text: `$33333333333333`, it raise UnknownSymbolException now.

```.java
Exception in thread "main" com.amazon.ion.UnknownSymbolException: 33333333333333
```

For exception, should I add more unit test for UnknownSymbolException line 520 - 521)
