### PR TITLE
Fixes NullPointerException when reading malformed symbol table import

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderBinaryRawX.java
+++ b/src/com/amazon/ion/impl/IonReaderBinaryRawX.java
@@ -283,6 +283,12 @@ abstract class IonReaderBinaryRawX
                 else if (_value_tid == _Private_IonConstants.tidTypedecl) {
                     assert (_value_tid == (BINARY_VERSION_MARKER_TID & 0xff)); // the bvm tid happens to be type decl
                     if (_value_len == BINARY_VERSION_MARKER_LEN ) {
+                        if (getDepth() != 0) {
+                            // In Ion text, we can interpret an IVM in the wrong position as an ordinary Symbol,
+                            // but in Ion binary, the BVM is unambiguously an IVM rather than a Symbol, and it
+                            // is not allowed in any container type.
+                            throw newErrorAt("Encountered IVM type code E0 below the top level");
+                        }
                         // this isn't valid for any type descriptor except the first byte
                         // of a 4 byte version marker - so lets read the rest
                         load_version_marker();


### PR DESCRIPTION
*Issue #, if available:*
#395 

*Description of changes:*

* Adds a null check where the NPE was being thrown. If the field name symbol is null, skips the value. This will cause the import to be treated like any other malformed import.
* Adds the [test data](https://github.com/FasterXML/jackson-dataformats-binary/blob/dbcfff6c5e4ee7ddad7e0d63a37e00aca67889a2/ion/src/test/resources/data/issue-303.ion) provided in https://github.com/FasterXML/jackson-dataformats-binary/issues/303 to `amzn/ion-tests`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
