### PR TITLE
Adds caching of the IonStruct representations of local symbol tables …

### DIFF
--- a/src/com/amazon/ion/impl/SymbolTableAsStruct.java
+++ b/src/com/amazon/ion/impl/SymbolTableAsStruct.java
@@ -1,0 +1,18 @@
+package com.amazon.ion.impl;
+
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.SymbolTable;
+import com.amazon.ion.ValueFactory;
+
+/**
+ * Identifies {@link SymbolTable} implementations capable of producing IonStruct representations of themselves.
+ */
+interface SymbolTableAsStruct {
+
+    /**
+     * Provides an IonStruct representation of the SymbolTable.
+     * @param valueFactory the {@link ValueFactory} from which to construct the IonStruct.
+     * @return an IonStruct representing the SymbolTable.
+     */
+    IonStruct getIonRepresentation(ValueFactory valueFactory);
+}

--- a/src/com/amazon/ion/impl/SymbolTableStructCache.java
+++ b/src/com/amazon/ion/impl/SymbolTableStructCache.java
@@ -1,0 +1,137 @@
+package com.amazon.ion.impl;
+
+import com.amazon.ion.IonList;
+import com.amazon.ion.IonStruct;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.SymbolTable;
+import com.amazon.ion.ValueFactory;
+
+import java.util.Iterator;
+
+import static com.amazon.ion.SystemSymbols.IMPORTS;
+import static com.amazon.ion.SystemSymbols.ION_SYMBOL_TABLE;
+import static com.amazon.ion.SystemSymbols.MAX_ID;
+import static com.amazon.ion.SystemSymbols.NAME;
+import static com.amazon.ion.SystemSymbols.SYMBOLS;
+import static com.amazon.ion.SystemSymbols.VERSION;
+
+/**
+ * Caches the IonStruct representation of a {@link SymbolTable}.
+ */
+class SymbolTableStructCache {
+
+    private final SymbolTable symbolTable;
+    private final SymbolTable[] importedTables;
+    private final int firstLocalSid;
+
+    /**
+     * Memoized result of {@link #getIonRepresentation(ValueFactory)};
+     * Once this is created, it may be mutated as symbols are added using {@link #addSymbol(String, int)}.
+     */
+    private IonStruct image;
+
+    /**
+     * @param symbolTable the SymbolTable to represent as an IonStruct.
+     * @param importedTables the symbol table's imported shared symbol tables.
+     * @param image the IonStruct representation, if available. If null, an IonStruct will be created lazily.
+     */
+    SymbolTableStructCache(SymbolTable symbolTable, SymbolTable[] importedTables, IonStruct image) {
+        this.symbolTable = symbolTable;
+        this.importedTables = importedTables;
+        this.firstLocalSid = symbolTable.getImportedMaxId() + 1;
+        this.image = image;
+    }
+
+    /**
+     * Returns the IonStruct representation of the symbol table. Creates and stores a new IonStruct on the first
+     * invocation.
+     * @param factory the {@link ValueFactory} from which to construct the IonStruct.
+     * @return an IonStruct representing the symbol table.
+     */
+    public IonStruct getIonRepresentation(ValueFactory factory) {
+        synchronized (this) {
+            if (image == null) {
+                makeIonRepresentation(factory);
+            }
+            return image;
+        }
+    }
+
+    /**
+     * @return true if an IonStruct has already been created for the symbol table; otherwise, false.
+     */
+    public boolean hasStruct() {
+        return image != null;
+    }
+
+    /**
+     * Create a new IonStruct representation of the symbol table.
+     * @param factory the {@link ValueFactory} from which to construct the IonStruct.
+     */
+    private void makeIonRepresentation(ValueFactory factory) {
+        image = factory.newEmptyStruct();
+
+        image.addTypeAnnotation(ION_SYMBOL_TABLE);
+
+        if (importedTables.length > 0) {
+            // The system symbol table may be the first import. If it is, skip it.
+            int i = importedTables[0].isSystemTable() ? 1 : 0;
+            if (i < importedTables.length) {
+                IonList importsList = factory.newEmptyList();
+                while (i < importedTables.length) {
+                    SymbolTable importedTable = importedTables[i];
+                    IonStruct importStruct = factory.newEmptyStruct();
+
+                    importStruct.add(NAME,
+                        factory.newString(importedTable.getName()));
+                    importStruct.add(VERSION,
+                        factory.newInt(importedTable.getVersion()));
+                    importStruct.add(MAX_ID,
+                        factory.newInt(importedTable.getMaxId()));
+
+                    importsList.add(importStruct);
+                    i++;
+                }
+                image.add(IMPORTS, importsList);
+            }
+        }
+
+        if (symbolTable.getMaxId() > symbolTable.getImportedMaxId()) {
+            Iterator<String> localSymbolIterator = symbolTable.iterateDeclaredSymbolNames();
+            int sid = symbolTable.getImportedMaxId() + 1;
+            while (localSymbolIterator.hasNext()) {
+                addSymbol(localSymbolIterator.next(), sid);
+                sid++;
+            }
+        }
+    }
+
+    /**
+     * Adds a new symbol table with the given symbol ID to the IonStruct's 'symbols' list.
+     * @param symbolName can be null when there's a gap in the local symbols list.
+     * @param sid the symbol ID to assign to the new symbol.
+     */
+    void addSymbol(String symbolName, int sid) {
+        assert sid >= firstLocalSid;
+
+        ValueFactory sys = image.getSystem();
+
+        IonValue syms = image.get(SYMBOLS);
+        // If the user has manually created a symbol table via an IonStruct, it may be malformed.
+        // The following removes any "symbols" fields that aren't lists, then creates a list for
+        // the symbols field if necessary.
+        while (syms != null && syms.getType() != IonType.LIST) {
+            image.remove(syms);
+            syms = image.get(SYMBOLS);
+        }
+        if (syms == null) {
+            syms = sys.newEmptyList();
+            image.put(SYMBOLS, syms);
+        }
+
+        int thisOffset = sid - firstLocalSid;
+        IonValue name = sys.newString(symbolName);
+        ((IonList) syms).add(thisOffset, name);
+    }
+}

--- a/src/com/amazon/ion/impl/_Private_Utils.java
+++ b/src/com/amazon/ion/impl/_Private_Utils.java
@@ -873,21 +873,23 @@ public final class _Private_Utils
      */
     public static IonStruct symtabTree(SymbolTable symtab, ValueFactory valueFactory)
     {
-        LocalSymbolTableAsStruct localSymbolTableAsStruct;
-        if (symtab instanceof  LocalSymbolTableAsStruct) {
-            localSymbolTableAsStruct = (LocalSymbolTableAsStruct) symtab;
+        SymbolTableAsStruct localSymbolTableAsStruct;
+        if (symtab instanceof SymbolTableAsStruct) {
+            localSymbolTableAsStruct = (SymbolTableAsStruct) symtab;
         } else {
-            localSymbolTableAsStruct = (LocalSymbolTableAsStruct) new LocalSymbolTableAsStruct.Factory(valueFactory)
+            LocalSymbolTableAsStruct table =
+                (LocalSymbolTableAsStruct) new LocalSymbolTableAsStruct.Factory(valueFactory)
                     .newLocalSymtab(symtab.getSystemSymbolTable(), symtab.getImportedTables());
             Iterator<String> localSymbolsIterator = symtab.iterateDeclaredSymbolNames();
             while (localSymbolsIterator.hasNext()) {
                 String localSymbol = localSymbolsIterator.next();
                 if (localSymbol != null) {
-                    localSymbolTableAsStruct.intern(localSymbol);
+                    table.intern(localSymbol);
                 }
             }
+            localSymbolTableAsStruct = table;
         }
-        return localSymbolTableAsStruct.getIonRepresentation();
+        return localSymbolTableAsStruct.getIonRepresentation(valueFactory);
     }
 
     /**


### PR DESCRIPTION
…created by the incremental reader, improving performance for repetitive system iterates/gets.

*Description of changes:*
Note: depends on #385 

When users work with `IonDatagram`, they have the option to use `IonDatagram.systemIterate()` and `IonDatagram.systemGet()` to retrieve IonValue representations of system values, including symbol tables. The existing implementations went to great lengths to avoid having to re-create the IonStruct representation of the same symbol table more than once. This was achieved via `LocalSymbolTableAsStruct`, a SymbolTable implementation that lazily memoizes its IonStruct representation. The initial implementation of `IonReaderBinaryIncremental` contained no memoization.

I used `ion-java-benchmark-cli` to measure the impact of this by `load()`ing an IonDatagram and `systemIterate()`ing over it 10 times. Here are the results before the change proposed in this PR:

```
Benchmark                                   (input)                                            (options)  Mode  Cnt           Score           Error   Units
Bench.run                                   log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5        1654.691 ±      2009.406   ms/op
Bench.run:Heap usage                        log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5         908.400 ±         5.236      MB
Bench.run:Serialized size                   log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5          22.263                      MB
Bench.run:·gc.alloc.rate                    log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5         622.364 ±       437.103  MB/sec
Bench.run:·gc.alloc.rate.norm               log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5  1360856316.800 ±        67.491    B/op
Bench.run:·gc.churn.PS_Eden_Space           log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5         436.389 ±       306.488  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm      log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5   954204160.000 ±         0.001    B/op
Bench.run:·gc.churn.PS_Survivor_Space       log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5          79.674 ±        43.507  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm  log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5   185512774.400 ± 298267471.311    B/op
Bench.run:·gc.count                         log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5          11.000                  counts
Bench.run:·gc.time                          log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5        2310.000                      ms

Bench.run                                   log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5         824.175 ±        31.864   ms/op
Bench.run:Heap usage                        log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5         496.964 ±         2.579      MB
Bench.run:Serialized size                   log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5          22.263                      MB
Bench.run:·gc.alloc.rate                    log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5         401.647 ±         9.411  MB/sec
Bench.run:·gc.alloc.rate.norm               log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5   560459308.800 ±      1007.569    B/op
Bench.run:·gc.churn.PS_Eden_Space           log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5         341.910 ±         8.011  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm      log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5   477102080.000 ±         0.001    B/op
Bench.run:·gc.count                         log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5           5.000                  counts
Bench.run:·gc.time                          log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5         375.000                      ms
```
The incremental reader took twice as long.

Here are the results after the change.

```
Benchmark                               (input)                                            (options)  Mode  Cnt          Score           Error   Units
Bench.run                               log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5        768.055 ±        36.275   ms/op
Bench.run:Heap usage                    log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5        561.020 ±        43.898      MB
Bench.run:Serialized size               log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5         22.263                      MB
Bench.run:·gc.alloc.rate                log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5        477.734 ±        13.285  MB/sec
Bench.run:·gc.alloc.rate.norm           log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5  638322667.200 ±       110.212    B/op
Bench.run:·gc.churn.PS_Eden_Space       log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5        324.339 ±       142.945  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm  log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5  433586176.000 ± 199304214.371    B/op
Bench.run:·gc.count                     log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5          5.000                  counts
Bench.run:·gc.time                      log.ion      read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}    ss    5        318.000                      ms
Bench.run                               log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5        773.216 ±        30.664   ms/op
Bench.run:Heap usage                    log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5        496.899 ±         3.553      MB
Bench.run:Serialized size               log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5         22.263                      MB
Bench.run:·gc.alloc.rate                log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5        417.698 ±         9.869  MB/sec
Bench.run:·gc.alloc.rate.norm           log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5  560460067.200 ±      1590.513    B/op
Bench.run:·gc.churn.PS_Eden_Space       log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5        355.573 ±         8.401  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm  log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5  477102080.000 ±         0.001    B/op
Bench.run:·gc.count                     log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5          5.000                  counts
Bench.run:·gc.time                      log.ion  read::{f:ION_BINARY,t:FILE,a:DOM,R:NON_INCREMENTAL}    ss    5        374.000                      ms
```

Both readers take the same amount of time (which is dominated by materializing and iterating the IonDatagram, not parsing).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
