### PR TITLE
Adds an option to IonSystemBuilder to allow the incremental reader to be used by the DOM.

### DIFF
--- a/src/com/amazon/ion/impl/_Private_IncrementalReader.java
+++ b/src/com/amazon/ion/impl/_Private_IncrementalReader.java
@@ -1,0 +1,14 @@
+package com.amazon.ion.impl;
+
+/**
+ * Interface to be implemented by all incremental IonReaders. See
+ * {@link com.amazon.ion.system.IonReaderBuilder#withIncrementalReadingEnabled(boolean)}.
+ */
+public interface _Private_IncrementalReader {
+
+    /**
+     * Requires that the reader not currently be buffering an incomplete value.
+     * @throws com.amazon.ion.IonException if the reader is buffering an incomplete value.
+     */
+    void requireCompleteValue();
+}

--- a/src/com/amazon/ion/impl/_Private_IonReaderBuilder.java
+++ b/src/com/amazon/ion/impl/_Private_IonReaderBuilder.java
@@ -1,0 +1,172 @@
+package com.amazon.ion.impl;
+
+import com.amazon.ion.IonException;
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonTextReader;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.system.IonReaderBuilder;
+import com.amazon.ion.util.IonStreamUtils;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+
+import static com.amazon.ion.impl.LocalSymbolTable.DEFAULT_LST_FACTORY;
+import static com.amazon.ion.impl._Private_IonReaderFactory.makeIncrementalReader;
+import static com.amazon.ion.impl._Private_IonReaderFactory.makeReader;
+
+/**
+ * {@link IonReaderBuilder} extension for internal use only.
+ */
+public class _Private_IonReaderBuilder extends IonReaderBuilder {
+
+    private _Private_LocalSymbolTableFactory lstFactory;
+
+    private _Private_IonReaderBuilder() {
+        super();
+        lstFactory = DEFAULT_LST_FACTORY;
+    }
+
+    private _Private_IonReaderBuilder(_Private_IonReaderBuilder that) {
+        super(that);
+        this.lstFactory = that.lstFactory;
+    }
+
+    /**
+     * Declares the {@link _Private_LocalSymbolTableFactory} to use when constructing applicable readers.
+     *
+     * @param factory the factory to use, or {@link LocalSymbolTable#DEFAULT_LST_FACTORY} if null.
+     *
+     * @return this builder instance, if mutable;
+     * otherwise a mutable copy of this builder.
+     *
+     * @see #setLstFactory(_Private_LocalSymbolTableFactory)
+     */
+    public IonReaderBuilder withLstFactory(_Private_LocalSymbolTableFactory factory) {
+        _Private_IonReaderBuilder b = (_Private_IonReaderBuilder) mutable();
+        b.setLstFactory(factory);
+        return b;
+    }
+
+    /**
+     * @see #withLstFactory(_Private_LocalSymbolTableFactory)
+     */
+    public void setLstFactory(_Private_LocalSymbolTableFactory factory) {
+        mutationCheck();
+        if (factory == null) {
+            lstFactory = DEFAULT_LST_FACTORY;
+        } else {
+            lstFactory = factory;
+        }
+    }
+
+    public static class Mutable extends _Private_IonReaderBuilder {
+
+        public Mutable() {
+        }
+
+        public Mutable(IonReaderBuilder that) {
+            super((_Private_IonReaderBuilder) that);
+        }
+
+        @Override
+        public IonReaderBuilder immutable() {
+            return new _Private_IonReaderBuilder(this);
+        }
+
+        @Override
+        public IonReaderBuilder mutable() {
+            return this;
+        }
+
+        @Override
+        protected void mutationCheck() {
+        }
+
+    }
+
+    @Override
+    public IonReader build(byte[] ionData, int offset, int length)
+    {
+        if (isIncrementalReadingEnabled()) {
+            if (IonStreamUtils.isGzip(ionData, offset, length)) {
+                throw new IllegalArgumentException("Automatic GZIP detection is not supported with incremental" +
+                    "support enabled. Wrap the bytes with a GZIPInputStream and call build(InputStream).");
+            }
+            if (IonStreamUtils.isIonBinary(ionData, offset, length)) {
+                return makeIncrementalReader(this, new ByteArrayInputStream(ionData, offset, length));
+            }
+        }
+        return makeReader(validateCatalog(), ionData, offset, length, lstFactory);
+    }
+
+    /**
+     * Determines whether a stream that begins with the bytes in the provided buffer could be binary Ion.
+     * @param buffer up to the first four bytes in a stream.
+     * @param length the actual number of bytes in the buffer.
+     * @return true if the first 'length' bytes in 'buffer' match the first 'length' bytes in the binary IVM.
+     */
+    private static boolean startsWithIvm(byte[] buffer, int length) {
+        for (int i = 0; i < length; i++) {
+            if (_Private_IonConstants.BINARY_VERSION_MARKER_1_0[i] != buffer[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public IonReader build(InputStream ionData)
+    {
+        InputStream wrapper = ionData;
+        if (isIncrementalReadingEnabled()) {
+            if (!ionData.markSupported()) {
+                wrapper = new BufferedInputStream(ionData);
+            }
+            wrapper.mark(_Private_IonConstants.BINARY_VERSION_MARKER_SIZE);
+            byte[] possibleIVM = new byte[_Private_IonConstants.BINARY_VERSION_MARKER_SIZE];
+            int bytesRead;
+            try {
+                bytesRead = wrapper.read(possibleIVM);
+                wrapper.reset();
+            } catch (IOException e) {
+                throw new IonException(e);
+            }
+            if (IonStreamUtils.isGzip(possibleIVM, 0, possibleIVM.length)) {
+                throw new IllegalArgumentException("Automatic GZIP detection is not supported with incremental" +
+                    "support enabled. Wrap the bytes with a GZIPInputStream and call build(InputStream).");
+            }
+            // If the input stream is growing, it is possible that fewer than BINARY_VERSION_MARKER_SIZE bytes are
+            // available yet. Simply check whether the stream *could* contain binary Ion based on the available bytes.
+            // If it can't, fall back to text.
+            // NOTE: if incremental text reading is added, there will need to be logic that handles the case where
+            // the reader is created with 0 bytes available, as it is impossible to determine text vs. binary without
+            // reading at least one byte. Currently, in that case, just create a binary incremental reader. Either the
+            // stream will always be empty (in which case it doesn't matter whether a text or binary reader is used)
+            // or it's a binary stream (in which case the correct reader was created) or it's a growing text stream
+            // (which has always been unsupported).
+            if (startsWithIvm(possibleIVM, bytesRead)) {
+                return makeIncrementalReader(this, wrapper);
+            }
+        }
+        return makeReader(validateCatalog(), wrapper, lstFactory);
+    }
+
+    @Override
+    public IonReader build(Reader ionText) {
+        return makeReader(validateCatalog(), ionText, lstFactory);
+    }
+
+    @Override
+    public IonReader build(IonValue value) {
+        return makeReader(validateCatalog(), value, lstFactory);
+    }
+
+    @Override
+    public IonTextReader build(String ionText) {
+        return makeReader(validateCatalog(), ionText, lstFactory);
+    }
+
+}

--- a/src/com/amazon/ion/impl/_Private_IonReaderFactory.java
+++ b/src/com/amazon/ion/impl/_Private_IonReaderFactory.java
@@ -241,9 +241,10 @@ public final class _Private_IonReaderFactory
     }
 
     public static final IonReader makeReader(IonCatalog catalog,
-                                             IonValue value)
+                                             IonValue value,
+                                             _Private_LocalSymbolTableFactory lstFactory)
     {
-        return new IonReaderTreeUserX(value, catalog, LocalSymbolTable.DEFAULT_LST_FACTORY);
+        return new IonReaderTreeUserX(value, catalog, lstFactory);
     }
 
     public static final IonReader makeSystemReader(IonSystem system,

--- a/src/com/amazon/ion/impl/_Private_Utils.java
+++ b/src/com/amazon/ion/impl/_Private_Utils.java
@@ -879,6 +879,13 @@ public final class _Private_Utils
         } else {
             localSymbolTableAsStruct = (LocalSymbolTableAsStruct) new LocalSymbolTableAsStruct.Factory(valueFactory)
                     .newLocalSymtab(symtab.getSystemSymbolTable(), symtab.getImportedTables());
+            Iterator<String> localSymbolsIterator = symtab.iterateDeclaredSymbolNames();
+            while (localSymbolsIterator.hasNext()) {
+                String localSymbol = localSymbolsIterator.next();
+                if (localSymbol != null) {
+                    localSymbolTableAsStruct.intern(localSymbol);
+                }
+            }
         }
         return localSymbolTableAsStruct.getIonRepresentation();
     }

--- a/src/com/amazon/ion/impl/lite/IonLoaderLite.java
+++ b/src/com/amazon/ion/impl/lite/IonLoaderLite.java
@@ -15,8 +15,6 @@
 
 package com.amazon.ion.impl.lite;
 
-import static com.amazon.ion.impl._Private_IonReaderFactory.makeReader;
-
 import com.amazon.ion.IonCatalog;
 import com.amazon.ion.IonDatagram;
 import com.amazon.ion.IonException;
@@ -24,8 +22,10 @@ import com.amazon.ion.IonLoader;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonWriter;
+import com.amazon.ion.impl._Private_IncrementalReader;
 import com.amazon.ion.impl._Private_IonWriterFactory;
-import com.amazon.ion.impl._Private_LocalSymbolTableFactory;
+import com.amazon.ion.system.IonReaderBuilder;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -41,7 +41,7 @@ final class IonLoaderLite
     /** Not null. */
     private final IonCatalog    _catalog;
 
-    private final _Private_LocalSymbolTableFactory _lstFactory;
+    private final IonReaderBuilder _readerBuilder;
 
     /**
      * @param system must not be null.
@@ -54,7 +54,13 @@ final class IonLoaderLite
 
         _system = system;
         _catalog = catalog;
-        _lstFactory = _system.getLstFactory();
+        if (catalog == system.getCatalog()) {
+            _readerBuilder = system.getReaderBuilder();
+        } else {
+            // The IonCatalog provided in the constructor always takes precedence over the one already configured on the
+            // system's IonReaderBuilder.
+            _readerBuilder = system.getReaderBuilder().withCatalog(catalog).immutable();
+        }
     }
 
     public IonSystem getSystem()
@@ -99,7 +105,7 @@ final class IonLoaderLite
     public IonDatagram load(String ionText) throws IonException
     {
         try {
-            IonReader reader = makeReader(_catalog, ionText, _lstFactory);
+            IonReader reader = _readerBuilder.build(ionText);
             IonDatagramLite datagram = load_helper(reader);
             return datagram;
         }
@@ -111,7 +117,7 @@ final class IonLoaderLite
     public IonDatagram load(Reader ionText) throws IonException, IOException
     {
         try {
-            IonReader reader = makeReader(_catalog, ionText, _lstFactory);
+            IonReader reader = _readerBuilder.build(ionText);
             IonDatagramLite datagram = load_helper(reader);
             return datagram;
         }
@@ -124,7 +130,7 @@ final class IonLoaderLite
 
     public IonDatagram load(byte[] ionData) throws IonException
     {
-        IonReader reader = makeReader(_catalog, ionData, 0, ionData.length, _lstFactory);
+        IonReader reader = _readerBuilder.build(ionData, 0, ionData.length);
         try {
             return load(reader);
         }
@@ -142,14 +148,21 @@ final class IonLoaderLite
     public IonDatagram load(InputStream ionData)
         throws IonException, IOException
     {
+        IonReader reader = null;
         try {
-            IonReader reader = makeReader(_catalog, ionData, _lstFactory);
+            reader = _readerBuilder.build(ionData);
             return load(reader);
         }
         catch (IonException e) {
             IOException io = e.causeOfType(IOException.class);
             if (io != null) throw io;
             throw e;
+        } finally {
+            // If a value was incomplete, incremental readers will not yet have raised an error. Force an error
+            // to be raised in this case.
+            if (_readerBuilder.isIncrementalReadingEnabled() && reader instanceof _Private_IncrementalReader) {
+                ((_Private_IncrementalReader) reader).requireCompleteValue();
+            }
         }
     }
 

--- a/src/com/amazon/ion/impl/lite/IonSymbolLite.java
+++ b/src/com/amazon/ion/impl/lite/IonSymbolLite.java
@@ -308,8 +308,8 @@ final class IonSymbolLite
             return null;
         }
         String name = _stringValue(symbolTableProvider);
-        if (name == null && _sid != 0) {
-            assert(_sid > 0);
+        if (name == null) {
+            assert(_sid >= 0);
             throw new UnknownSymbolException(_sid);
         }
         return name;

--- a/src/com/amazon/ion/system/IonSystemBuilder.java
+++ b/src/com/amazon/ion/system/IonSystemBuilder.java
@@ -101,6 +101,7 @@ public class IonSystemBuilder
 
     IonCatalog myCatalog;
     boolean myStreamCopyOptimized = false;
+    IonReaderBuilder readerBuilder;
 
 
     /** You no touchy. */
@@ -113,6 +114,7 @@ public class IonSystemBuilder
     {
         this.myCatalog      = that.myCatalog;
         this.myStreamCopyOptimized = that.myStreamCopyOptimized;
+        this.readerBuilder = that.readerBuilder;
     }
 
     //=========================================================================
@@ -274,6 +276,59 @@ public class IonSystemBuilder
     //=========================================================================
 
     /**
+     * Gets the reader builder whose options will be used when building an
+     * {@link IonSystem}. By default, {@link IonReaderBuilder#standard()} will
+     * be used.
+     *
+     * @see #setReaderBuilder(IonReaderBuilder)
+     * @see #withReaderBuilder(IonReaderBuilder)
+     */
+    public final IonReaderBuilder getReaderBuilder() {
+        return readerBuilder;
+    }
+
+    /**
+     * Sets the reader builder whose options will be used to use when building
+     * an {@link IonSystem}. The reader builder's catalog will never be used; the
+     * catalog provided to {@link #setCatalog(IonCatalog)} or
+     * {@link #withCatalog(IonCatalog)} will always be used instead.
+     *
+     * @param builder the reader builder to use in built systems.
+     *  If null, each system will be built with {@link IonReaderBuilder#standard()}.
+     *
+     * @see #getReaderBuilder()
+     * @see #withReaderBuilder(IonReaderBuilder)
+     *
+     * @throws UnsupportedOperationException if this is immutable.
+     */
+    public final void setReaderBuilder(IonReaderBuilder builder) {
+        mutationCheck();
+        readerBuilder = builder;
+    }
+
+    /**
+     * Declares the reader builder whose options will be used to use when building
+     * an {@link IonSystem}, returning a new mutable builder if this is immutable.
+     * The reader builder's catalog will never be used; the catalog provided to
+     * {@link #setCatalog(IonCatalog)} or {@link #withCatalog(IonCatalog)} will
+     * always be used instead.
+     *
+     * @param builder the reader builder to use in built systems.
+     *  If null, each system will be built with {@link IonReaderBuilder#standard()}.
+     *
+     * @see #getReaderBuilder()
+     * @see #setReaderBuilder(IonReaderBuilder)
+     */
+    public final IonSystemBuilder withReaderBuilder(IonReaderBuilder builder)
+    {
+        IonSystemBuilder b = mutable();
+        b.setReaderBuilder(builder);
+        return b;
+    }
+
+    //=========================================================================
+
+    /**
      * Builds a new {@link IonSystem} instance based on this builder's
      * configuration properties.
      */
@@ -298,10 +353,9 @@ public class IonSystemBuilder
         bwb.setInitialSymbolTable(systemSymtab);
         // This is what we need, more or less.
 //        bwb = bwb.fillDefaults();
-        IonReaderBuilder rb = IonReaderBuilder.standard().withCatalog(catalog);
-        IonSystem sys = newLiteSystem(twb, bwb, rb);
-
-        return sys;
+        IonReaderBuilder rb = readerBuilder == null ? IonReaderBuilder.standard() : readerBuilder;
+        rb = rb.withCatalog(catalog);
+        return newLiteSystem(twb, bwb, rb);
     }
 
     //=========================================================================

--- a/test/com/amazon/ion/BinaryByteArrayIteratorSystemProcessingTest.java
+++ b/test/com/amazon/ion/BinaryByteArrayIteratorSystemProcessingTest.java
@@ -23,6 +23,11 @@ public class BinaryByteArrayIteratorSystemProcessingTest
 {
     private byte[] myBytes;
 
+    @Override
+    protected int expectedLocalNullSlotSymbolId()
+    {
+        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL ? 0 : 10;
+    }
 
     @Override
     protected void prepare(String text)

--- a/test/com/amazon/ion/BinaryStreamIteratorSystemProcessingTest.java
+++ b/test/com/amazon/ion/BinaryStreamIteratorSystemProcessingTest.java
@@ -26,6 +26,11 @@ public class BinaryStreamIteratorSystemProcessingTest
     private byte[] myBytes;
     private InputStream myStream;
 
+    @Override
+    protected int expectedLocalNullSlotSymbolId()
+    {
+        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL ? 0 : 10;
+    }
 
     @Override
     protected void prepare(String text)

--- a/test/com/amazon/ion/BinaryTest.java
+++ b/test/com/amazon/ion/BinaryTest.java
@@ -78,24 +78,6 @@ public class BinaryTest extends IonTestCase
     private IonValue ion(final String hex)
     {
         byte[] data = hexToBytes(MAGIC_COOKIE + hex);
-        // Note: when ion-java#379 is complete, the following branch should be removed.
-        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
-            IonReader reader = getStreamingMode().newIonReader(system().getCatalog(), data);
-            Iterator<IonValue> iterator = system().iterate(reader);
-            IonValue value = null;
-            if (iterator.hasNext()) {
-                value = iterator.next();
-            }
-            if (iterator.hasNext()) {
-                throw new IonException("not a single value");
-            }
-            try {
-                reader.close();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            return value;
-        }
         return system().singleValue(data);
     }
 

--- a/test/com/amazon/ion/DatagramTreeReaderSystemProcessingTest.java
+++ b/test/com/amazon/ion/DatagramTreeReaderSystemProcessingTest.java
@@ -40,6 +40,14 @@ public class DatagramTreeReaderSystemProcessingTest
         myDatagramMaker = maker;
     }
 
+    @Override
+    protected int expectedLocalNullSlotSymbolId()
+    {
+        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL  && myDatagramMaker.sourceIsBinary()
+            ? 0
+            : 10;
+    }
+
     /**
      * Load the datagram. The datagram is only loaded during
      * {@link #read()} and {@link #systemRead()}.

--- a/test/com/amazon/ion/IonSystemTest.java
+++ b/test/com/amazon/ion/IonSystemTest.java
@@ -29,12 +29,19 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.zip.GZIPOutputStream;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 
 public class IonSystemTest
     extends IonTestCase
 {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     //========================================================================
     // iterate(Reader)
 
@@ -312,6 +319,12 @@ public class IonSystemTest
         checkInt(1234, dg.get(0));
     }
 
+    private void expectIncrementalReaderToFail() {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            thrown.expect(IllegalArgumentException.class);
+        }
+    }
+
     @Test
     public void testGzipDetection()
         throws Exception
@@ -321,12 +334,14 @@ public class IonSystemTest
         byte[] gzipTextBytes = gzip(textBytes);
 
         checkGzipDetection(textBytes);
+        expectIncrementalReaderToFail();
         checkGzipDetection(gzipTextBytes);
 
         byte[] binaryBytes = loader().load(ionText).getBytes();
         byte[] gzipBinaryBytes = gzip(binaryBytes);
 
         checkGzipDetection(binaryBytes);
+        expectIncrementalReaderToFail();
         checkGzipDetection(gzipBinaryBytes);
     }
 
@@ -347,6 +362,7 @@ public class IonSystemTest
         String ionText = "1234";
         byte[] textBytes = _Private_Utils.utf8(ionText);
         byte[] gzipTextBytes = gzip(textBytes);
+        expectIncrementalReaderToFail();
         IonInt ionValue = (IonInt) system().singleValue(gzipTextBytes);
 
         assertEquals(1234, ionValue.intValue());
@@ -358,6 +374,7 @@ public class IonSystemTest
         String ionText = "1234";
         byte[] binaryIon = toBinaryIon(ionText);
         byte[] gzipBytes = gzip(binaryIon);
+        expectIncrementalReaderToFail();
         IonInt ionValue = (IonInt) system().singleValue(gzipBytes);
 
         assertEquals(1234, ionValue.intValue());

--- a/test/com/amazon/ion/LoadBinaryBytesSystemProcessingTest.java
+++ b/test/com/amazon/ion/LoadBinaryBytesSystemProcessingTest.java
@@ -23,6 +23,11 @@ public class LoadBinaryBytesSystemProcessingTest
 {
     private byte[] myBytes;
 
+    @Override
+    protected int expectedLocalNullSlotSymbolId()
+    {
+        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL ? 0 : 10;
+    }
 
     @Override
     protected void prepare(String text)

--- a/test/com/amazon/ion/LoadBinaryStreamSystemProcessingTest.java
+++ b/test/com/amazon/ion/LoadBinaryStreamSystemProcessingTest.java
@@ -24,6 +24,11 @@ public class LoadBinaryStreamSystemProcessingTest
 {
     private byte[] myBytes;
 
+    @Override
+    protected int expectedLocalNullSlotSymbolId()
+    {
+        return getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL ? 0 : 10;
+    }
 
     @Override
     protected void prepare(String text)

--- a/test/com/amazon/ion/impl/OptimizedBinaryWriterTestCase.java
+++ b/test/com/amazon/ion/impl/OptimizedBinaryWriterTestCase.java
@@ -180,7 +180,10 @@ public abstract class OptimizedBinaryWriterTestCase
 
         // TODO amzn/ion-java/issues/16 - Currently, doesn't copy annotations or field names,
         //      so we always expect no transfer of raw bytes
-        if (ir.isInStruct() || ir.getTypeAnnotationSymbols().length > 0)
+        // TODO amzn/ion-java/issues/381 - IonReaderBinaryIncremental currently doesn't support the byte transfer
+        //      facet. Once this is fixed, remove the `asFacet` check below.
+        if (ir.isInStruct() || ir.getTypeAnnotationSymbols().length > 0
+            || ir.asFacet(_Private_ByteTransferReader.class) == null)
         {
             expectedTransferInvoked = false;
         }

--- a/test/com/amazon/ion/streaming/OffsetSpanBinaryReaderTest.java
+++ b/test/com/amazon/ion/streaming/OffsetSpanBinaryReaderTest.java
@@ -65,6 +65,11 @@ public class OffsetSpanBinaryReaderTest
     @Test
     public void testCurrentSpanBeyondMaxInt()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         IonDatagram dg = system().newDatagram();
         dg.add().newBlob(new byte[2000]);
         byte[] binary = dg.getBytes();
@@ -80,6 +85,11 @@ public class OffsetSpanBinaryReaderTest
     @Test
     public void testCurrentSpanBeyondMaxIntForOrderedStruct()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         // Value is ordered-struct { name:{{ /* 1024 bytes */}} }
 
         byte[] data = hexToBytes("E0 01 00 EA "

--- a/test/com/amazon/ion/streaming/OffsetSpanReaderTest.java
+++ b/test/com/amazon/ion/streaming/OffsetSpanReaderTest.java
@@ -55,6 +55,11 @@ public class OffsetSpanReaderTest
     @Test
     public void testCurrentSpan()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         read("'''hello''' 1 2 3 4 5 6 7 8 9 10 '''Kumo the fluffy dog! He is so fluffy and yet so happy!'''");
         assertSame(IonType.STRING, in.next());
         checkCurrentSpan(4, 10, 0);
@@ -72,6 +77,11 @@ public class OffsetSpanReaderTest
 
     @Test
     public void testCurrentSpanFromStreamMed() throws IOException {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         final ByteArrayOutputStream buf = new ByteArrayOutputStream();
         final int count = 8000;
         for (int i = 0; i < count; i++) {

--- a/test/com/amazon/ion/streaming/SeekableReaderTest.java
+++ b/test/com/amazon/ion/streaming/SeekableReaderTest.java
@@ -58,6 +58,11 @@ public class SeekableReaderTest
     @Test
     public void testTrivialSpan()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         String text = "null";
         read(text);
         in.next();
@@ -73,6 +78,11 @@ public class SeekableReaderTest
     @Test
     public void testWalkingBackwards()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         String text =
             "null true 3 4e0 5.0 6666-06-06T '7' \"8\" {{\"\"}} {{}} [] () {}";
 
@@ -113,6 +123,11 @@ public class SeekableReaderTest
     @Test
     public void testHoistingWithinContainers()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         read("{f:v,g:[c, (d), e], /* h */ $0:null} s");
 
         in.next();
@@ -188,6 +203,11 @@ public class SeekableReaderTest
     @Test
     public void testHoistingLongValue()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         // This value is "long" in that it has a length subfield in the prefix.
         String text = " \"123456789012345\" ";
         read(text);
@@ -205,6 +225,11 @@ public class SeekableReaderTest
     public void testHoistingOrderedStruct()
     throws IOException
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         File file = getTestdataFile("good/structOrdered.10n");
         byte[] binary = _Private_Utils.loadFileBytes(file);
 
@@ -224,6 +249,11 @@ public class SeekableReaderTest
     public void testHoistingAnnotatedTopLevelValue()
         throws IOException
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         read("a::v");
         in.next();
         Span span = sr.currentSpan();
@@ -241,6 +271,11 @@ public class SeekableReaderTest
     public void testHoistingAnnotatedContainedValue()
         throws IOException
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         read("[a::v]");
         in.next();
         in.stepIn();

--- a/test/com/amazon/ion/streaming/SpanReaderTest.java
+++ b/test/com/amazon/ion/streaming/SpanReaderTest.java
@@ -43,6 +43,11 @@ public class SpanReaderTest
     @Test
     public void testCallingCurrentSpan()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         String text =
             "null true 3 4e0 5.0 6666-06-06T '7' \"8\" {{\"\"}} {{}} [] () {}";
 
@@ -80,6 +85,11 @@ public class SpanReaderTest
     @Test
     public void testCurrentSpanWithinContainers()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         read("{f:v,g:[c]} s");
 
         in.next();
@@ -110,6 +120,11 @@ public class SpanReaderTest
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanBeforeFirstTopLevel()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            throw new IllegalStateException();
+        }
         read("foo");
         sp.currentSpan();
     }
@@ -117,6 +132,11 @@ public class SpanReaderTest
 
     private void callCurrentSpanBeforeFirstChild(String ionText)
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         read(ionText);
         in.next();
         in.stepIn();
@@ -126,24 +146,44 @@ public class SpanReaderTest
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanBeforeFirstListChild()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            throw new IllegalStateException();
+        }
         callCurrentSpanBeforeFirstChild("[v]");
     }
 
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanBeforeFirstSexpChild()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            throw new IllegalStateException();
+        }
         callCurrentSpanBeforeFirstChild("(v)");
     }
 
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanBeforeFirstStructChild()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            throw new IllegalStateException();
+        }
         callCurrentSpanBeforeFirstChild("{f:v}");
     }
 
 
     private void callCurrentSpanAfterLastChild(String ionText)
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            return;
+        }
         read(ionText);
         in.next();
         in.stepIn();
@@ -155,18 +195,33 @@ public class SpanReaderTest
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanAfterLastListChild()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            throw new IllegalStateException();
+        }
         callCurrentSpanAfterLastChild("[v]");
     }
 
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanAfterLastSexpChild()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            throw new IllegalStateException();
+        }
         callCurrentSpanAfterLastChild("(v)");
     }
 
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanAfterLastStructChild()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            throw new IllegalStateException();
+        }
         callCurrentSpanAfterLastChild("{f:v}");
     }
 
@@ -174,6 +229,11 @@ public class SpanReaderTest
     @Test(expected=IllegalStateException.class)
     public void testCurrentSpanAtEndOfStream()
     {
+        if (getStreamingMode() == StreamingMode.NEW_STREAMING_INCREMENTAL) {
+            // TODO the incremental reader does not currently support the SpanProvider or SeekableReader facets.
+            //      See ion-java/issues/382 and ion-java/issues/383.
+            throw new IllegalStateException();
+        }
         read("foo");
         in.next();
         assertEquals(null, in.next());


### PR DESCRIPTION
*Issue #, if available:*
#379 

*Description of changes:*

Adds an option to IonSystemBuilder to allow IonSystem to create incremental readers via `IonSystem.newReader`, `IonSystem.singleValue`, `IonLoader.load`, and `IonSystem.iterate`. This allows users of the DOM to receive some performance benefits of the new reader implementation, although these benefits are not as dramatic as when the reader is used directly since more of the time is spent materializing IonValue objects.

Here's one example:
```
Benchmark                               (input)                                            (options)  Mode  Cnt          Score           Error   Units
Bench.run                               log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5        490.506 ±        10.695   ms/op
Bench.run:Heap usage                    log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5        859.538 ±         2.035      MB
Bench.run:Serialized size               log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5         22.263                      MB
Bench.run:·gc.alloc.rate                log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5        816.114 ±         8.965  MB/sec
Bench.run:·gc.alloc.rate.norm           log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5  852803812.800 ±        67.491    B/op
Bench.run:·gc.count                     log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5            ≈ 0                  counts
Bench.run                               log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5        675.353 ±        36.249   ms/op
Bench.run:Heap usage                    log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5        923.788 ±         1.975      MB
Bench.run:Serialized size               log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5         22.263                      MB
Bench.run:·gc.alloc.rate                log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5        734.860 ±        22.610  MB/sec
Bench.run:·gc.alloc.rate.norm           log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5  910537892.800 ±      1007.569    B/op
Bench.run:·gc.count                     log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5            ≈ 0                  counts
```

That's a 27% improvement, while using the readers directly over the same data results in a 47% improvement.

This also allows users to use the DOM incrementally using `IonLoader.load(IonReader)`, `IonSystem.iterate(InputStream)`, and `IonSystem.iterate(IonReader)`. See examples in the tests added to IonReaderBinaryIncrementalTest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
