### PR TITLE
Bumps version to 1.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazon.ion</groupId>
   <artifactId>ion-java</artifactId>
-  <version>1.9.0</version>
+  <version>1.9.2</version>
   <packaging>bundle</packaging>
 
   <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
This is directly based on 1.9.0 due to #416.  It effectively reverts
the 1.9.1 release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
