### PR TITLE
Compacts preallocated headers when possible

### DIFF
--- a/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
+++ b/src/com/amazon/ion/impl/bin/IonRawBinaryWriter.java
@@ -202,6 +202,15 @@ import java.util.NoSuchElementException;
 
         /*package*/ abstract void patchLength(final WriteBuffer buffer, final long position, final long length);
 
+        /**
+         * Returns the length (in bytes) of the header that this mode would preallocate. This is the number of
+         * bytes preallocated for the VarUInt length (the number in the mode name) plus one extra byte for the
+         * type descriptor itself. (Examples: PREALLOCATE_0 returns `1`, PREALLOCATE_1 returns `2`, etc.)
+         */
+        int preallocatedHeaderLength() {
+            return typedLength;
+        }
+
         /*package*/ static PreallocationMode withPadSize(final int pad)
         {
             switch (pad)
@@ -723,48 +732,70 @@ import java.util.NoSuchElementException;
 
     private ContainerInfo popContainer()
     {
-        final ContainerInfo current = containers.pop();
-        if (current == null)
+        final ContainerInfo currentContainer = containers.pop();
+        if (currentContainer == null)
         {
             throw new IllegalStateException("Tried to pop container state without said container");
         }
 
         // only patch for real containers and annotations -- we use VALUE for tracking only
-        final long length = current.length;
-        if (current.type != ContainerType.VALUE)
+        long length = currentContainer.length;
+        if (currentContainer.type != ContainerType.VALUE)
         {
             // patch in the length
-            final long position = current.position;
-            if (current.length <= preallocationMode.contentMaxLength && preallocationMode != PreallocationMode.PREALLOCATE_0)
+            final long positionOfFirstLengthByte = currentContainer.position;
+            if (length <= 0xD) {
+                // The body of this container/wrapper is small enough that its length can fit in the lower nibble of
+                // the type descriptor byte; we don't need the extra length bytes that were preallocated (if any).
+                // We'll shift the encoded body of the container/wrapper backwards in the buffer to overwrite them.
+
+                // The number of bytes we need to shift by is determined by the writer's preallocation mode.
+                final int numberOfBytesToShiftBy = preallocationMode.preallocatedHeaderLength() - 1;
+
+                // `length` is the encoded length of the container/wrapper we're stepping out of. It does not
+                // include any header bytes. In this `if` branch, we've confirmed that `length` is <= 0xD,
+                // so this downcast from `long` to `int` is safe.
+                final int lengthOfSliceToShift = (int) length;
+
+                // Shift the container/wrapper body backwards in the buffer. Because this only happens when
+                // `lengthOfSliceToShift` is 13 or fewer bytes, this will usually be a very fast memcpy.
+                // It's slightly more work if the slice we're shifting happens to straddle two memory blocks
+                // inside the buffer.
+                buffer.shiftBytesLeft(lengthOfSliceToShift, numberOfBytesToShiftBy);
+
+                // Overwrite the lower nibble of the original type descriptor byte with the body's encoded length.
+                final long typeDescriptorPosition = positionOfFirstLengthByte - 1;
+                final long type = (buffer.getUInt8At(typeDescriptorPosition) & 0xF0) | length;
+                buffer.writeUInt8At(typeDescriptorPosition, type);
+
+                // We've reclaimed some number of bytes; adjust the container length as appropriate.
+                length -= numberOfBytesToShiftBy;
+            }
+            else if (currentContainer.length <= preallocationMode.contentMaxLength)
             {
-                preallocationMode.patchLength(buffer, position, length);
+                // The container's encoded body is too long to fit the length in the type descriptor byte, but it will
+                // fit in the preallocated length bytes that were added to the buffer when the container was started.
+                // Update those bytes with the VarUInt encoding of the length value.
+                preallocationMode.patchLength(buffer, positionOfFirstLengthByte, length);
             }
             else
             {
-                // side patch
-                if (current.length <= 0xD && preallocationMode == PreallocationMode.PREALLOCATE_0)
-                {
-                    // XXX if we're not using padding we can get here and optimize the length a little without side patching!
-                    final long typePosition = position - 1;
-                    final long type = (buffer.getUInt8At(typePosition) & 0xF0) | current.length;
-                    buffer.writeUInt8At(typePosition, type);
-                }
-                else
-                {
-                    addPatchPoint(position, preallocationMode.typedLength - 1, length);
-                }
+                // The container's encoded body is too long to fit in the length bytes that were preallocated.
+                // Write the VarUInt encoding of the length in a secondary buffer and make a note to include that
+                // when we go to flush the primary buffer to the output stream.
+                addPatchPoint(positionOfFirstLengthByte, preallocationMode.typedLength - 1, length);
             }
         }
-        if (current.patches != null)
+        if (currentContainer.patches != null)
         {
             // at this point, we've appended our patch points upward, lets make sure we get
             // our child patch points in
-            extendPatchPoints(current.patches);
+            extendPatchPoints(currentContainer.patches);
         }
 
         // make sure to record length upward
         updateLength(length);
-        return current;
+        return currentContainer;
     }
 
     private void writeVarUInt(final long value)

--- a/src/com/amazon/ion/impl/bin/WriteBuffer.java
+++ b/src/com/amazon/ion/impl/bin/WriteBuffer.java
@@ -262,10 +262,10 @@ import java.util.List;
                 if (length == 0) {
                     // ...lower the `limit` because we've reclaimed some bytes in this block...
                     block.limit -= numberOfBytesToShift;
-                    // ... and early return.
+                    // ...and early return.
                     return;
                 }
-                // Otherwise, use our new buffer offset to recalculate our position our block-specific position.
+                // Otherwise, use our new buffer offset to recalculate our block-specific position.
                 blockIndex = index(bufferOffset);
                 block = blocks.get(blockIndex);
                 blockOffset = offset(bufferOffset);
@@ -281,7 +281,7 @@ import java.util.List;
             length -= numberOfBytesToShift;
         }
         if (block != null) {
-            // We've reclaimed some space in this block, lower the `limit` accordingly.
+            // We've reclaimed some space in this block; lower the `limit` accordingly.
             block.limit -= shiftBy;
         }
     }

--- a/test/com/amazon/ion/impl/bin/WriteBufferTest.java
+++ b/test/com/amazon/ion/impl/bin/WriteBufferTest.java
@@ -921,4 +921,42 @@ public class WriteBufferTest
         buf.truncate(3);
         assertBuffer("ARG".getBytes("UTF-8"));
     }
+
+    @Test
+    public void shiftBytesLeftWithinFirstBufferBlock() throws IOException {
+        assertEquals(11, ALLOCATOR.getBlockSize());
+        // All bytes are being shifted within the first buffer block.
+        buf.writeBytes("01234567".getBytes());
+        buf.shiftBytesLeft(4, 1);
+        assertBuffer("0124567".getBytes());
+    }
+
+    @Test
+    public void shiftBytesLeftWithinLastBufferBlock() throws IOException {
+        assertEquals(11, ALLOCATOR.getBlockSize());
+        // All bytes are being shifted within the last buffer block.
+        buf.writeBytes("0123456789ABCDEF".getBytes());
+        buf.shiftBytesLeft(3, 2);
+        assertBuffer("0123456789ADEF".getBytes());
+    }
+
+    @Test
+    public void shiftBytesLeftAcrossBufferBlocks() throws IOException {
+        assertEquals(11, ALLOCATOR.getBlockSize());
+        // Some bytes are shifted to the previous block, some are shifted within
+        // the last block.
+        buf.writeBytes("0123456789ABCDEF".getBytes());
+        buf.shiftBytesLeft(8, 3);
+        assertBuffer("0123489ABCDEF".getBytes());
+    }
+
+    @Test
+    public void shiftBytesLeftAcrossBufferBlocksExclusively() throws IOException {
+        assertEquals(11, ALLOCATOR.getBlockSize());
+        // Unlike `shiftBytesLeftAcrossBufferBlocks`, EVERY byte that is shifted
+        // in the buffer ends up in the previous block.
+        buf.writeBytes("0123456789ABCDEF".getBytes());
+        buf.shiftBytesLeft(5, 5);
+        assertBuffer("012345BCDEF".getBytes());
+    }
 }


### PR DESCRIPTION
*Issue #, if available:* 

Fixes #399.

*Description of changes:*

`IonRawBinaryWriter` can be configured to preallocate buffer bytes to
hold the length prefix of a new container or annotations wrapper. This
option trades processing speed for data size. Preallocating more bytes
makes the encoded data larger, but increases the chances that the
container's length (once calculated) can be written directly into the
existing buffer.

This patch modifies the writer such that, when finalizing the encoding
of a container or annotations wrapper, the writer will check to see if
the encoded length is small enough to fit in the type descriptor byte.
If it is, the encoded bytes are shifted backwards in the buffer to
eliminate the unnecessary preallocation. This means that the encoding of
small containers isn't penalized for having preallocation enabled.

Benchmarks showed no substantial difference in processing speed from the
previous release, so this data size improvement does not come at the
cost of throughput.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
