### PR TITLE
Fixes a bug in WriteBuffer#shiftBytesLeft

### DIFF
--- a/src/com/amazon/ion/impl/bin/WriteBuffer.java
+++ b/src/com/amazon/ion/impl/bin/WriteBuffer.java
@@ -230,10 +230,12 @@ import java.util.List;
         // In this method, "buffer offsets" are absolute indexes into the WriteBuffer and
         // "block offsets" are indexes that are relative to the beginning of the current Block.
 
+        // The first buffer offset that does not yet contain data.
+        long position = position();
         // This is the buffer offset of the first byte that we will be shifting backwards.
-        long sourceBufferOffset = position() - length;
+        long sourceBufferOffset = position - length;
         // When we're done, this will be the first offset in the buffer that does not contain data.
-        long writeBufferLimit = sourceBufferOffset - shiftBy + length;
+        long writeBufferLimit = position - shiftBy;
 
         while (length > 0) {
             // Convert the source buffer offset into a (Block, block offset) pair.

--- a/src/com/amazon/ion/impl/bin/WriteBuffer.java
+++ b/src/com/amazon/ion/impl/bin/WriteBuffer.java
@@ -184,7 +184,7 @@ import java.util.List;
      * @throws IllegalArgumentException if `shiftBy` is greater than either `length` or the WriteBuffer's block size.
      */
     public void shiftBytesLeft(int length, int shiftBy) {
-        if (shiftBy == 0) {
+        if (length == 0 || shiftBy == 0) {
             // Nothing to do.
             return;
         }

--- a/src/com/amazon/ion/impl/bin/WriteBuffer.java
+++ b/src/com/amazon/ion/impl/bin/WriteBuffer.java
@@ -249,7 +249,7 @@ import java.util.List;
             Block destinationBlock = blocks.get(destinationBlockIndex);
             int destinationBlockOffset = offset(destinationBufferOffset);
 
-            // Determine how many bytes are left in the source in destination blocks following their respective
+            // Determine how many bytes are left in the source and destination blocks following their respective
             // block offsets.
             int bytesLeftInSourceBlock = sourceBlock.limit - sourceBlockOffset;
             int bytesLeftInDestinationBlock = destinationBlock.limit - destinationBlockOffset;

--- a/test/com/amazon/ion/impl/bin/WriteBufferTest.java
+++ b/test/com/amazon/ion/impl/bin/WriteBufferTest.java
@@ -987,7 +987,7 @@ public class WriteBufferTest
         buf.writeBytes("0123456789|0123456789|0123456789|0123456789|0123456789|".getBytes());
         // We can shift left amounts greater than the block size
         buf.shiftBytesLeft(24, 24);
-        buf.writeBytes("0123456789|0123456789|012345678".getBytes());
+        assertBuffer("01234569|0123456789|0123456789|".getBytes());
     }
 
     @Test
@@ -1038,7 +1038,7 @@ public class WriteBufferTest
         buf.writeBytes("0123456789AB".getBytes());
         // Shift left by more bytes than we're shifting (shiftBy > length)
         buf.shiftBytesLeft(2, 5);
-        buf.writeBytes("01234AB".getBytes());
+        assertBuffer("01234AB".getBytes());
     }
 
     @Test
@@ -1046,7 +1046,7 @@ public class WriteBufferTest
         assertEquals(11, ALLOCATOR.getBlockSize());
         buf.writeBytes("01234567AB".getBytes());
         buf.shiftBytesLeft(2, 8);
-        buf.writeBytes("AB".getBytes());
+        assertBuffer("AB".getBytes());
     }
 
     @Test
@@ -1054,7 +1054,7 @@ public class WriteBufferTest
         assertEquals(11, ALLOCATOR.getBlockSize());
         buf.writeBytes("0123456789AB".getBytes());
         buf.shiftBytesLeft(2, 10);
-        buf.writeBytes("AB".getBytes());
+        assertBuffer("AB".getBytes());
     }
 
     @Test


### PR DESCRIPTION
This patch fixes a bug in the `WriteBuffer` that caused the
`shiftBytesLeft` method to corrupt data if it was called such that the
final `Block` in the list was emptied AND the second-to-last block
reclaimed some capacity. This would only occur if the writer
was configured to use length preallocation greater than 0 and if they
were writing more than 32KB of Ion (the default block size) between
flushes.

This change accounts for that case and, if the last `Block`
is emptied, returns it to the pool for reuse.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
