### PR TITLE
Adds a pool of UTF-8 decoders, making reader instantiation less expensive.

### DIFF
--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -126,7 +126,7 @@ import java.util.NoSuchElementException;
 
     final Utf8StringEncoder utf8StringEncoder = Utf8StringEncoderPool
             .getInstance()
-            .getOrCreateUtf8Encoder();
+            .getOrCreate();
 
     private static final byte[] makeTypedPreallocatedBytes(final int typeDesc, final int length)
     {

--- a/src/com/amazon/ion/impl/bin/utf8/ByteBufferPool.java
+++ b/src/com/amazon/ion/impl/bin/utf8/ByteBufferPool.java
@@ -1,0 +1,26 @@
+package com.amazon.ion.impl.bin.utf8;
+
+/**
+ * A thread-safe shared pool of {@link PoolableByteBuffer}s.
+ */
+public class ByteBufferPool extends Pool<PoolableByteBuffer> {
+
+    private static final ByteBufferPool INSTANCE = new ByteBufferPool();
+
+    // Do not allow instantiation; all classes should share the singleton instance.
+    private ByteBufferPool() {
+        super(new Allocator<PoolableByteBuffer>() {
+            @Override
+            public PoolableByteBuffer newInstance(Pool<PoolableByteBuffer> pool) {
+                return new PoolableByteBuffer(pool);
+            }
+        });
+    }
+
+    /**
+     * @return a threadsafe shared instance of {@link ByteBufferPool}.
+     */
+    public static ByteBufferPool getInstance() {
+        return INSTANCE;
+    }
+}

--- a/src/com/amazon/ion/impl/bin/utf8/Pool.java
+++ b/src/com/amazon/ion/impl/bin/utf8/Pool.java
@@ -1,0 +1,64 @@
+package com.amazon.ion.impl.bin.utf8;
+
+import java.util.concurrent.ArrayBlockingQueue;
+
+abstract class Pool<T extends Poolable<?>> {
+
+    /**
+     * Allocates objects to be pooled.
+     * @param <T> the type of object.
+     */
+    interface Allocator<T extends Poolable<?>> {
+
+        /**
+         * Allocate a new object and link it to the given pool.
+         * @param pool the pool to which the new object will be linked.
+         * @return a new instance.
+         */
+        T newInstance(Pool<T> pool);
+    }
+
+    // The maximum number of objects that can be waiting in the queue before new ones will be discarded.
+    private static final int MAX_QUEUE_SIZE = 128;
+
+    // A queue of previously initialized objects that can be loaned out.
+    private final ArrayBlockingQueue<T> bufferQueue;
+
+    // Allocator of objects to be pooled.
+    private final Allocator<T> allocator;
+
+    Pool(Allocator<T> allocator) {
+        this.allocator = allocator;
+        bufferQueue = new ArrayBlockingQueue<T>(MAX_QUEUE_SIZE);
+    }
+
+    /**
+     * If the pool is not empty, removes an object from the pool and returns it;
+     * otherwise, constructs a new object.
+     *
+     * @return An object.
+     */
+    public T getOrCreate() {
+        // The `poll` method does not block. If the queue is empty it returns `null` immediately.
+        T object = bufferQueue.poll();
+        if (object == null) {
+            // No buffers were available in the pool. Create a new one.
+            object = allocator.newInstance(this);
+        }
+        return object;
+    }
+
+    /**
+     * Adds the provided instance to the pool. If the pool is full, the instance will
+     * be discarded.
+     *
+     * Callers MUST NOT use an object after returning it to the pool.
+     *
+     * @param object   An object to add to the pool.
+     */
+    public void returnToPool(T object) {
+        // The `offer` method does not block. If the queue is full, it returns `false` immediately.
+        // If the provided instance cannot be added to the pool, we discard it silently.
+        bufferQueue.offer(object);
+    }
+}

--- a/src/com/amazon/ion/impl/bin/utf8/Poolable.java
+++ b/src/com/amazon/ion/impl/bin/utf8/Poolable.java
@@ -1,0 +1,30 @@
+package com.amazon.ion.impl.bin.utf8;
+
+import java.io.Closeable;
+
+/**
+ * Base class for types that may be pooled.
+ * @param <T> the concrete type.
+ */
+abstract class Poolable<T extends Poolable<T>> implements Closeable {
+
+    // The pool to which this object is linked.
+    private final Pool<T> pool;
+
+    /**
+     * @param pool the pool to which the object will be returned upon {@link #close()}.
+     */
+    Poolable(Pool<T> pool) {
+        this.pool = pool;
+    }
+
+    /**
+     * Attempts to return this instance to the pool with which it is associated, if any.
+     *
+     * Do not continue to use this instance after calling this method.
+     */
+    @Override
+    public void close() {
+        pool.returnToPool((T) this);
+    }
+}

--- a/src/com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java
+++ b/src/com/amazon/ion/impl/bin/utf8/PoolableByteBuffer.java
@@ -1,0 +1,33 @@
+package com.amazon.ion.impl.bin.utf8;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Holds a reusable {@link ByteBuffer}. Instances of this class are reusable but are NOT threadsafe.
+ *
+ * Instances are vended by {@link ByteBufferPool#getOrCreate()}.
+ *
+ * Users are expected to call {@link #close()} when the decoder is no longer needed.
+ */
+public class PoolableByteBuffer extends Poolable<PoolableByteBuffer> {
+
+    static final int BUFFER_SIZE_IN_BYTES = 4 * 1024;
+
+    // The reusable buffer.
+    private final ByteBuffer buffer;
+
+    /**
+     * @param pool the pool to which the object will be returned upon {@link #close()}.
+     */
+    PoolableByteBuffer(Pool<PoolableByteBuffer> pool) {
+        super(pool);
+        buffer = ByteBuffer.allocate(BUFFER_SIZE_IN_BYTES);
+    }
+
+    /**
+     * @return the buffer.
+     */
+    public ByteBuffer getBuffer() {
+        return buffer;
+    }
+}

--- a/src/com/amazon/ion/impl/bin/utf8/Utf8StringDecoder.java
+++ b/src/com/amazon/ion/impl/bin/utf8/Utf8StringDecoder.java
@@ -1,0 +1,97 @@
+package com.amazon.ion.impl.bin.utf8;
+
+import com.amazon.ion.IonException;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
+
+/**
+ * Decodes {@link String}s from UTF-8. Instances of this class are reusable but are NOT threadsafe.
+ *
+ * Instances are vended by {@link Utf8StringDecoderPool#getOrCreate()}.
+ *
+ * Users are expected to call {@link #close()} when the decoder is no longer needed.
+ *
+ * There are two ways of using this class:
+ * <ol>
+ *     <li>Use {@link #decode(ByteBuffer, int)} to decode the requested number of bytes from the given ByteBuffer in
+ *     a single step. Or,</li>
+ *     <li>Use the following sequence of method calls:
+ *     <ol>
+ *         <li>{@link #prepareDecode(int)} to prepare the decoder to decode the requested number of bytes.</li>
+ *         <li>{@link #partialDecode(ByteBuffer, boolean)} to decode the available bytes from the byte buffer. This may
+ *         be repeated as more bytes are made available in the ByteBuffer, which is the caller's responsibility.</li>
+ *         <li>{@link #finishDecode()} to finish decoding and return the resulting String.</li>
+ *     </ol>
+ *     Note: {@link #decode(ByteBuffer, int)} must not be called between calls to {@link #prepareDecode(int)} and
+ *     {@link #finishDecode()}.
+ *     </li>
+ * </ol>
+ */
+public class Utf8StringDecoder extends Poolable<Utf8StringDecoder> {
+
+    // The size of the UTF-8 decoding buffer.
+    private static final int UTF8_BUFFER_SIZE_IN_BYTES = 4 * 1024;
+
+    private final CharBuffer reusableUtf8DecodingBuffer;
+    private final CharsetDecoder utf8CharsetDecoder;
+    private CharBuffer utf8DecodingBuffer;
+
+    Utf8StringDecoder(Pool<Utf8StringDecoder> pool) {
+        super(pool);
+        reusableUtf8DecodingBuffer = CharBuffer.allocate(UTF8_BUFFER_SIZE_IN_BYTES);
+        utf8CharsetDecoder = Charset.forName("UTF-8").newDecoder();
+    }
+
+    /**
+     * Prepares the decoder to decode the given number of UTF-8 bytes.
+     * @param numberOfBytes the number of bytes to decode.
+     */
+    public void prepareDecode(int numberOfBytes) {
+        utf8CharsetDecoder.reset();
+        utf8DecodingBuffer = reusableUtf8DecodingBuffer;
+        if (numberOfBytes > reusableUtf8DecodingBuffer.capacity()) {
+            utf8DecodingBuffer = CharBuffer.allocate(numberOfBytes);
+        }
+    }
+
+    /**
+     * Decodes the available bytes from the given ByteBuffer.
+     * @param utf8InputBuffer a ByteBuffer containing UTF-8 bytes.
+     * @param endOfInput true if the end of the UTF-8 sequence is expected to occur in the buffer; otherwise, false.
+     */
+    public void partialDecode(ByteBuffer utf8InputBuffer, boolean endOfInput) {
+        CoderResult coderResult = utf8CharsetDecoder.decode(utf8InputBuffer, utf8DecodingBuffer, endOfInput);
+        if (coderResult.isError()) {
+            throw new IonException("Illegal value encountered while validating UTF-8 data in input stream. " + coderResult.toString());
+        }
+    }
+
+    /**
+     * Finishes decoding and returns the resulting String.
+     * @return the decoded Java String.
+     */
+    public String finishDecode() {
+        utf8DecodingBuffer.flip();
+        return utf8DecodingBuffer.toString();
+    }
+
+    /**
+     * Decodes the given number of UTF-8 bytes from the given ByteBuffer into a Java String.
+     * @param utf8InputBuffer a ByteBuffer containing UTF-8 bytes.
+     * @param numberOfBytes the number of bytes from the utf8InputBuffer to decode.
+     * @return the decoded Java String.
+     */
+    public String decode(ByteBuffer utf8InputBuffer, int numberOfBytes) {
+        prepareDecode(numberOfBytes);
+
+        utf8DecodingBuffer.position(0);
+        utf8DecodingBuffer.limit(utf8DecodingBuffer.capacity());
+
+        partialDecode(utf8InputBuffer, true);
+        return finishDecode();
+    }
+}

--- a/src/com/amazon/ion/impl/bin/utf8/Utf8StringDecoderPool.java
+++ b/src/com/amazon/ion/impl/bin/utf8/Utf8StringDecoderPool.java
@@ -1,0 +1,26 @@
+package com.amazon.ion.impl.bin.utf8;
+
+/**
+ * A thread-safe shared pool of {@link Utf8StringDecoder}s that can be used for UTF8 decoding.
+ */
+public class Utf8StringDecoderPool extends Pool<Utf8StringDecoder> {
+
+    private static final Utf8StringDecoderPool INSTANCE = new Utf8StringDecoderPool();
+
+    // Do not allow instantiation; all classes should share the singleton instance.
+    private Utf8StringDecoderPool() {
+        super(new Allocator<Utf8StringDecoder>() {
+            @Override
+            public Utf8StringDecoder newInstance(Pool<Utf8StringDecoder> pool) {
+                return new Utf8StringDecoder(pool);
+            }
+        });
+    }
+
+    /**
+     * @return a threadsafe shared instance of {@link Utf8StringDecoderPool}.
+     */
+    public static Utf8StringDecoderPool getInstance() {
+        return INSTANCE;
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
Fixes #370 

*Description of changes:*
1. Created generic base classes for poolable objects (`Poolable` - the negative diff for `Utf8StringEncoder` shows what was extracted) and for pools of poolable objects (`Pool` - the negative diff for `Utf8StringEncoderPool` shows what was extracted).
2. Created `Utf8StringDecoder` (extends `Poolable`) and `Utf8StringDecoderPool` (extends `Pool`) to provide reusable logic and character buffers for decoding UTF-8 strings.
3. Modified `IonReaderBinaryIncremental` (the new incremental binary reader) and `IonReaderBinaryRawX` (the old binary reader) to use `Utf8StringDecoderPool` and `Utf8StringDecoder`.
4. Because `IonReaderBinaryRawX` requires an additional `ByteBuffer` for its string decoding (not required by the incremental reader), created `PoolableByteBuffer` (extends `Poolable`) and `ByteBufferPool` (extends `Pool`) to provide reusable `ByteBuffer`s to this reader.

This takes care of a lot of the expense that comes with instantiating binary readers. To test, I benchmarked a loop like the following on a binary Ion file containing only `"foo"` (using a manual change to [`ion-java-benchmark-cli`](https://github.com/amzn/ion-java-benchmark-cli) that I plan to add as a proper option [at some point](https://github.com/amzn/ion-java-benchmark-cli/issues/12)):

```java
for (int i = 0; i < 10000; i++) {
    IonReader reader = readerBuilder.build(buffer);
    fullyTraverse(reader, false);
    reader.close();
}
```

Results before the proposed change:

```
Benchmark                                               (input)                                                    (options)  Mode  Cnt          Score         Error   Units
Bench.run                                   singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3       6136.583 ±    1525.138   us/op
Bench.run:Heap usage                        singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3        218.982 ±    4715.263      MB
Bench.run:Serialized size                   singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3         ≈ 10⁻⁵                    MB
Bench.run:·gc.alloc.rate                    singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3      14709.968 ±    3647.687  MB/sec
Bench.run:·gc.alloc.rate.norm               singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3   99440016.278 ±       0.260    B/op
Bench.run:·gc.churn.PS_Eden_Space           singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3      14694.721 ±    4046.463  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm      singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3   99335597.947 ± 3029246.426    B/op
Bench.run:·gc.churn.PS_Survivor_Space       singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3          0.144 ±       0.273  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm  singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3        971.336 ±    1938.260    B/op
Bench.run:·gc.count                         singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3        703.000                counts
Bench.run:·gc.time                          singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3        272.000                    ms

Bench.run                                   singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3       7526.666 ±     588.629   us/op
Bench.run:Heap usage                        singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3        700.571 ±    3701.472      MB
Bench.run:Serialized size                   singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3         ≈ 10⁻⁵                    MB
Bench.run:·gc.alloc.rate                    singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3      16081.923 ±    1245.981  MB/sec
Bench.run:·gc.alloc.rate.norm               singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3  133360016.341 ±       0.232    B/op
Bench.run:·gc.churn.PS_Eden_Space           singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3      16022.834 ±    1376.757  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm      singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3  132869899.349 ± 2851250.571    B/op
Bench.run:·gc.churn.PS_Survivor_Space       singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3          0.187 ±       0.541  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm  singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3       1552.268 ±    4454.582    B/op
Bench.run:·gc.count                         singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3        674.000                counts
Bench.run:·gc.time                          singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3        271.000                    ms
```

Results after the change:

```
Benchmark                                               (input)                                                    (options)  Mode  Cnt         Score         Error   Units
Bench.run                                   singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3      2492.856 ±     199.448   us/op
Bench.run:Heap usage                        singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3       181.488 ±    4739.342      MB
Bench.run:Serialized size                   singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3        ≈ 10⁻⁵                    MB
Bench.run:·gc.alloc.rate                    singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3      5971.134 ±     476.275  MB/sec
Bench.run:·gc.alloc.rate.norm               singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3  16400016.116 ±       0.010    B/op
Bench.run:·gc.churn.PS_Eden_Space           singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3      5956.038 ±     873.075  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm      singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3  16358390.389 ± 1170599.800    B/op
Bench.run:·gc.churn.PS_Survivor_Space       singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3         0.195 ±       0.633  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm  singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3       536.332 ±    1761.203    B/op
Bench.run:·gc.count                         singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3       676.000                counts
Bench.run:·gc.time                          singleStringFoo.10n      read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL}  avgt    3       264.000                    ms

Bench.run                                   singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3      2611.016 ±     239.516   us/op
Bench.run:Heap usage                        singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3        69.573 ±     317.594      MB
Bench.run:Serialized size                   singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3        ≈ 10⁻⁵                    MB
Bench.run:·gc.alloc.rate                    singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3      3031.101 ±     280.326  MB/sec
Bench.run:·gc.alloc.rate.norm               singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3   8720016.116 ±       0.095    B/op
Bench.run:·gc.churn.PS_Eden_Space           singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3      3025.731 ±     308.857  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm      singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3   8704552.518 ±   84175.653    B/op
Bench.run:·gc.churn.PS_Survivor_Space       singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3         0.150 ±       0.332  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm  singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3       430.269 ±     918.321    B/op
Bench.run:·gc.count                         singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3       647.000                counts
Bench.run:·gc.time                          singleStringFoo.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:NON_INCREMENTAL}  avgt    3       254.000                    ms
```

I tried with various other file sizes as well, and observed (as expected) that the benefit diminishes as the size of the stream increases and more time is spent on parsing than reader instantiation.

I'm going to continue to experiment with pooling in the readers and writers. At the extreme, we could pool an object that holds _everything_ readers and writers need. I'll determine whether the performance benefits would be worth the complexity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
