### PR TITLE
Enables the incremental reader to iterate annotations lazily.

### DIFF
--- a/src/com/amazon/ion/impl/bin/IntList.java
+++ b/src/com/amazon/ion/impl/bin/IntList.java
@@ -30,6 +30,16 @@ public class IntList {
     }
 
     /**
+     * Constructs a new IntList that contains all the elements of the given IntList.
+     * @param other the IntList to copy.
+     */
+    public IntList(final IntList other) {
+        this.numberOfValues = other.numberOfValues;
+        this.data = new int[other.data.length];
+        System.arraycopy(other.data, 0, this.data, 0, numberOfValues);
+    }
+
+    /**
      * Accessor.
      * @return  The number of ints currently stored in the list.
      */

--- a/test/com/amazon/ion/impl/IonReaderLookaheadBufferTest.java
+++ b/test/com/amazon/ion/impl/IonReaderLookaheadBufferTest.java
@@ -1000,7 +1000,7 @@ public class IonReaderLookaheadBufferTest
 
         lookahead.fillInput();
         assertEquals(1, lookahead.getIvmIndex());
-        assertTrue(lookahead.getAnnotationSids().isEmpty());
+        assertFalse(lookahead.hasAnnotations());
         assertTrue(lookahead.getSymbolTableMarkers().isEmpty());
         assertEquals(5, lookahead.getValueStart());
         assertIonTypeId(IonType.INT, 0x1, lookahead.getValueTid());
@@ -1014,7 +1014,7 @@ public class IonReaderLookaheadBufferTest
         assertEquals(indexForInitialBufferSize(1, 1, 7), lookahead.getIvmIndex());
         lookahead.resetIvmIndex();
         assertEquals(-1, lookahead.getIvmIndex());
-        assertTrue(lookahead.getAnnotationSids().isEmpty());
+        assertFalse(lookahead.hasAnnotations());
         assertTrue(lookahead.getSymbolTableMarkers().isEmpty());
         assertEquals(indexForInitialBufferSize(6, 6, 12), lookahead.getValueStart());
         assertIonTypeId(IonType.STRUCT, 0x1, lookahead.getValueTid());
@@ -1023,7 +1023,9 @@ public class IonReaderLookaheadBufferTest
         lookahead.fillInput();
         assertEquals(-1, lookahead.getIvmIndex());
         assertTrue(lookahead.getSymbolTableMarkers().isEmpty());
-        assertEquals(Arrays.asList(4, 5), lookahead.getAnnotationSids());
+        assertTrue(lookahead.hasAnnotations());
+        assertEquals(indexForInitialBufferSize(10, 10, 16), lookahead.getAnnotationSidsMarker().startIndex);
+        assertEquals(indexForInitialBufferSize(12, 12, 18), lookahead.getAnnotationSidsMarker().endIndex);
         assertEquals(indexForInitialBufferSize(12, 12, 18), lookahead.getValueStart());
         assertIonTypeId(IonTypeID.ION_TYPE_ANNOTATION_WRAPPER, 0x5, lookahead.getValueTid());
         assertEquals(indexForInitialBufferSize(14, 14, 20), lookahead.getValueEnd());
@@ -1031,7 +1033,7 @@ public class IonReaderLookaheadBufferTest
         lookahead.fillInput();
         assertEquals(-1, lookahead.getIvmIndex());
         assertTrue(lookahead.getSymbolTableMarkers().isEmpty());
-        assertTrue(lookahead.getAnnotationSids().isEmpty());
+        assertFalse(lookahead.hasAnnotations());
         assertEquals(indexForInitialBufferSize(15, 15, 21), lookahead.getValueStart());
         assertIonTypeId(IonType.INT, 0x0, lookahead.getValueTid());
         assertEquals(indexForInitialBufferSize(15, 15, 21), lookahead.getValueEnd());
@@ -1060,8 +1062,8 @@ public class IonReaderLookaheadBufferTest
             builder.withInitialBufferSize(initialBufferSize);
         }
         lookahead = bufferFor(
-            // Symbol table declaring symbol 'x'.
-            0xE7, 0x81, 0x83, 0xD4, 0x87, 0xB2, 0x81, 'x',
+            // Symbol table with extra annotation 'name' declaring symbol 'x'.
+            0xE8, 0x82, 0x83, 0x84, 0xD4, 0x87, 0xB2, 0x81, 'x',
             // Symbol value with SID 10 ('x').
             0x71, 0x0A,
             // The value will not be consumed, so the indices continue.
@@ -1087,25 +1089,25 @@ public class IonReaderLookaheadBufferTest
         );
         lookahead.fillInput();
         assertEquals(1, lookahead.getIvmIndex());
-        assertTrue(lookahead.getAnnotationSids().isEmpty());
-        List<IonReaderLookaheadBuffer.SymbolTableMarker> symbolTableMarkers = lookahead.getSymbolTableMarkers();
+        assertFalse(lookahead.hasAnnotations());
+        List<IonReaderLookaheadBuffer.Marker> symbolTableMarkers = lookahead.getSymbolTableMarkers();
         assertEquals(1, symbolTableMarkers.size());
-        assertEquals(8, symbolTableMarkers.get(0).startIndex);
-        assertEquals(12, symbolTableMarkers.get(0).endIndex);
-        assertEquals(13, lookahead.getValueStart());
+        assertEquals(9, symbolTableMarkers.get(0).startIndex);
+        assertEquals(13, symbolTableMarkers.get(0).endIndex);
+        assertEquals(14, lookahead.getValueStart());
         assertIonTypeId(IonType.SYMBOL, 0x1, lookahead.getValueTid());
-        assertEquals(14, lookahead.getValueEnd());
+        assertEquals(15, lookahead.getValueEnd());
         lookahead.resetSymbolTableMarkers();
         assertTrue(lookahead.getSymbolTableMarkers().isEmpty());
 
         lookahead.fillInput();
         symbolTableMarkers = lookahead.getSymbolTableMarkers();
         assertEquals(1, symbolTableMarkers.size());
-        assertEquals(18, symbolTableMarkers.get(0).startIndex);
-        assertEquals(25, symbolTableMarkers.get(0).endIndex);
-        assertEquals(26, lookahead.getValueStart());
+        assertEquals(19, symbolTableMarkers.get(0).startIndex);
+        assertEquals(26, symbolTableMarkers.get(0).endIndex);
+        assertEquals(27, lookahead.getValueStart());
         assertIonTypeId(IonType.SYMBOL, 0x1, lookahead.getValueTid());
-        assertEquals(27, lookahead.getValueEnd());
+        assertEquals(28, lookahead.getValueEnd());
 
         IonReader reader = lookahead.newIonReader(IonReaderBuilder.standard());
         assertEquals(IonType.SYMBOL, reader.next());
@@ -1116,13 +1118,13 @@ public class IonReaderLookaheadBufferTest
         lookahead.fillInput();
         symbolTableMarkers = lookahead.getSymbolTableMarkers();
         assertEquals(2, symbolTableMarkers.size());
-        assertEquals(indexForInitialBufferSize(28, 28, 55), symbolTableMarkers.get(0).startIndex);
-        assertEquals(indexForInitialBufferSize(32, 32, 59), symbolTableMarkers.get(0).endIndex);
-        assertEquals(indexForInitialBufferSize(36, 36, 63), symbolTableMarkers.get(1).startIndex);
-        assertEquals(indexForInitialBufferSize(40, 40, 67), symbolTableMarkers.get(1).endIndex);
-        assertEquals(indexForInitialBufferSize(41, 41, 68), lookahead.getValueStart());
+        assertEquals(indexForInitialBufferSize(28, 28, 56), symbolTableMarkers.get(0).startIndex);
+        assertEquals(indexForInitialBufferSize(32, 32, 60), symbolTableMarkers.get(0).endIndex);
+        assertEquals(indexForInitialBufferSize(36, 36, 64), symbolTableMarkers.get(1).startIndex);
+        assertEquals(indexForInitialBufferSize(40, 40, 68), symbolTableMarkers.get(1).endIndex);
+        assertEquals(indexForInitialBufferSize(41, 41, 69), lookahead.getValueStart());
         assertIonTypeId(IonType.SYMBOL, 0x1, lookahead.getValueTid());
-        assertEquals(indexForInitialBufferSize(42, 42, 69), lookahead.getValueEnd());
+        assertEquals(indexForInitialBufferSize(42, 42, 70), lookahead.getValueEnd());
 
         assertEquals(IonType.SYMBOL, reader.next());
         assertEquals("d", reader.stringValue());
@@ -1191,6 +1193,44 @@ public class IonReaderLookaheadBufferTest
         IonReader reader = lookahead.newIonReader(IonReaderBuilder.standard());
         assertEquals(IonType.SYMBOL, reader.next());
         assertEquals("hello", reader.stringValue());
+        assertNull(reader.next());
+        reader.close();
+    }
+
+    @Test
+    public void annotationMarkersAreCorrectlyShifted() throws Exception {
+        if (initialBufferSize == null || initialBufferSize != 1) {
+            return;
+        }
+        // Set the maximum size at 1 IVM (4 bytes) + the symbol table (12 bytes) + the value (2 bytes) + part of the
+        // next value (3 bytes).
+        builder = IonBufferConfiguration.Builder.standard()
+            .withInitialBufferSize(21)
+            .withMaximumBufferSize(21);
+        createCountingEventHandler(builder, new AtomicLong());
+        lookahead = bufferFor(
+            // Symbol table with the symbol 'hello'.
+            0xEB, 0x81, 0x83, 0xD8, 0x87, 0xB6, 0x85, 'h', 'e', 'l', 'l', 'o',
+            // Symbol 10 (hello)
+            0x71, 0x0A,
+            // name::hello
+            0xE4, 0x81, 0x84, 0x71, 0x0A
+        );
+
+        lookahead.fillInput();
+        assertFalse(lookahead.moreDataRequired());
+        IonReader reader = lookahead.newIonReader(IonReaderBuilder.standard());
+        assertEquals(IonType.SYMBOL, reader.next());
+        assertFalse(lookahead.hasAnnotations());
+        // The buffer will reach its maximum size after recording the annotation marker. The marker's indices will
+        // be shifted left when space is reclaimed to fit the value.
+        lookahead.fillInput();
+        assertFalse(lookahead.moreDataRequired());
+        assertEquals("hello", reader.stringValue());
+        assertEquals(IonType.SYMBOL, reader.next());
+        assertTrue(lookahead.hasAnnotations());
+        assertEquals(2, lookahead.getAnnotationSidsMarker().startIndex);
+        assertEquals(3, lookahead.getAnnotationSidsMarker().endIndex);
         assertNull(reader.next());
         reader.close();
     }


### PR DESCRIPTION
*Description of changes:*
This PR includes two optimizations:
1. (Minor) Uses `IntList` introduced in #404 for storing annotation SIDs without upgrading to `Integer`.
2. Lazily parsing and resolving annotation SIDs. Previously, annotation SIDs were eagerly parsed (in `IonReaderLookaheadBuffer`) at the top-level, and parsed on-demand but in their entirety below the top-level (in `IonReaderBinaryIncremental.getAnnotationSids`). Now, as long as annotation iterator reuse is enabled, annotations at any level are both parsed and resolved lazily (when accessed via the iterator provided by `IonReader.iterateTypeAnnotations`). This enables performance improvements in cases where the user does not access some or all annotations on a value, as is the case when skip-scanning.

*Performance:*

I used ion-java-benchmark-cli to verify that there is no observed impact to performance for streams that don't make heavy use of annotations.

I also used ion-java-benchmark-cli to do a comparison targeted to this change. The test data is a stream of top-level floats (chosen to minimize the value parsing time), each with a variable number of annotations.

The first trial involved iterating all annotations on every value.

Before:

```
Benchmark                                               (input)                                              (options)  Mode  Cnt          Score       Error   Units
Bench.run                                   annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        632.625 ±     6.560   ms/op
Bench.run:Heap usage                        annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4         28.486 ±     0.305      MB
Bench.run:Serialized size                   annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        100.350                  MB
Bench.run:·gc.alloc.rate                    annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        188.526 ±     1.849  MB/sec
Bench.run:·gc.alloc.rate.norm               annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4  131332260.000 ±     7.462    B/op
Bench.run:·gc.churn.PS_Eden_Space           annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        186.506 ±     1.829  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm      annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4  129925120.000 ±     0.001    B/op
Bench.run:·gc.churn.PS_Survivor_Space       annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4          0.314 ±     0.066  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm  annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4     218647.250 ± 45039.772    B/op
Bench.run:·gc.count                         annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        260.000              counts
Bench.run:·gc.time                          annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4         96.000                  ms
```

After:

```
Benchmark                                  (input)                                              (options)  Mode  Cnt      Score    Error   Units
Bench.run                      annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4    564.878 ±  4.420   ms/op
Bench.run:Heap usage           annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4      5.666 ±  4.339      MB
Bench.run:Serialized size      annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4    100.350               MB
Bench.run:·gc.alloc.rate       annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4      0.135 ±  0.001  MB/sec
Bench.run:·gc.alloc.rate.norm  annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4  84128.889 ± 11.488    B/op
Bench.run:·gc.count            annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        ≈ 0           counts
```

The second trial involved retrieving only the first annotation on each value.

Before:

```
Benchmark                                               (input)                                              (options)  Mode  Cnt          Score         Error   Units
Bench.run                                   annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        595.577 ±      24.995   ms/op
Bench.run:Heap usage                        annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4         19.235 ±      94.244      MB
Bench.run:Serialized size                   annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        100.350                    MB
Bench.run:·gc.alloc.rate                    annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        200.281 ±       8.033  MB/sec
Bench.run:·gc.alloc.rate.norm               annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4  131332258.353 ±       7.023    B/op
Bench.run:·gc.churn.PS_Eden_Space           annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        199.079 ±       3.125  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm      annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4  130547711.882 ± 5544439.327    B/op
Bench.run:·gc.churn.PS_Survivor_Space       annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4          0.303 ±       0.077  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm  annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4     199042.118 ±   56985.986    B/op
Bench.run:·gc.count                         annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        258.000                counts
Bench.run:·gc.time                          annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        118.000                    ms
```

After:

```
Benchmark                                  (input)                                              (options)  Mode  Cnt      Score   Error   Units
Bench.run                      annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4    497.792 ± 8.578   ms/op
Bench.run:Heap usage           annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4      5.330 ± 0.028      MB
Bench.run:Serialized size      annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4    100.350              MB
Bench.run:·gc.alloc.rate       annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4      0.154 ± 0.003  MB/sec
Bench.run:·gc.alloc.rate.norm  annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4  84125.333 ± 5.685    B/op
Bench.run:·gc.count            annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:INCREMENTAL}  avgt    4        ≈ 0          counts
```

For reference, here are the results for the incremental reader (which had no performance difference when reading a single annotation vs all annotations because annotations are parsed and resolved eagerly):

```
Benchmark                                               (input)                                                  (options)  Mode  Cnt          Score         Error   Units
Bench.run                                   annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:NON_INCREMENTAL}  avgt    4        832.241 ±      19.998   ms/op
Bench.run:Heap usage                        annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:NON_INCREMENTAL}  avgt    4         27.072 ±      44.461      MB
Bench.run:Serialized size                   annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:NON_INCREMENTAL}  avgt    4        100.350                    MB
Bench.run:·gc.alloc.rate                    annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:NON_INCREMENTAL}  avgt    4        199.936 ±       7.366  MB/sec
Bench.run:·gc.alloc.rate.norm               annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:NON_INCREMENTAL}  avgt    4  182990436.615 ±      26.216    B/op
Bench.run:·gc.churn.PS_Eden_Space           annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:NON_INCREMENTAL}  avgt    4        198.118 ±       8.860  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm      annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:NON_INCREMENTAL}  avgt    4  181326347.987 ± 3377440.465    B/op
Bench.run:·gc.churn.PS_Survivor_Space       annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:NON_INCREMENTAL}  avgt    4          0.232 ±       0.043  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm  annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:NON_INCREMENTAL}  avgt    4     212396.051 ±   39487.424    B/op
Bench.run:·gc.count                         annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:NON_INCREMENTAL}  avgt    4        282.000                counts
Bench.run:·gc.time                          annotatedFloats.10n  read::{f:ION_BINARY,t:FILE,a:STREAMING,R:NON_INCREMENTAL}  avgt    4        113.000                    ms
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
