### PR TITLE
Add options to configure whether each top level value should be on a …

### DIFF
--- a/src/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java
+++ b/src/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java
@@ -34,10 +34,6 @@ public class _Private_IonTextWriterBuilder
     extends IonTextWriterBuilder
 {
     private final static CharSequence SPACE_CHARACTER = " ";
-    // TODO amzn/ion-java/issues/57 decide if this should be platform-specific
-    private final static CharSequence LINE_SEPARATOR =
-        System.getProperty("line.separator");
-
 
     public static _Private_IonTextWriterBuilder standard()
     {
@@ -148,13 +144,17 @@ public class _Private_IonTextWriterBuilder
     final CharSequence lineSeparator()
     {
         if (_pretty_print) {
-            return LINE_SEPARATOR;
+            return getNewLineType().getCharSequence();
         }
         else {
             return SPACE_CHARACTER;
         }
     }
 
+    final CharSequence topLevelSeparator()
+    {
+        return getWriteTopLevelValuesOnNewLines() ? getNewLineType().getCharSequence() : lineSeparator();
+    }
 
     //=========================================================================
 
@@ -171,6 +171,11 @@ public class _Private_IonTextWriterBuilder
         if (b.getCharset() == null)
         {
             b.setCharset(UTF8);
+        }
+
+        if (b.getNewLineType() == null)
+        {
+            b.setNewLineType(NewLineType.PLATFORM_DEPENDENT);
         }
 
         return (_Private_IonTextWriterBuilder) b.immutable();

--- a/src/com/amazon/ion/system/IonTextWriterBuilder.java
+++ b/src/com/amazon/ion/system/IonTextWriterBuilder.java
@@ -717,7 +717,7 @@ public abstract class IonTextWriterBuilder
     /**
      * Gets whether each top level value for standard printing should start on a new line. The default value is {@code false}.
      * When false, the IonTextWriter will insert a single space character (U+0020) between top-level values.
-     * When pretty-printing, this setting is ignored; the pretty printer will always insert start top-level values on a new line.
+     * When pretty-printing, this setting is ignored; the pretty printer will always start top-level values on a new line.
      *
      * @return value indicating whether standard printing will insert a newline between top-level values
      *
@@ -732,7 +732,7 @@ public abstract class IonTextWriterBuilder
     /**
      * Sets whether each top level value for standard printing should start on a new line. The default value is {@code false}.
      * When false, the IonTextWriter will insert a single space character (U+0020) between top-level values.
-     * When pretty-printing, this setting is ignored; the pretty printer will always insert start top-level values on a new line.
+     * When pretty-printing, this setting is ignored; the pretty printer will always start top-level values on a new line.
      *
      * @param writeTopLevelValuesOnNewLines value indicating whether standard printing will insert a newline between top-level values
      *
@@ -748,7 +748,7 @@ public abstract class IonTextWriterBuilder
     /**
      * Declares whether each top level value for standard printing should start on a new line. The default value is {@code false}.
      * When false, the IonTextWriter will insert a single space character (U+0020) between top-level values.
-     * When pretty-printing, this setting is ignored; the pretty printer will always insert start top-level values on a new line.
+     * When pretty-printing, this setting is ignored; the pretty printer will always start top-level values on a new line.
      *
      * @param writeTopLevelValuesOnNewLines value indicating whether standard printing will insert a newline between top-level values
      *

--- a/src/com/amazon/ion/util/IonTextUtils.java
+++ b/src/com/amazon/ion/util/IonTextUtils.java
@@ -68,6 +68,27 @@ public class IonTextUtils
     }
 
     /**
+     * Ion whitespace is defined as one of the characters space, tab, newline,
+     * and carriage-return.  This matches the definition of whitespace used by
+     * JSON.
+     *
+     * @param charSequence the CharSequence to test.
+     * @return {@code true} if {@code charSequence} consists entirely of the four legal
+     * Ion whitespace characters.
+     *
+     * @see #isWhitespace(int)
+     * @see <a href="http://tools.ietf.org/html/rfc4627">RFC 4627</a>
+     */
+    public static boolean isAllWhitespace(CharSequence charSequence) {
+        for (int i = 0; i < charSequence.length(); i++) {
+            if (!IonTextUtils.isWhitespace(Character.codePointAt(charSequence, i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Determines whether a given code point is one of the valid Ion numeric
      * terminators.
      * <p>


### PR DESCRIPTION
…new line and what line separator should be used

**Issue #, if available:**

fixes #57
fixes #350 

**Description of changes:**

Adds two new configuration options to the IonTextWriterBuilder

The first (related to #57) is to add an option to specify the type of line separator. Consumers of the ion-java library can choose a platform independent line separator or explicitly choose to use a platform-dependent line separator.
Existing behavior is (mostly) retained as the new default, in that it will continue to use platform specific line separators, but in fixing this, I discovered that the old implementation was inconsistent with its use of newlines. In some cases it used `\n` and in other cases it used the platform dependent value.

The second (related to #350) is to add an option to start each top level value on a new line for the standard writer. Existing behavior is retained as the default.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
