### PR TITLE
Makes the PooledBlockAllocatorProvider a singleton

### DIFF
--- a/src/com/amazon/ion/impl/bin/PooledBlockAllocatorProvider.java
+++ b/src/com/amazon/ion/impl/bin/PooledBlockAllocatorProvider.java
@@ -77,10 +77,10 @@ import java.util.concurrent.ConcurrentMap;
         public void close() {}
     }
 
-    // A globally shared instance of the PooledBlockAllocatorProvider that is lazily initialized.
+    // A globally shared instance of the PooledBlockAllocatorProvider.
     // This instance allows BlockAllocators to be re-used across instantiations of classes like
     // the binary Ion writer, thereby avoiding costly array initializations.
-    private static PooledBlockAllocatorProvider instance;
+    private static final PooledBlockAllocatorProvider INSTANCE = new PooledBlockAllocatorProvider();
     private final ConcurrentMap<Integer, BlockAllocator> allocators;
 
     private PooledBlockAllocatorProvider()
@@ -88,11 +88,8 @@ import java.util.concurrent.ConcurrentMap;
         allocators = new ConcurrentHashMap<Integer, BlockAllocator>();
     }
 
-    public static synchronized PooledBlockAllocatorProvider getInstance() {
-        if (instance == null) {
-            instance = new PooledBlockAllocatorProvider();
-        }
-        return instance;
+    public static PooledBlockAllocatorProvider getInstance() {
+        return INSTANCE;
     }
 
     @Override

--- a/src/com/amazon/ion/impl/bin/PooledBlockAllocatorProvider.java
+++ b/src/com/amazon/ion/impl/bin/PooledBlockAllocatorProvider.java
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentMap;
      * <p>
      * This implementation is thread-safe.
      */
-    private final class PooledBlockAllocator extends BlockAllocator
+    private static final class PooledBlockAllocator extends BlockAllocator
     {
         private final int blockSize, blockLimit;
         private final ConcurrentLinkedQueue<Block> freeBlocks;

--- a/src/com/amazon/ion/impl/bin/_PrivateIon_HashTrampoline.java
+++ b/src/com/amazon/ion/impl/bin/_PrivateIon_HashTrampoline.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 @Deprecated
 public class _PrivateIon_HashTrampoline
 {
-    private static final PooledBlockAllocatorProvider ALLOCATOR_PROVIDER = new PooledBlockAllocatorProvider();
+    private static final PooledBlockAllocatorProvider ALLOCATOR_PROVIDER = PooledBlockAllocatorProvider.getInstance();
     
     public static IonWriter newIonWriter(ByteArrayOutputStream baos) throws IOException
     {

--- a/src/com/amazon/ion/impl/bin/_Private_IonManagedBinaryWriterBuilder.java
+++ b/src/com/amazon/ion/impl/bin/_Private_IonManagedBinaryWriterBuilder.java
@@ -52,7 +52,7 @@ public final class _Private_IonManagedBinaryWriterBuilder
             @Override
             BlockAllocatorProvider createAllocatorProvider()
             {
-                return new PooledBlockAllocatorProvider();
+                return PooledBlockAllocatorProvider.getInstance();
             }
         },
         BASIC

--- a/test/com/amazon/ion/impl/bin/PooledBlockAllocatorProviderTest.java
+++ b/test/com/amazon/ion/impl/bin/PooledBlockAllocatorProviderTest.java
@@ -30,7 +30,7 @@ public class PooledBlockAllocatorProviderTest
     @Before
     public void setup()
     {
-        provider = new PooledBlockAllocatorProvider();
+        provider = PooledBlockAllocatorProvider.getInstance();
     }
 
     @After


### PR DESCRIPTION
### Description

Many applications need to initialize IonWriters repeatedly for
short-lived tasks. For example, a webserver might create a new
IonWriter for each HTTP response that it needs to write. In such
cases, the bulk of the compute time needed to serialize the
response data is often spent initializing the byte array buffer
backing the IonWriter rather than performing the write logic itself.

Each time that a (e.g.) binary IonWriter is initialized, a new
PooledBlockAllocatorProvider (PBAP) is initialized with it to dole
out new byte array buffers. It attempts to reuse these byte arrays
wherever possible during its lifespan. Unfortunately, the PBAP only
lives as long as the IonWriter itself. If a new IonWriter is created,
a new PBAP (and therefore new byte arrays) are created as well.

This change modifies the PooledBlockAllocatorProvider (which was
already thread-safe) to be a globally shared singleton. This makes
repeatedly initializing new IonWriters substantially cheaper.

### Benchmarks

I wrote [a simple, unscientific benchmark](https://gist.github.com/zslayton/45194bfab526703e89e655a2eb8a7232) that creates a binary `IonWriter`, writes a value to a `ByteArrayOutputStream`, and then closes the `IonWriter` in a loop. The results below are the median of 5 runs each.

| Before | After | Difference |
|--|--|--|
| 1046 ms | 399 ms | **-61.85%** |

### Testing

This PR passes our current test suite but does not include new tests. I'm open to ideas for how to demonstrate that this won't cause problems.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
