### PR TITLE
Makes `writeValueRecursively` iterative

### DIFF
--- a/src/com/amazon/ion/impl/IonWriterUserBinary.java
+++ b/src/com/amazon/ion/impl/IonWriterUserBinary.java
@@ -105,7 +105,7 @@ class IonWriterUserBinary
 
         // From here on, we won't call back into this method, so we won't
         // bother doing all those checks again.
-        writeValueRecursively(type, reader);
+        writeValueRecursively(reader);
     }
 
 

--- a/src/com/amazon/ion/impl/_Private_IonWriterBase.java
+++ b/src/com/amazon/ion/impl/_Private_IonWriterBase.java
@@ -395,8 +395,8 @@ public abstract class _Private_IonWriterBase
                     // We're finishing our traversal.
                     break;
                 }
-                // We're beginning our traversal. Don't advance the cursor; instead, use the IonType that was
-                // passed in by the caller.
+                // We're beginning our traversal. Don't advance the cursor; instead, use the current
+                // value's IonType.
                 type = reader.getType();
                 // We've begun processing the starting value.
                 alreadyProcessedTheStartingValue = true;


### PR DESCRIPTION
The method `_Private_IonWriterBase#writeValueRecursively` is
recursive in two senses:

1. It visits all of the children in the provided IonReader's
   current value recursively.
2. The method itself is implemented using recursion.

This patch modifies the implementation to be iterative,
eliminating a source of StackOverflowExceptions and offering
a modest reduction in CPU cost.

### Benchmark

This benchmark creates an `IonStruct` that is 1,000 levels deep, wraps it in an `IonReader`, then uses `writeValueRecursively` to write it to a binary Ion stream 100k times. The source can be viewed [here](https://gist.github.com/zslayton/d9677b2e8355324a6dccba8f79988dc2).

This change does not affect allocations or garbage collection, only CPU time.

**Before**

```
                                       Score           Error   Units
time                                1804.311 ±         7.401   ms/op
·gc.alloc.rate                      1089.760 ±         3.556  MB/sec
·gc.alloc.rate.norm           2636281467.200 ±        70.340    B/op
·gc.churn.G1_Eden_Space             1092.004 ±        73.732  MB/sec
·gc.churn.G1_Eden_Space.norm  2641782374.400 ± 180920323.756    B/op
·gc.churn.G1_Old_Gen                   0.171 ±         0.040  MB/sec
·gc.churn.G1_Old_Gen.norm         413110.400 ±     96520.541    B/op
·gc.count                            114.000                  counts
·gc.time                              83.000                      ms
```

**After**

```
                                       Score           Error   Units
time                                1735.452 ±        42.039   ms/op
·gc.alloc.rate                      1123.361 ±        21.138  MB/sec
·gc.alloc.rate.norm           2636281504.000 ±         0.001    B/op
·gc.churn.G1_Eden_Space             1131.249 ±        89.896  MB/sec
·gc.churn.G1_Eden_Space.norm  2654679859.200 ± 200798830.041    B/op
·gc.churn.G1_Old_Gen                   0.162 ±         0.046  MB/sec
·gc.churn.G1_Old_Gen.norm         380224.000 ±    112156.067    B/op
·gc.count                            105.000                  counts
·gc.time                              82.000                      ms
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
