### PR TITLE
Properly sizes the buffer when a fixed-size stream is provided to the incremental reader with default configuration.

### DIFF
--- a/src/com/amazon/ion/IonBufferConfiguration.java
+++ b/src/com/amazon/ion/IonBufferConfiguration.java
@@ -90,6 +90,21 @@ public final class IonBufferConfiguration extends BufferConfiguration<IonBufferC
         }
 
         /**
+         * Provides a new builder that would build IonBufferConfiguration instances with configuration identical to
+         * the given configuration.
+         * @param existingConfiguration an existing configuration.
+         * @return a new mutable builder.
+         */
+        public static Builder from(IonBufferConfiguration existingConfiguration) {
+            return IonBufferConfiguration.Builder.standard()
+                .onData(existingConfiguration.getDataHandler())
+                .onOversizedValue(existingConfiguration.getOversizedValueHandler())
+                .onOversizedSymbolTable(existingConfiguration.getOversizedSymbolTableHandler())
+                .withInitialBufferSize(existingConfiguration.getInitialBufferSize())
+                .withMaximumBufferSize(existingConfiguration.getMaximumBufferSize());
+        }
+
+        /**
          * Sets the handler that will be notified when oversized symbol tables are encountered. If the maximum buffer
          * size is finite (see {@link #withMaximumBufferSize(int)}, this handler is required to be non-null.
          *


### PR DESCRIPTION
*Description of changes:*

In order to ease migration from the previous reader implementation, the incremental reader does not require users to manually specify its initial buffer size, which defaults to 32KB. In cases where the user wants to read a small fixed-size stream (e.g. from a byte array), excessive memory will be allocated if the stream is smaller than 32KB.

This PR proposes a change that will right-size the buffer configuration in this case. This significantly improves performance in the above case without requiring the user to manually provide buffer configuration. Providing this configuration still leads to the best performance, but this gets close. I think it will be common for users to skip manual configuration due to the cognitive load required to reason about it.

I used ion-java-benchmark-cli to verify that there is no observed impact to performance for streams that aren't fixed-size and/or very small.

I also used ion-java-benchmark-cli to do a comparison targeted to this change. These benchmarks repetitively read a 795 byte Ion value using a single reader per value, using the default configuration. Before this change, that resulted in a 32KB internal buffer. After this change, the buffer will be right-sized to 1024 B.

Before:

```
Bench.run                                  offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4      446.039 ±    52.451   us/op
Bench.run:Heap usage                       offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4      302.291 ±  1348.086      MB
Bench.run:Serialized size                  offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4        0.001                  MB
Bench.run:·gc.alloc.rate                   offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4     7404.276 ±   872.362  MB/sec
Bench.run:·gc.alloc.rate.norm              offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4  3638416.020 ±     0.006    B/op
Bench.run:·gc.churn.PS_Eden_Space          offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4     7389.689 ±   935.707  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm     offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4  3631186.436 ± 66253.686    B/op
Bench.run:·gc.churn.PS_Survivor_Space      offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4        0.216 ±     0.509  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4      105.696 ±   244.439    B/op
Bench.run:·gc.count                        offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4      703.000              counts
Bench.run:·gc.time                         offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4      340.000                  ms
```
After:

```
Bench.run                                  offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4      297.000 ±     4.541   us/op
Bench.run:Heap usage                       offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4       42.316 ±   208.808      MB
Bench.run:Serialized size                  offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4        0.001                  MB
Bench.run:·gc.alloc.rate                   offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4     1418.057 ±    21.648  MB/sec
Bench.run:·gc.alloc.rate.norm              offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4   464016.013 ±     0.003    B/op
Bench.run:·gc.churn.PS_Eden_Space          offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4     1415.141 ±    39.704  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm     offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4   463060.445 ±  6145.908    B/op
Bench.run:·gc.churn.PS_Survivor_Space      offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4        0.404 ±     0.162  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4      132.032 ±    51.152    B/op
Bench.run:·gc.count                        offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4      831.000              counts
Bench.run:·gc.time                         offer.10n   read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:auto}  avgt    4      345.000                  ms
```

That's a 33% improvement in this case.

For reference, manually specifying an initial buffer size of 1024 performs only slightly better (~3%) than automatic right-sizing. (Results were the same before and after the changes in this PR.)

```
Benchmark                                    (input)                                                       (options)  Mode  Cnt       Score      Error   Units
Bench.run                                  offer.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:1024}  avgt    4     286.944 ±    8.386   us/op
Bench.run:Heap usage                       offer.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:1024}  avgt    4      36.917 ±   83.990      MB
Bench.run:Serialized size                  offer.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:1024}  avgt    4       0.001                 MB
Bench.run:·gc.alloc.rate                   offer.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:1024}  avgt    4    1477.858 ±   43.391  MB/sec
Bench.run:·gc.alloc.rate.norm              offer.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:1024}  avgt    4  467216.013 ±    0.003    B/op
Bench.run:·gc.churn.PS_Eden_Space          offer.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:1024}  avgt    4    1475.333 ±   47.651  MB/sec
Bench.run:·gc.churn.PS_Eden_Space.norm     offer.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:1024}  avgt    4  466416.935 ± 2269.539    B/op
Bench.run:·gc.churn.PS_Survivor_Space      offer.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:1024}  avgt    4       0.332 ±    0.295  MB/sec
Bench.run:·gc.churn.PS_Survivor_Space.norm offer.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:1024}  avgt    4     105.041 ±   95.531    B/op
Bench.run:·gc.count                        offer.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:1024}  avgt    4     677.000             counts
Bench.run:·gc.time                         offer.10n  read::{f:ION_BINARY,t:BUFFER,a:STREAMING,R:INCREMENTAL,Z:1024}  avgt    4     307.000                 ms
```

A note on the implementation: I saw a ~10% improvement using the pre-computed `FIXED_SIZE_CONFIGURATIONS` cache, compared to allocating new IonBufferConfiguration instances on-demand. The `FIXED_SIZE_CONFIGURATIONS` array has length 16. IonBufferConfiguration instances are immutable.

Alternative considered: I considered adding logic to right-size the buffer configuration for any fixed-size buffer, even when the user has already specified a buffer configuration. This required copying the configuration and mutating only the buffer size options. I decided against this because 1) `FIXED_SIZE_CONFIGURATIONS` cannot be used, which eats into some of the performance benefit, and 2) in this case the user is already manually providing a buffer configuration, and should be able to correct the initial buffer size easily.

This change also includes two technically-unrelated fixes for validation behavior uncovered by recent additions to ion-tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
