### PR TITLE
Fixes performance regression detector so that it refreshes the git submodules when checking out the prior commit

### DIFF
--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -68,7 +68,7 @@ jobs:
         run : rm -r /home/runner/.m2
 
       - name: Build ion-java from the previous commit
-        run: cd ion-java && git checkout HEAD^ && mvn clean install
+        run: cd ion-java && git checkout HEAD^ && git submodule update --recursive && mvn clean install
 
       - name: Build ion-java-benchmark-cli
         run: cd ion-java-benchmark-cli && mvn clean install


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This fixes the performance regression detector. Right now, if you add a new test case and update the `ion-test` submodule commit, the workflow will fail if the _prior_ commit cannot pass the _new_ test case. The solution is to refresh the git submodules.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
