### PR TITLE
Fixes handling of NaN and +/-Inf when downconverting to json

### DIFF
--- a/src/com/amazon/ion/impl/IonWriterSystemText.java
+++ b/src/com/amazon/ion/impl/IonWriterSystemText.java
@@ -604,7 +604,7 @@ class IonWriterSystemText
         throws IOException
     {
         startValue();
-        _output.printFloat(value);
+        _output.printFloat(_options, value);
         closeValue();
     }
 

--- a/src/com/amazon/ion/impl/_Private_IonTextAppender.java
+++ b/src/com/amazon/ion/impl/_Private_IonTextAppender.java
@@ -798,7 +798,7 @@ public final class _Private_IonTextAppender
     }
 
 
-    public void printFloat(double value)
+    public void printFloat(_Private_IonTextWriterBuilder _options, double value)
         throws IOException
     {
         // shortcut zero cases
@@ -815,15 +815,27 @@ public final class _Private_IonTextAppender
         }
         else if (Double.isNaN(value))
         {
-            appendAscii("nan");
+            if (_options._float_nan_and_inf_as_null) {
+                appendAscii("null");
+            } else {
+                appendAscii("nan");
+            }
         }
         else if (value == Double.POSITIVE_INFINITY)
         {
-            appendAscii("+inf");
+            if (_options._float_nan_and_inf_as_null) {
+                appendAscii("null");
+            } else {
+                appendAscii("+inf");
+            }
         }
         else if (value == Double.NEGATIVE_INFINITY)
         {
-            appendAscii("-inf");
+            if (_options._float_nan_and_inf_as_null) {
+                appendAscii("null");
+            } else {
+                appendAscii("-inf");
+            }
         }
         else
         {
@@ -846,7 +858,7 @@ public final class _Private_IonTextAppender
         }
     }
 
-    public void printFloat(Double value)
+    public void printFloat(_Private_IonTextWriterBuilder _options, Double value)
         throws IOException
     {
         if (value == null)
@@ -855,7 +867,7 @@ public final class _Private_IonTextAppender
         }
         else
         {
-            printFloat(value.doubleValue());
+            printFloat(_options, value.doubleValue());
         }
     }
 

--- a/src/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java
+++ b/src/com/amazon/ion/impl/_Private_IonTextWriterBuilder.java
@@ -47,9 +47,12 @@ public class _Private_IonTextWriterBuilder
     //=========================================================================
 
     private boolean _pretty_print;
+
+    // These options control whether the IonTextWriter will write standard ion or ion that is down-converted json.
     public boolean _blob_as_string;
     public boolean _clob_as_string;
     public boolean _decimal_as_float;
+    public boolean _float_nan_and_inf_as_null;
     public boolean _sexp_as_list;
     public boolean _skip_annotations;
     public boolean _string_as_json;
@@ -57,6 +60,7 @@ public class _Private_IonTextWriterBuilder
     public boolean _timestamp_as_millis;
     public boolean _timestamp_as_string;
     public boolean _untyped_nulls;
+
     private _Private_CallbackBuilder _callback_builder;
 
 
@@ -73,6 +77,7 @@ public class _Private_IonTextWriterBuilder
         this._blob_as_string      = that._blob_as_string     ;
         this._clob_as_string      = that._clob_as_string     ;
         this._decimal_as_float    = that._decimal_as_float   ;
+        this._float_nan_and_inf_as_null = that._float_nan_and_inf_as_null;
         this._sexp_as_list        = that._sexp_as_list       ;
         this._skip_annotations    = that._skip_annotations   ;
         this._string_as_json      = that._string_as_json     ;
@@ -123,6 +128,7 @@ public class _Private_IonTextWriterBuilder
         _clob_as_string      = true;
         // datagramAsList    = true; // TODO
         _decimal_as_float    = true;
+        _float_nan_and_inf_as_null = true;
         _sexp_as_list        = true;
         _skip_annotations    = true;
         // skipSystemValues  = true; // TODO

--- a/src/com/amazon/ion/util/IonTextUtils.java
+++ b/src/com/amazon/ion/util/IonTextUtils.java
@@ -876,7 +876,7 @@ public class IonTextUtils
     {
         _Private_IonTextAppender appender =
             _Private_IonTextAppender.forAppendable(out);
-        appender.printFloat(value);
+        appender.printFloat(STANDARD, value);
     }
 
     public static String printFloat(double value)
@@ -900,7 +900,7 @@ public class IonTextUtils
     {
         _Private_IonTextAppender appender =
             _Private_IonTextAppender.forAppendable(out);
-        appender.printFloat(value);
+        appender.printFloat(STANDARD, value);
     }
 
     public static String printFloat(Double value)

--- a/test/com/amazon/ion/impl/TextWriterTest.java
+++ b/test/com/amazon/ion/impl/TextWriterTest.java
@@ -488,6 +488,57 @@ public class TextWriterTest
     }
 
     @Test
+    public void testWritingFloatNanToJson()
+            throws Exception
+    {
+        options = IonTextWriterBuilder.json();
+        options.setInitialIvmHandling(SUPPRESS);
+
+        IonDatagram dg = system().newDatagram();
+        dg.add().newFloat(Double.NaN);
+
+        iw = makeWriter();
+        dg.writeTo(iw);
+
+        String actual = outputString();
+        assertEquals("null", actual);
+    }
+
+    @Test
+    public void testWritingFloatPositiveInfinityToJson()
+            throws Exception
+    {
+        options = IonTextWriterBuilder.json();
+        options.setInitialIvmHandling(SUPPRESS);
+
+        IonDatagram dg = system().newDatagram();
+        dg.add().newFloat(Double.POSITIVE_INFINITY);
+
+        iw = makeWriter();
+        dg.writeTo(iw);
+
+        String actual = outputString();
+        assertEquals("null", actual);
+    }
+
+    @Test
+    public void testWritingFloatNegativeInfinityToJson()
+            throws Exception
+    {
+        options = IonTextWriterBuilder.json();
+        options.setInitialIvmHandling(SUPPRESS);
+
+        IonDatagram dg = system().newDatagram();
+        dg.add().newFloat(Double.NEGATIVE_INFINITY);
+
+        iw = makeWriter();
+        dg.writeTo(iw);
+
+        String actual = outputString();
+        assertEquals("null", actual);
+    }
+
+    @Test
     public void testSuppressInitialIvm()
         throws Exception
     {


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

The Ion Docs section on [Down Converting to Json](https://amzn.github.io/ion-docs/guides/cookbook.html#down-converting-to-json) says:

> Floats are printed as JSON *number* with `nan` and `+-inf` converted to JSON *null*

Right now, `ion-java` just writes them as `nan`, `+inf`, and `-inf`. This PR makes `ion-java` write JSON *null* as expected.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
