### PR TITLE
Optimizes the incremental reader's symbol table reading logic for tables with imports.

### DIFF
--- a/src/com/amazon/ion/impl/ImportLocation.java
+++ b/src/com/amazon/ion/impl/ImportLocation.java
@@ -1,0 +1,53 @@
+package com.amazon.ion.impl;
+
+/**
+ * A SymbolToken's import location, allowing for symbols with unknown text to be mapped to a particular slot
+ * in a shared symbol table.
+ * NOTE: this is currently not publicly accessible, but it is an important step toward being able to correctly
+ * round-trip symbols with unknown text from shared symbol tables in different symbol table contexts. See
+ * https://github.com/amzn/ion-java/issues/126 . Support is added now to avoid risking the appearance of performance
+ * degradation if ImportLocation support were added after initial release of the incremental IonReader.
+ */
+class ImportLocation {
+
+    // The name of the shared symbol table.
+    final String name;
+
+    // The index into the shared symbol table.
+    final int sid;
+
+    ImportLocation(String name, int sid) {
+        this.name = name;
+        this.sid = sid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getSid() {
+        return sid;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ImportLocation::{name: %s, sid: %d}", name, sid);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ImportLocation)) {
+            return false;
+        }
+        ImportLocation that = (ImportLocation) o;
+        return this.getName().equals(that.getName()) && this.getSid() == that.getSid();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result += 31 * getName().hashCode();
+        result += 31 * getSid();
+        return result;
+    }
+}

--- a/src/com/amazon/ion/impl/LocalSymbolTableImports.java
+++ b/src/com/amazon/ion/impl/LocalSymbolTableImports.java
@@ -278,6 +278,21 @@ final class LocalSymbolTableImports
         return myImports;
     }
 
+    /**
+     * Gets the {@link ImportLocation} for the given symbol ID.
+     * @param sid the symbol ID.
+     * @return an ImportLocation, or null if the given symbol ID is not present in the imports.
+     */
+    ImportLocation getImportLocation(int sid) {
+        // TODO once ion-java moves to Java 1.6+, the search for the import could use Arrays.binarySearch.
+        for (int i = myBaseSids.length - 1; i >= 0; i--) {
+            if (myBaseSids[i] < sid) {
+                return new ImportLocation(myImports[i].getName(), sid - myBaseSids[i]);
+            }
+        }
+        return null;
+    }
+
     @Override
     public String toString()
     {

--- a/test/com/amazon/ion/impl/IonReaderBinaryIncrementalTest.java
+++ b/test/com/amazon/ion/impl/IonReaderBinaryIncrementalTest.java
@@ -1675,7 +1675,7 @@ public class IonReaderBinaryIncrementalTest {
 
     private static void assertSymbolEquals(
         String expectedText,
-        IonReaderBinaryIncremental.ImportLocation expectedImportLocation,
+        ImportLocation expectedImportLocation,
         SymbolToken actual
     ) {
         assertEquals(expectedText, actual.getText());
@@ -2162,11 +2162,11 @@ public class IonReaderBinaryIncrementalTest {
         IonReaderBinaryIncremental.SymbolTokenImpl symbolValue =
             (IonReaderBinaryIncremental.SymbolTokenImpl) reader.symbolValue();
         assertNull(symbolValue.getText());
-        assertEquals(new IonReaderBinaryIncremental.ImportLocation("foo", 3), symbolValue.getImportLocation());
+        assertEquals(new ImportLocation("foo", 3), symbolValue.getImportLocation());
         assertEquals(IonType.SYMBOL, reader.next());
         symbolValue = (IonReaderBinaryIncremental.SymbolTokenImpl) reader.symbolValue();
         assertNull(symbolValue.getText());
-        assertEquals(new IonReaderBinaryIncremental.ImportLocation("foo", 4), symbolValue.getImportLocation());
+        assertEquals(new ImportLocation("foo", 4), symbolValue.getImportLocation());
         assertEquals(IonType.SYMBOL, reader.next());
         assertEquals("123", reader.stringValue());
         assertEquals(IonType.SYMBOL, reader.next());
@@ -2175,7 +2175,7 @@ public class IonReaderBinaryIncrementalTest {
             new IonReaderBinaryIncremental.SymbolTokenImpl(
                 null,
                 15,
-                new IonReaderBinaryIncremental.ImportLocation("baz", 1)
+                new ImportLocation("baz", 1)
             ),
             symbolValue
         );
@@ -2185,7 +2185,7 @@ public class IonReaderBinaryIncrementalTest {
             new IonReaderBinaryIncremental.SymbolTokenImpl(
                 null,
                 16,
-                new IonReaderBinaryIncremental.ImportLocation("baz", 2)
+                new ImportLocation("baz", 2)
             ),
             symbolValue
         );


### PR DESCRIPTION
*Description of changes:*

Profiling has revealed that the incremental reader's existing handling of shared symbol tables performs poorly, and becomes noticeable when reading small values with shared symbol tables or streams that contain many symbol tables with imports.

This inefficiency was due to the fact that the reader stored symbols in a flat list, which required all imported symbols to be copied into the list every time the symbol table changed. After this change, only the local symbols are stored in that list; imported symbols are referenced from their underlying shared SymbolTables via [LocalSymbolTableImports](https://github.com/amzn/ion-java/blob/master/src/com/amazon/ion/impl/LocalSymbolTableImports.java), which is also used for this purpose by the other binary IonReader implementation.

I used ion-java-benchmark-cli to verify that there is no observed impact to performance for small or large streams that don't use shared symbol tables.

I also used ion-java-benchmark-cli to do a comparison targeted to this fix. It involves reading a small stream using shared symbol tables 100 times in a row.

Before:

```
Benchmark                                      (input)                                                                               (options)  Mode  Cnt       Score      Error   Units
Bench.run                                   shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4     151.307 ±    2.554   us/op
Bench.run:Heap usage                        shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4      94.836 ±  343.822      MB
Bench.run:Serialized size                   shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4      ≈ 10⁻³                 MB
Bench.run:·gc.alloc.rate                    shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4    4237.355 ±   69.259  MB/sec
Bench.run:·gc.alloc.rate.norm               shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4  706416.008 ±    0.022    B/op
Bench.run:·gc.churn.PS_Eden_Space           shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4    4230.845 ±   69.936  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm      shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4  705330.862 ± 4978.273    B/op
Bench.run:·gc.churn.PS_Survivor_Space       shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4       0.203 ±    0.173  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm  shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4      33.794 ±   29.305    B/op
Bench.run:·gc.count                         shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4     883.000             counts
Bench.run:·gc.time                          shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4     355.000                 ms
```

After:

```
Benchmark                                      (input)                                                                               (options)  Mode  Cnt       Score       Error   Units
Bench.run                                   shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4     115.972 ±     2.762   us/op
Bench.run:Heap usage                        shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4     113.331 ±   485.528      MB
Bench.run:Serialized size                   shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4      ≈ 10⁻³                  MB
Bench.run:·gc.alloc.rate                    shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4    5253.101 ±   129.797  MB/sec
Bench.run:·gc.alloc.rate.norm               shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4  671216.006 ±     0.017    B/op
Bench.run:·gc.churn.PS_Eden_Space           shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4    5245.017 ±    95.518  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm      shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4  670185.145 ±  5759.997    B/op
Bench.run:·gc.churn.PS_Survivor_Space       shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4       0.192 ±     0.184  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm  shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4      24.501 ±    23.765    B/op
Bench.run:·gc.count                         shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4     885.000              counts
Bench.run:·gc.time                          shape2.ion   read::{f:ION_BINARY,t:BUFFER,c:"imports.ion",a:STREAMING,k:true,R:INCREMENTAL,Z:4096}  avgt    4     361.000                  ms
```

The improvement was 151us -> 116us (23%).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
