### PR TITLE
Fix unexpected assertion error.

### DIFF
--- a/src/com/amazon/ion/impl/IonUTF8.java
+++ b/src/com/amazon/ion/impl/IonUTF8.java
@@ -381,8 +381,9 @@ class IonUTF8 {
         return (unicodeScalar > MAXIMUM_UTF16_1_CHAR_CODE_POINT);
     }
     public final static char highSurrogate(int unicodeScalar) {
-        assert(unicodeScalar > MAXIMUM_UTF16_1_CHAR_CODE_POINT);
-        assert(unicodeScalar <= Character.MAX_CODE_POINT);
+        if (!(unicodeScalar > MAXIMUM_UTF16_1_CHAR_CODE_POINT) || !(unicodeScalar <= Character.MAX_CODE_POINT)) {
+            throw new IonException("invalid unicodeScalar");
+        }
         int c = ((unicodeScalar - SURROGATE_OFFSET) >> 10);
         return (char)((c | HIGH_SURROGATE) & 0xffff);
     }

--- a/test/com/amazon/ion/IonExceptionTest.java
+++ b/test/com/amazon/ion/IonExceptionTest.java
@@ -15,11 +15,15 @@
 
 package com.amazon.ion;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+
+import com.amazon.ion.system.IonSystemBuilder;
 import org.junit.Test;
 
 
@@ -99,5 +103,23 @@ public class IonExceptionTest
         ie1.initCause(ie2);
         IonException ion = new IonException(ie1);
         assertNull(ion.causeOfType(IOException.class));
+    }
+
+    @Test
+    public void testCauseOfWrongEncoding() {
+        try {
+            // Wrong encoding
+            byte[] bytes_input = new byte[]{
+                    (byte) 0x27, (byte) 0x31, (byte) -0xB, (byte) 0x31, (byte) 0x31, (byte) 0x31, (byte) 0x27};
+
+            IonSystemBuilder.standard().build().newLoader().load(bytes_input);
+        } catch (IonException e) {
+            // The exception should be caught here
+            assertEquals(e.getMessage(), "invalid unicodeScalar");
+            return;
+        } catch (Exception ignore) {}
+
+        // Shouldn't reach here
+        fail();
     }
 }


### PR DESCRIPTION
**Description:**

Assertions error raised sometimes in IonUTF8.java when uses unexpected encoding, e.g. `iso-8859-1`.

**Summary of the code:**

Changed assert to IonException and added unit test.

&nbsp;

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
