### PR TITLE
Adds IonSystem field to IonContainerLite

### DIFF
--- a/src/com/amazon/ion/impl/lite/IonStructLite.java
+++ b/src/com/amazon/ion/impl/lite/IonStructLite.java
@@ -460,7 +460,7 @@ final class IonStructLite
 
     public ValueFactory add(final String fieldName)
     {
-        return new _Private_CurriedValueFactory(_context.getSystem())
+        return new _Private_CurriedValueFactory(getSystem())
         {
             @Override
             protected void handle(IonValue newValue)
@@ -531,7 +531,7 @@ final class IonStructLite
 
     public ValueFactory put(final String fieldName)
     {
-        return new _Private_CurriedValueFactory(_context.getSystem())
+        return new _Private_CurriedValueFactory(getSystem())
         {
             @Override
             protected void handle(IonValue newValue)

--- a/src/com/amazon/ion/impl/lite/IonValueLite.java
+++ b/src/com/amazon/ion/impl/lite/IonValueLite.java
@@ -633,7 +633,7 @@ abstract class IonValueLite
         if (symbols != null) {
             return symbols;
         }
-        return _context.getSystem().getSystemSymbolTable();
+        return getSystem().getSystemSymbolTable();
     }
 
     public SymbolTable getAssignedSymbolTable()
@@ -651,7 +651,7 @@ abstract class IonValueLite
 
     public IonType getType()
     {
-        throw new UnsupportedOperationException("this type "+this.getClass().getSimpleName()+" should not be instanciated, there is not IonType associated with it");
+        throw new UnsupportedOperationException("this type "+this.getClass().getSimpleName()+" should not be instantiated, there is not IonType associated with it");
     }
 
     public SymbolToken[] getTypeAnnotationSymbols()


### PR DESCRIPTION
Fixes #360.

### Description

All IonValueLite subclasses implement `getSystem()` by delegating that call to their internal `_context` field, which represents the parent value. The context will then delegate to its own context, and this process repeats up the tree until the top level is found. In deeply nested data, this linear search becomes especially expensive.

The `getSystem()` method is widely used. Among other examples, it is called several times per `add()` operation on a container.

This commit modifies `IonContainerLite` (the abstract base class for `IonStructLite` and `IonSequenceLite`) by adding an `IonSystem` field that is populated at instantiation time. Storing this reference guarantees that calls to `getSystem()` can always be resolved by either the current value or its immediate parent container.

By adding this functionality to `IonContainerLite` we are increasing the memory footprint of the container types but leaving the in-memory representation of the scalar types as-is.

### Testing

I used [the reproduction code](https://github.com/fnmdx111/ion-java-sof-minimal-repro) provided by @fnmdx111 to verify that `getSystem()` delegation was the issue -- profiling showed an outsized percentage of CPU time being spent in that method and callstacks thousands of frames deep. I ran it again after applying the fix and confirmed that the problem was gone.

The reproduction code produces a binary tree 1000 levels deep. I trimmed the test to 24 levels deep to get it to complete in a reasonable amount of time and then ran a few before-and-after tests to collect some unscientific performance numbers.

```java
public class Main {
    public static void main(String[] args) {
        System.out.println("Started at " + new Date());
        Plan plan = new CreateDeeplyNestedPlanTree(24).create(0);
        System.out.println("Created plan");

        try {
            IonSystem ion = IonSystemBuilder.standard().build();
            IonSexp sexp = ion.newEmptySexp();
            System.out.println("Serializing");
            long before = System.currentTimeMillis();
            plan.serializeInto(sexp);
            long after = System.currentTimeMillis();
            System.out.println("Serialized");
            System.out.println("Millis: " + (after - before));
        } finally {
            System.out.println("Finished at " + new Date());
        }
    }
}
```

#### Before (3 runs)
* 11,250 ms
* 11,983 ms
* 12,290 ms

#### After (3 runs)
* 7,152 ms
* 7,180 ms
* 8,489 ms


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
