### PR TITLE
Adds a pool of UTF8 String encoders

### DIFF
--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -46,15 +46,13 @@ import com.amazon.ion.IonWriter;
 import com.amazon.ion.SymbolTable;
 import com.amazon.ion.SymbolToken;
 import com.amazon.ion.Timestamp;
+import com.amazon.ion.impl.bin.utf8.Utf8StringEncoder;
+import com.amazon.ion.impl.bin.utf8.Utf8StringEncoderPool;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetEncoder;
-import java.nio.charset.CoderResult;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -125,14 +123,9 @@ import java.util.NoSuchElementException;
 
     private static final byte VARINT_NEG_ZERO   = (byte) 0xC0;
 
-    // See IonRawBinaryWriter#writeString(String) for usage information.
-    static final int SMALL_STRING_SIZE = 4 * 1024;
-
-    // Reusable resources for encoding Strings as UTF-8 bytes
-    final CharsetEncoder utf8Encoder = Charset.forName("UTF-8").newEncoder();
-    final ByteBuffer utf8EncodingBuffer = ByteBuffer.allocate((int) (SMALL_STRING_SIZE * utf8Encoder.maxBytesPerChar()));
-    final char[] charArray = new char[SMALL_STRING_SIZE];
-    final CharBuffer reusableCharBuffer = CharBuffer.wrap(charArray);
+    final Utf8StringEncoder utf8StringEncoder = Utf8StringEncoderPool
+            .getInstance()
+            .getOrCreateUtf8Encoder();
 
     private static final byte[] makeTypedPreallocatedBytes(final int typeDesc, final int length)
     {
@@ -1443,73 +1436,10 @@ import java.util.NoSuchElementException;
         }
         prepareValue();
 
-        /*
-         This method relies on the standard CharsetEncoder class to encode each String's UTF-16 char[] data into
-         UTF-8 bytes. Strangely, CharsetEncoders cannot operate directly on instances of a String. The CharsetEncoder
-         API requires all inputs and outputs to be specified as instances of java.nio.ByteBuffer and
-         java.nio.CharBuffer, making some number of allocations mandatory. Specifically, for each encoding operation
-         we need to have:
-
-            1. An instance of a UTF-8 CharsetEncoder.
-            2. A CharBuffer representation of the String's data.
-            3. A ByteBuffer into which the CharsetEncoder may write UTF-8 bytes.
-
-         To minimize the overhead involved, the IonRawBinaryWriter will reuse previously initialized resources wherever
-         possible. However, because CharBuffer and ByteBuffer each have a fixed length, we can only reuse them for
-         Strings that are small enough to fit. This creates two kinds of input String to encode: those that are small
-         enough for us to reuse our buffers ("small strings"), and those which are not ("large strings").
-
-         The String#getBytes(Charset) method cannot be used for two reasons:
-
-               1. It always allocates, so we cannot reuse any resources.
-               2. If/when it encounters character data that cannot be encoded as UTF-8, it simply replaces that data
-                 with a substitute character[1]. (Sometimes seen in applications as a '?'.) In order
-                 to surface invalid data to the user, the method must be able to detect these events at encoding time.
-
-            [1] https://en.wikipedia.org/wiki/Substitute_character
-        */
-
-        CharBuffer stringData;
-        ByteBuffer encodingBuffer;
-
-        int length = value.length();
-
-        // While it is possible to encode the Ion string using a fixed-size encodingBuffer, we need to be able to
-        // write the length of the complete UTF-8 string to the output stream before we write the string itself.
-        // For simplicity, we reuse or create an encodingBuffer that is large enough to hold the full string.
-
-        // In order to encode the input String, we need to pass it to CharsetEncoder as an implementation of CharBuffer.
-        // Surprisingly, the intuitive way to achieve this (the CharBuffer#wrap(CharSequence) method) adds a large
-        // amount of CPU overhead to the encoding process. Benchmarking shows that it's substantially faster
-        // to use String#getChars(int, int, char[], int) to copy the String's backing array and then call
-        // CharBuffer#wrap(char[]) on the copy.
-
-        if (length > SMALL_STRING_SIZE) {
-            // Allocate a new buffer for large strings
-            encodingBuffer = ByteBuffer.allocate((int) (value.length() * utf8Encoder.maxBytesPerChar()));
-            char[] chars = new char[value.length()];
-            value.getChars(0, value.length(), chars, 0);
-            stringData = CharBuffer.wrap(chars);
-        } else {
-            // Reuse our existing buffers for small strings
-            encodingBuffer = utf8EncodingBuffer;
-            encodingBuffer.clear();
-            stringData = reusableCharBuffer;
-            value.getChars(0, value.length(), charArray, 0);
-            reusableCharBuffer.rewind();
-            reusableCharBuffer.limit(value.length());
-        }
-
-        // Because encodingBuffer is guaranteed to be large enough to hold the encoded string, we can
-        // perform the encoding in a single call to CharsetEncoder#encode(CharBuffer, ByteBuffer, boolean).
-        CoderResult coderResult = utf8Encoder.encode(stringData, encodingBuffer, true);
-
-        // 'Underflow' is the success state of a CoderResult.
-        if (!coderResult.isUnderflow()) {
-            throw new IllegalArgumentException("Could not encode string as UTF8 bytes: " + value);
-        }
-        encodingBuffer.flip();
-        int utf8Length = encodingBuffer.remaining();
+        // UTF-8 encode the String
+        Utf8StringEncoder.Result encoderResult = utf8StringEncoder.encode(value);
+        int utf8Length = encoderResult.getEncodedLength();
+        byte[] utf8Buffer = encoderResult.getBuffer();
 
         // Write the type and length codes to the output stream.
         long previousPosition = buffer.position();
@@ -1521,7 +1451,7 @@ import java.util.NoSuchElementException;
         }
 
         // Write the encoded UTF-8 bytes to the output stream
-        buffer.writeBytes(encodingBuffer.array(), 0, utf8Length);
+        buffer.writeBytes(utf8Buffer, 0, utf8Length);
 
         long bytesWritten = buffer.position() - previousPosition;
         updateLength(bytesWritten);
@@ -1686,6 +1616,8 @@ import java.util.NoSuchElementException;
             buffer.close();
             patchBuffer.close();
             allocator.close();
+            // We cannot use `utf8StringEncoder` again after returning it to the pool.
+            Utf8StringEncoderPool.getInstance().returnEncoderToPool(utf8StringEncoder);
         }
         finally
         {

--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -1616,8 +1616,7 @@ import java.util.NoSuchElementException;
             buffer.close();
             patchBuffer.close();
             allocator.close();
-            // We cannot use `utf8StringEncoder` again after returning it to the pool.
-            Utf8StringEncoderPool.getInstance().returnEncoderToPool(utf8StringEncoder);
+            utf8StringEncoder.close();
         }
         finally
         {

--- a/src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java
+++ b/src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java
@@ -1,0 +1,148 @@
+package com.amazon.ion.impl.bin.utf8;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+
+/**
+ * Encodes {@link String}s to UTF-8. Instances of this class are reusable but are NOT threadsafe.
+ *
+ * Users are strongly encouraged to get instances from {@link Utf8StringEncoderPool#getOrCreateUtf8Encoder()}.
+ */
+public class Utf8StringEncoder {
+    // The longest String (as measured by {@link java.lang.String#length()}) that this instance can encode without
+    // requiring additional allocations.
+    private static final int SMALL_STRING_SIZE = 4 * 1024;
+
+    // Reusable resources for encoding Strings as UTF-8 bytes
+    final CharsetEncoder utf8Encoder;
+    final ByteBuffer utf8EncodingBuffer;
+    final char[] charArray;
+    final CharBuffer charBuffer;
+
+    public Utf8StringEncoder() {
+        utf8Encoder = Charset.forName("UTF-8").newEncoder();
+        utf8EncodingBuffer = ByteBuffer.allocate((int) (SMALL_STRING_SIZE * utf8Encoder.maxBytesPerChar()));
+        charArray = new char[SMALL_STRING_SIZE];
+        charBuffer = CharBuffer.wrap(charArray);
+    }
+
+    /**
+     * Encodes the provided String's text to UTF-8. Unlike {@link String#getBytes(Charset)}, this method will not
+     * silently replace characters that cannot be encoded with a substitute characters. Instead, it will throw
+     * an {@link IllegalArgumentException}.
+     *
+     * Some resources in the returned {@link Result} may be reused across calls to this method. Consequently,
+     * callers should use the Result and discard it immediately.
+     *
+     * @param text A Java String to encode as UTF8 bytes.
+     * @return  A {@link Result} containing a byte array of UTF-8 bytes and encoded length.
+     * @throws IllegalArgumentException if the String cannot be encoded as UTF-8.
+     */
+    public Result encode(String text) {
+        /*
+         This method relies on the standard CharsetEncoder class to encode each String's UTF-16 char[] data into
+         UTF-8 bytes. Strangely, CharsetEncoders cannot operate directly on instances of a String. The CharsetEncoder
+         API requires all inputs and outputs to be specified as instances of java.nio.ByteBuffer and
+         java.nio.CharBuffer, making some number of allocations mandatory. Specifically, for each encoding operation
+         we need to have:
+
+            1. An instance of a UTF-8 CharsetEncoder.
+            2. A CharBuffer representation of the String's data.
+            3. A ByteBuffer into which the CharsetEncoder may write UTF-8 bytes.
+
+         To minimize the overhead involved, the Utf8StringEncoder will reuse previously initialized resources wherever
+         possible. However, because CharBuffer and ByteBuffer each have a fixed length, we can only reuse them for
+         Strings that are small enough to fit. This creates two kinds of input String to encode: those that are small
+         enough for us to reuse our buffers ("small strings"), and those which are not ("large strings").
+
+         The String#getBytes(Charset) method cannot be used for two reasons:
+
+               1. It always allocates, so we cannot reuse any resources.
+               2. If/when it encounters character data that cannot be encoded as UTF-8, it simply replaces that data
+                 with a substitute character[1]. (Sometimes seen in applications as a '?'.) In order
+                 to surface invalid data to the user, the method must be able to detect these events at encoding time.
+
+            [1] https://en.wikipedia.org/wiki/Substitute_character
+        */
+
+        CharBuffer stringData;
+        ByteBuffer encodingBuffer;
+
+        int length = text.length();
+
+        // While it is technically possible to encode any String using a fixed-size encodingBuffer, we need
+        // to be able to write the length of the complete UTF-8 string to the output stream before we write the string
+        // itself. For simplicity, we reuse or create an encodingBuffer that is large enough to hold the full string.
+
+        // In order to encode the input String, we need to pass it to CharsetEncoder as an implementation of CharBuffer.
+        // Surprisingly, the intuitive way to achieve this (the CharBuffer#wrap(CharSequence) method) adds a large
+        // amount of CPU overhead to the encoding process. Benchmarking shows that it's substantially faster
+        // to use String#getChars(int, int, char[], int) to copy the String's backing array and then call
+        // CharBuffer#wrap(char[]) on the copy.
+
+        if (length > SMALL_STRING_SIZE) {
+            // Allocate a new buffer for large strings
+            encodingBuffer = ByteBuffer.allocate((int) (text.length() * utf8Encoder.maxBytesPerChar()));
+            char[] chars = new char[text.length()];
+            text.getChars(0, text.length(), chars, 0);
+            stringData = CharBuffer.wrap(chars);
+        } else {
+            // Reuse our existing buffers for small strings
+            encodingBuffer = utf8EncodingBuffer;
+            encodingBuffer.clear();
+            stringData = charBuffer;
+            text.getChars(0, text.length(), charArray, 0);
+            charBuffer.rewind();
+            charBuffer.limit(text.length());
+        }
+
+        // Because encodingBuffer is guaranteed to be large enough to hold the encoded string, we can
+        // perform the encoding in a single call to CharsetEncoder#encode(CharBuffer, ByteBuffer, boolean).
+        CoderResult coderResult = utf8Encoder.encode(stringData, encodingBuffer, true);
+
+        // 'Underflow' is the success state of a CoderResult.
+        if (!coderResult.isUnderflow()) {
+            throw new IllegalArgumentException("Could not encode string as UTF8 bytes: " + text);
+        }
+        encodingBuffer.flip();
+        int utf8Length = encodingBuffer.remaining();
+
+        // In most usages, the JVM should be able to eliminate this allocation via an escape analysis of the caller.
+        return new Result(utf8Length, encodingBuffer.array());
+    }
+
+    /**
+     * Represents the result of a {@link Utf8StringEncoder#encode(String)} operation.
+     */
+    public static class Result {
+        private byte[] buffer;
+        private int encodedLength;
+
+        public Result(int encodedLength, byte[] buffer) {
+            this.encodedLength = encodedLength;
+            this.buffer = buffer;
+        }
+
+        /**
+         * Returns a byte array containing the encoded UTF-8 bytes starting at index 0. This byte array is NOT
+         * guaranteed to be the same length as the data it contains. Callers must use {@link #getEncodedLength()}
+         * to determine the number of bytes that should be read from the byte array.
+         *
+         * @return the buffer containing UTF-8 bytes.
+         */
+        public byte[] getBuffer() {
+            return buffer;
+        }
+
+        /**
+         * @return the number of encoded bytes in the array returned by {@link #getBuffer()}.
+         */
+        public int getEncodedLength() {
+            return encodedLength;
+        }
+    }
+}

--- a/src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java
+++ b/src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoder.java
@@ -32,7 +32,7 @@ public class Utf8StringEncoder {
 
     /**
      * Encodes the provided String's text to UTF-8. Unlike {@link String#getBytes(Charset)}, this method will not
-     * silently replace characters that cannot be encoded with a substitute characters. Instead, it will throw
+     * silently replace characters that cannot be encoded with a substitute character. Instead, it will throw
      * an {@link IllegalArgumentException}.
      *
      * Some resources in the returned {@link Result} may be reused across calls to this method. Consequently,

--- a/src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoderPool.java
+++ b/src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoderPool.java
@@ -1,0 +1,60 @@
+package com.amazon.ion.impl.bin.utf8;
+
+import java.util.concurrent.ArrayBlockingQueue;
+
+/**
+ * A thread-safe shared pool of {@link Utf8StringEncoder}s that can be used for UTF8 encoding and decoding.
+ */
+public class Utf8StringEncoderPool {
+    // The maximum number of Utf8Encoders that can be waiting in the queue before new ones will be discarded.
+    private static final int MAX_QUEUE_SIZE = 32;
+
+    // A singleton instance.
+    private static final Utf8StringEncoderPool INSTANCE = new Utf8StringEncoderPool();
+
+    // A queue of previously initialized encoders that can be loaned out.
+    ArrayBlockingQueue<Utf8StringEncoder> bufferQueue;
+
+    // Do not allow instantiation; all classes should share the singleton instance.
+    private Utf8StringEncoderPool() {
+        bufferQueue = new ArrayBlockingQueue<Utf8StringEncoder>(MAX_QUEUE_SIZE);
+    }
+
+    /**
+     * @return a threadsafe shared instance of {@link Utf8StringEncoderPool}.
+     */
+    public static Utf8StringEncoderPool getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * If the pool is not empty, removes an instance of {@link Utf8StringEncoder} from the pool and returns it;
+     * otherwise, constructs a new instance.
+     *
+     * @return An instance of {@link Utf8StringEncoder}.
+     */
+    public Utf8StringEncoder getOrCreateUtf8Encoder() {
+        // The `poll` method does not block. If the queue is empty it returns `null` immediately.
+        Utf8StringEncoder encoder = bufferQueue.poll();
+        if (encoder == null) {
+            // No buffers were available in the pool. Create a new one.
+            encoder = new Utf8StringEncoder();
+        }
+        return encoder;
+    }
+
+    /**
+     * Adds the provided instance of {@link Utf8StringEncoder} to the pool. If the pool is full, the instance will
+     * be discarded.
+     *
+     * Callers MUST NOT use an encoder after returning it to the pool.
+     *
+     * @param encoder   A {@link Utf8StringEncoder} to add to the pool.
+     */
+    public void returnEncoderToPool(Utf8StringEncoder encoder) {
+        // The `offer` method does not block. If the queue is full, it returns `false` immediately.
+        // If the provided instance cannot be added to the pool, we discard it silently.
+        bufferQueue.offer(encoder);
+    }
+
+}

--- a/src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoderPool.java
+++ b/src/com/amazon/ion/impl/bin/utf8/Utf8StringEncoderPool.java
@@ -5,15 +5,15 @@ import java.util.concurrent.ArrayBlockingQueue;
 /**
  * A thread-safe shared pool of {@link Utf8StringEncoder}s that can be used for UTF8 encoding and decoding.
  */
-public class Utf8StringEncoderPool {
-    // The maximum number of Utf8Encoders that can be waiting in the queue before new ones will be discarded.
-    private static final int MAX_QUEUE_SIZE = 32;
+public enum Utf8StringEncoderPool {
+    // The only enum variant; a singleton instance.
+    INSTANCE;
 
-    // A singleton instance.
-    private static final Utf8StringEncoderPool INSTANCE = new Utf8StringEncoderPool();
+    // The maximum number of Utf8Encoders that can be waiting in the queue before new ones will be discarded.
+    private static final int MAX_QUEUE_SIZE = 128;
 
     // A queue of previously initialized encoders that can be loaned out.
-    ArrayBlockingQueue<Utf8StringEncoder> bufferQueue;
+    private final ArrayBlockingQueue<Utf8StringEncoder> bufferQueue;
 
     // Do not allow instantiation; all classes should share the singleton instance.
     private Utf8StringEncoderPool() {
@@ -38,7 +38,7 @@ public class Utf8StringEncoderPool {
         Utf8StringEncoder encoder = bufferQueue.poll();
         if (encoder == null) {
             // No buffers were available in the pool. Create a new one.
-            encoder = new Utf8StringEncoder();
+            encoder = new Utf8StringEncoder(this);
         }
         return encoder;
     }


### PR DESCRIPTION
Most of the expense involved in constructing new binary writers
comes from allocating/initializing the buffers needed to encode
Java's UTF-16 Strings to UTF-8.

This change refactors the UTF-8 encoding logic into its own
class (Utf8StringEncoder) and introduces a singleton
Utf8StringEncoderPool that allows these encoders to be reused
across instantiations of binary writers.

### Benchmark

This test initializes a new binary writer, writes a small string (`"foo"`), then closes the writer in a tight loop. The source can be found [here](https://gist.github.com/zslayton/95730187f86f467ced87f13452ba9fb4).

**Before**
```
Benchmark                             Score           Error   Units
time                                 37.664 ±         3.661   ms/op
·gc.alloc.rate                      773.095 ±         3.882  MB/sec
·gc.alloc.rate.norm           438323910.400 ±    366718.519    B/op
·gc.churn.G1_Eden_Space             739.958 ±       238.206  MB/sec
·gc.churn.G1_Eden_Space.norm  419640115.200 ± 135676093.820    B/op
·gc.churn.G1_Old_Gen                  0.017 ±         0.033  MB/sec
·gc.churn.G1_Old_Gen.norm          9425.600 ±     18474.404    B/op
·gc.count                            20.000                  counts
·gc.time                             13.000                      ms
```

**After**
```
Benchmark                             Score           Error   Units
time                                 17.788 ±         3.631   ms/op
·gc.alloc.rate                       43.899 ±         0.850  MB/sec
·gc.alloc.rate.norm            24007104.000 ±    489259.500    B/op
·gc.churn.G1_Eden_Space              57.248 ±       182.466  MB/sec
·gc.churn.G1_Eden_Space.norm   31457280.000 ± 100263003.914    B/op
·gc.count                             2.000                  counts
·gc.time                              4.000                      ms
```

Following this change, the benchmark:
* Took 52.77% less time to run.
* Reduced its allocation rate from ~773MB/sec to ~44MB/sec (94.32% less)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
