### PR TITLE
Adds README for ion-java-cli

### DIFF
--- a/ion-java-cli/README.md
+++ b/ion-java-cli/README.md
@@ -8,3 +8,11 @@ Build ion-java-cli. Note that using -f option for ion-java-cli's `pom.xml`.
 ```
 $ mvn -f ion-java-cli/pom.xml install
 ```
+
+## Getting Started
+Invoking `ion-java-cli-x.y.jar` under `ion-java-cli/target/` directory. <br/> 
+
+For example:
+```
+java -jar ion-java-cli/target/ion-java-cli-1.0.jar process test_file.ion -f pretty -o output.ion
+```

--- a/ion-java-cli/README.md
+++ b/ion-java-cli/README.md
@@ -1,0 +1,10 @@
+# Amazon Ion Java CLI
+A Java implementation of CLI where its design document is located in [here](https://github.com/amzn/ion-test-driver#design).
+
+The package is stored under `ion-java/ion-java-cli`.
+
+## Setup
+Build ion-java-cli. Note that using -f option for ion-java-cli's `pom.xml`.
+```
+$ mvn -f ion-java-cli/pom.xml install
+```


### PR DESCRIPTION
This PR set up a README file of Ion-java-cli including setup instruction and a link to its design doc.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
