### PR TITLE
Adds GitHub workflow to detect the performance regression of ion-java automatically.

### DIFF
--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -4,10 +4,8 @@
 name: Ion Java performance regression detector
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   detect-regression:

--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Ion Jave performance regression detector
+name: Ion Java performance regression detector
 
 on:
   push:
@@ -10,8 +10,8 @@ on:
     branches: [ master ]
 
 jobs:
-  detetct-regression:
-    name: Detetct Regression
+  detect-regression:
+    name: Detect Regression
 
     runs-on: ubuntu-latest
 
@@ -21,52 +21,107 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: Checkout ion-java repository from the current commit
+      - name: Checkout ion-java from the new commit.
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
           submodules: recursive
-      - run: git checkout HEAD^
-
-      - name: Build ion-java from the current commit
-        run: mvn clean install
-
-      - name: Build ion-java-benchmark-cli based on the current ion-java
-        uses: actions/checkout@v2
-        with:
-          repository: amzn/ion-java-benchmark-cli
-          ref: master
-      - run: mvn clean install
-
-      - name: Check the version of ion-java
-        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
-
-      - name: Generate test Ion Data
-        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar generate -S 500 -T string -f ion_text testWorkflow.ion
-
-      - name: Test read preformance of the ion-java from the current commit
-        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar read testWorkflow.ion -o readPerformanceCurrent.ion -r ion
-
-      - name: Clean maven dependency repository
-        run : rm -r /home/runner/.m2
-
-      - name: Checkout ion-java repository from the new commit
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
+          path: ion-java
 
       - name: Build ion-java from the new commit
-        run: mvn clean install
+        run: cd ion-java && mvn clean install
 
-      - name: Build ion-java-benchmark-cli based on the new ion-java
+      - name: Checkout ion-java-benchmark-cli
         uses: actions/checkout@v2
         with:
           repository: amzn/ion-java-benchmark-cli
           ref: master
-      - run: mvn clean install
+          path: ion-java-benchmark-cli
+
+      - name: Build ion-java-benchmark-cli
+        run: cd ion-java-benchmark-cli && mvn clean install
+
+      - name: Check the version of ion-java.
+        run: java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
+
+      - name: Generate test Ion Data
+        run: |
+          mkdir -p testData
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/benchmark/testStruct.isl testData/testStruct.10n
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/benchmark/testList.isl testData/testList.10n
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/benchmark/testNestedStruct.isl testData/testNestedStruct.10n
+
+      - name: Upload test Ion Data to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: test Ion Data
+          path: testData
+
+      - name: Benchmark ion-java from the new commit
+        run: |
+          mkdir -p benchmarkResults
+          cd ion-java-benchmark-cli && java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar run-suite --test-ion-data /home/runner/work/ion-java/ion-java/testData --benchmark-options-combinations tst/com/amazon/ion/benchmark/optionsCombinations.ion /home/runner/work/ion-java/ion-java/benchmarkResults
+
+      - name: Upload benchmark results to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Benchmark result
+          path: benchmarkResults
+
+      - name: Clean maven dependencies repository
+        run : rm -r /home/runner/.m2
+
+      - name: Build ion-java from the previous commit
+        run: cd ion-java && git checkout HEAD^ && mvn clean install
+
+      - name: Build ion-java-benchmark-cli
+        run: cd ion-java-benchmark-cli && mvn clean install
 
       - name: Check the version of ion-java
-        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
+        run: java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
 
-      - name: Test read preformance of ion-java from the new commit
-        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar read testWorkflow.ion -o readPerformanceNew.ion -r ion
+      - name: Create directories for test data and benchmark results
+        run: |
+          mkdir -p benchmarkResults
+          mkdir -p testData
+
+      - name: Download test Ion Data from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: test Ion Data
+          path: testData
+
+      - name: Download benchmark results of ion-java from the new commit from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: Benchmark result
+          path: benchmarkResults
+
+      - name: Benchmark ion-java from the previous commit and add the generated benchmark results to the existing directories
+        run: cd ion-java-benchmark-cli && java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar run-suite --test-ion-data /home/runner/work/ion-java/ion-java/testData --benchmark-options-combinations tst/com/amazon/ion/benchmark/optionsCombinations.ion /home/runner/work/ion-java/ion-java/benchmarkResults
+
+      - name: Upload new benchmark results directory to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Benchmark result
+          path: benchmarkResults
+
+      - name: Detect performance regression
+        id: regression_result
+        run: |
+          result=true
+          cd benchmarkResults && for FILE in *; do message=$(java -jar /home/runner/work/ion-java/ion-java/ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar compare --benchmark-result-previous $FILE/previous.ion --benchmark-result-new $FILE/new.ion $FILE/report.ion | tee /dev/stderr) && if [ "$message" != "" ]; then result=false; fi; done
+          echo "::set-output name=regression-result::$result"
+          echo $result
+
+      - name: Upload comparison reports to the benchmark results directory
+        uses: actions/upload-artifact@v2
+        with:
+          name: Benchmark result
+          path: benchmarkResults
+
+      - name: Fail the workflow if regression happened
+        env:
+          regression_detect: ${{steps.regression_result.outputs.regression-result}}
+        if: ${{ env.regression_detect == 'false' }}
+        run: exit 1

--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -1,0 +1,72 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Ion Jave performance regression detector
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  detetct-regression:
+    name: Detetct Regression
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Checkout ion-java repository from the current commit
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+          submodules: recursive
+      - run: git checkout HEAD^
+
+      - name: Build ion-java from the current commit
+        run: mvn clean install
+
+      - name: Build ion-java-benchmark-cli based on the current ion-java
+        uses: actions/checkout@v2
+        with:
+          repository: amzn/ion-java-benchmark-cli
+          ref: master
+      - run: mvn clean install
+
+      - name: Check the version of ion-java
+        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
+
+      - name: Generate test Ion Data
+        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar generate -S 500 -T string -f ion_text testWorkflow.ion
+
+      - name: Test read preformance of the ion-java from the current commit
+        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar read testWorkflow.ion -o readPerformanceCurrent.ion -r ion
+
+      - name: Clean maven dependency repository
+        run : rm -r /home/runner/.m2
+
+      - name: Checkout ion-java repository from the new commit
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Build ion-java from the new commit
+        run: mvn clean install
+
+      - name: Build ion-java-benchmark-cli based on the new ion-java
+        uses: actions/checkout@v2
+        with:
+          repository: amzn/ion-java-benchmark-cli
+          ref: master
+      - run: mvn clean install
+
+      - name: Check the version of ion-java
+        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar --version
+
+      - name: Test read preformance of ion-java from the new commit
+        run: java -jar target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar read testWorkflow.ion -o readPerformanceNew.ion -r ion

--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -3,9 +3,7 @@
 
 name: Ion Java performance regression detector
 
-on:
-  pull_request:
-    branches: [master]
+on: [pull_request]
 
 jobs:
   detect-regression:


### PR DESCRIPTION
**Description:**

This work flow will be invoked when there is new ion-java commit gets pushed to the master branch of amzn/ion-java.

**Step 1:**
Build ion-java from the new commit on GitHub runner.
**Step 2:**
Build ion-java-benchmark-cli on the same GitHub runner. In this way the benchmark results of ion-java from the new commit will be generated after the benchmark step.
**Step 3:**
Generate three shapes of test ion data (Ion List |  Ion Struct | Nested Ion Struct) by using the sub-command of  ion-java-benchmark-cli.
**Step 4:**
Upload all generated test ion data to artifacts.  
**Step 5:**
For each shape of test data, six ion-java-benchmark-cli invokes will be implemented to finish the benchmark process. After this process, the benchmark results generated from different ion-java-benchmark invoke will be saved in different directories.
**Step 6:**
Upload the benchmark results to artifacts.
**Step 7:**
Clean the directory .m2/ which can make sure the second build will be implemented in a clean environment.
The sequence of maven project searching for maven dependencies is searching locally first then searching in maven central. If we build ion-java locally, then the ion-java-benchmark-cli will find the local ion-java first then start the benchmark process. When we try to benchmark different version of ion-java, it is necessary to clean up the .m2/ directory which contains all maven dependencies to make sure ion-java-benchmark-cli will not take the ion-java from the previous build process.
**Step 8:**
Check out the ion-java from the previous commit by using ‘git checkout HEAD^’ and build ion-java from the previous commit.
**Step 9:**
Build ion-java-benchmark-cli for the second time to make sure the following benchmark process will be executed to the ion-java from the previous commit.
**Step 10:**
Benchmark ion-java from the previous commit with the same test ion data and same ion-java-benchmark invokes.
**Step 11:**
Upload all benchmark results to artifacts.
**Step 12:**
Iterate all directories in the benchmark results then using API ‘ion-java-benchmark compare’ to compare the benchmark results from different ion-java commits with the same test data and ion-java-benchmark-cli invoke, then generating the comparison report and saving this report under the same directory as the benchmark results.
**Step 13:**
Detect the performance regression by comparing the scores in comparison reports with thresholds value(The calculating threshold process will be finished when comparing the benchmark results.)
**Step 14:**
If there is one performance regression detected, the workflow will be failed and users can keep doing research on benchmark results by downloading the artifacts of this workflow.

**Performance regression detected test:**

Action link:
https://github.com/linlin-s/ion-java/actions/runs/1113837386
Using https://github.com/amzn/ion-java/pull/368  as an new ion-java commit to invoke the workflow which has heap usage performance regression compares to https://github.com/amzn/ion-java/pull/369
The results is shown as this:
![image](https://user-images.githubusercontent.com/84819822/128791652-9cf74cb1-2e5c-4df0-8d87-504e345edd3e.png)

**Performance regression not detected test:**

Action link:
https://github.com/linlin-s/ion-java/actions/runs/1113787088
Using the ion-java commit without any change to invoke the workflow
The results is shown as this:
<img width="1289" alt="image" src="https://user-images.githubusercontent.com/84819822/128791726-94a518fd-6e34-48f7-9c2d-1c216c35af3b.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
