### PR TITLE
Updates actions/setup-java to v2 in Github Actions main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,9 @@ jobs:
         with:
           submodules: recursive
       - name: Use java ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - run: mvn test
       - run: mvn package -f ion-java-cli/pom.xml


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Upgrades from `actions/setup-java@v1` to `actions/setup-java@v2`. v2 is the current version, and it's harder to find the documentation for the old version now.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
