### PR TITLE
Increases the non-incremental binary reader's container length limit from 2GB to 72PB.

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderBinarySystemX.java
+++ b/src/com/amazon/ion/impl/IonReaderBinarySystemX.java
@@ -189,7 +189,7 @@ class IonReaderBinarySystemX
                 _v.setAuthoritativeType(AS_TYPE.int_value);
             }
             else if (_value_len <= MAX_BINARY_LENGTH_LONG) {
-                long v = readULong(_value_len);
+                long v = readULong((int) _value_len);
 
                 if (v < 0) {
                     // we probably can't fit this magnitude properly into a Java long
@@ -222,7 +222,7 @@ class IonReaderBinarySystemX
                 }
             }
             else {
-                BigInteger v = readBigInteger(_value_len, is_negative);
+                BigInteger v = readBigInteger((int) _value_len, is_negative);
                 _v.setValue(v);
                 _v.setAuthoritativeType(AS_TYPE.bigInteger_value);
             }
@@ -233,24 +233,24 @@ class IonReaderBinarySystemX
                 d = 0.0;
             }
             else {
-                d = readFloat(_value_len);
+                d = readFloat((int) _value_len);
             }
             _v.setValue(d);
             _v.setAuthoritativeType(AS_TYPE.double_value);
             break;
         case DECIMAL:
-            Decimal dec = readDecimal(_value_len);
+            Decimal dec = readDecimal((int) _value_len);
             _v.setValue(dec);
             _v.setAuthoritativeType(AS_TYPE.decimal_value);
             break;
         case TIMESTAMP:
             // TODO: it looks like a 0 length return a null timestamp - is that right?
-            Timestamp t = readTimestamp(_value_len);
+            Timestamp t = readTimestamp((int) _value_len);
             _v.setValue(t);
             _v.setAuthoritativeType(AS_TYPE.timestamp_value);
             break;
         case SYMBOL:
-            long sid = readULong(_value_len);
+            long sid = readULong((int) _value_len);
             if (sid < 0 || sid > Integer.MAX_VALUE) {
                 String message = "symbol id ["
                                + sid
@@ -265,7 +265,7 @@ class IonReaderBinarySystemX
             _v.setAuthoritativeType(AS_TYPE.int_value);
             break;
         case STRING:
-            String s = readString(_value_len);
+            String s = readString((int) _value_len);
             _v.setValue(s);
             _v.setAuthoritativeType(AS_TYPE.string_value);
             break;

--- a/test/com/amazon/ion/impl/IonReaderBinaryRawLargeStreamTest.java
+++ b/test/com/amazon/ion/impl/IonReaderBinaryRawLargeStreamTest.java
@@ -1,5 +1,6 @@
 package com.amazon.ion.impl;
 
+import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonWriter;
@@ -7,25 +8,27 @@ import com.amazon.ion.Timestamp;
 import com.amazon.ion.system.IonBinaryWriterBuilder;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.util.RepeatInputStream;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.math.BigDecimal;
 
 import static com.amazon.ion.impl._Private_IonConstants.BINARY_VERSION_MARKER_1_0;
+import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 
+// NOTE: these tests each take several seconds to complete.
 public class IonReaderBinaryRawLargeStreamTest {
 
-    // NOTE: this test takes several seconds to complete.
-    @Test
-    public void testReadLargeScalarStream() throws Exception {
+    private byte[] testData(Timestamp timestamp) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IonWriter writer = IonBinaryWriterBuilder.standard().build(out);
-        final Timestamp timestamp = Timestamp.forDay(2000, 1, 1);
         writer.writeString("foo");
         writer.writeDecimal(BigDecimal.TEN);
         writer.writeTimestamp(timestamp);
@@ -34,6 +37,12 @@ public class IonReaderBinaryRawLargeStreamTest {
         // Strip the IVM, as this needs to be one continuous stream to avoid resetting the reader's internals.
         byte[] data = new byte[dataWithIvm.length - BINARY_VERSION_MARKER_1_0.length];
         System.arraycopy(dataWithIvm, BINARY_VERSION_MARKER_1_0.length, data, 0, data.length);
+        return data;
+    }
+
+    public void readLargeScalarStream(IonReaderBuilder readerBuilder) throws Exception {
+        final Timestamp timestamp = Timestamp.forDay(2000, 1, 1);
+        byte[] data = testData(timestamp);
         // The binary reader uses Integer.MIN_VALUE to mean NO_LIMIT for its _local_remaining value, which keeps track
         // of the remaining number of bytes in the current value. Between values at the top level, this should always be
         // NO_LIMIT. No arithmetic should ever be performed on the value when it is set to NO_LIMIT. If bugs exist that
@@ -49,12 +58,12 @@ public class IonReaderBinaryRawLargeStreamTest {
         // the stream reached Integer.MAX_VALUE in length.
         // Repeat the batch a sufficient number of times to exceed a total stream length of Integer.MAX_VALUE, plus
         // a few more to make sure batches continue to be read correctly.
-        final int totalNumberOfBatches = (Integer.MAX_VALUE / data.length) + 7;
+        final int totalNumberOfBatches = (Integer.MAX_VALUE / data.length) + 7; // 7 makes the value exceed Integer.MAX_VALUE by an arbitrary amount.
         InputStream inputStream = new SequenceInputStream(
             new ByteArrayInputStream(BINARY_VERSION_MARKER_1_0),
             new RepeatInputStream(data, totalNumberOfBatches - 1) // This will provide the data 'totalNumberOfBatches' times
         );
-        IonReader reader = IonReaderBuilder.standard().build(inputStream);
+        IonReader reader = readerBuilder.build(inputStream);
         reader.next();
         assertEquals("foo", reader.stringValue());
         reader.next();
@@ -70,4 +79,298 @@ public class IonReaderBinaryRawLargeStreamTest {
         }
         assertEquals(totalNumberOfBatches, batchesRead);
     }
+
+    @Test
+    public void readLargeScalarStreamNonIncremental() throws Exception {
+        readLargeScalarStream(IonReaderBuilder.standard());
+    }
+
+    @Test
+    public void readLargeScalarStreamIncremental() throws Exception {
+        readLargeScalarStream(IonReaderBuilder.standard().withIncrementalReadingEnabled(true));
+    }
+
+    @Test
+    public void readLargeContainer() throws Exception {
+        final Timestamp timestamp = Timestamp.forDay(2000, 1, 1);
+
+        byte[] data = testData(timestamp);
+
+        final int totalNumberOfBatches = (Integer.MAX_VALUE / data.length) + 32768; // 32768 makes the value exceed Integer.MAX_VALUE by an arbitrary amount.
+        ByteArrayOutputStream header = new ByteArrayOutputStream();
+        header.write(BINARY_VERSION_MARKER_1_0);
+        header.write(0xBE); // List with length subfield.
+        IonBinary.writeVarUInt(header, (long) data.length * totalNumberOfBatches); // Length
+        InputStream inputStream = new SequenceInputStream(
+            new ByteArrayInputStream(header.toByteArray()),
+            new RepeatInputStream(data, totalNumberOfBatches - 1) // This will provide the data 'totalNumberOfBatches' times
+        );
+
+        IonReader reader = IonReaderBuilder.standard().build(inputStream);
+        assertEquals(IonType.LIST, reader.next());
+        reader.stepIn();
+        int batchesRead = 0;
+        while (reader.next() != null) {
+            // Materializing on every iteration makes the tests take too long. Do it on every 100.
+            boolean materializeValues = (batchesRead % 100) == 0;
+            assertEquals(IonType.STRING, reader.getType());
+            if (materializeValues) {
+                assertEquals("foo", reader.stringValue());
+            }
+            assertEquals(IonType.DECIMAL, reader.next());
+            if (materializeValues) {
+                assertEquals(BigDecimal.TEN, reader.decimalValue());
+            }
+            assertEquals(IonType.TIMESTAMP, reader.next());
+            if (materializeValues) {
+                assertEquals(timestamp, reader.timestampValue());
+            }
+            batchesRead++;
+        }
+        assertNull(reader.next());
+        reader.stepOut();
+        assertNull(reader.next());
+        assertEquals(totalNumberOfBatches, batchesRead);
+    }
+
+    @Test
+    public void skipLargeContainer() throws Exception {
+        final Timestamp timestamp = Timestamp.forDay(2000, 1, 1);
+
+        byte[] data = testData(timestamp);
+
+        final int totalNumberOfBatches = (Integer.MAX_VALUE / data.length) + 17; // 17 makes the value exceed Integer.MAX_VALUE by an arbitrary amount.
+        ByteArrayOutputStream header = new ByteArrayOutputStream();
+        header.write(BINARY_VERSION_MARKER_1_0);
+        header.write(0xCE); // S-exp with length subfield.
+        IonBinary.writeVarUInt(header, (long) data.length * totalNumberOfBatches); // Length
+        InputStream inputStream = new SequenceInputStream(
+            new ByteArrayInputStream(header.toByteArray()),
+            new SequenceInputStream(
+                new RepeatInputStream(data, totalNumberOfBatches - 1), // This will provide the data 'totalNumberOfBatches' times
+                new ByteArrayInputStream(new byte[]{(byte) 0x83, 'b', 'a', 'r'}) // The string "bar"
+            )
+        );
+
+        IonReader reader = IonReaderBuilder.standard().build(inputStream);
+        assertEquals(IonType.SEXP, reader.next());
+        assertEquals(IonType.STRING, reader.next());
+        assertEquals("bar", reader.stringValue());
+        assertNull(reader.next());
+    }
+
+    @Test
+    public void skipLargeNestedContainer() throws Exception {
+        final Timestamp timestamp = Timestamp.forDay(2000, 1, 1);
+
+        byte[] data = testData(timestamp);
+
+        final int totalNumberOfBatches = (Integer.MAX_VALUE / data.length) + 512; // 512 makes the value exceed Integer.MAX_VALUE by an arbitrary amount.
+        final long nestedDataLength = (long) data.length * totalNumberOfBatches;
+        ByteArrayOutputStream header = new ByteArrayOutputStream();
+        header.write(BINARY_VERSION_MARKER_1_0);
+        header.write(0xCE); // S-exp with length subfield.
+        IonBinary.writeVarUInt(header, 1 + IonBinary.lenVarUInt(nestedDataLength) + nestedDataLength); // Length
+        header.write(0xBE); // List with length subfield.
+        IonBinary.writeVarUInt(header, nestedDataLength);
+        InputStream inputStream = new SequenceInputStream(
+            new ByteArrayInputStream(header.toByteArray()),
+            new SequenceInputStream(
+                new RepeatInputStream(data, totalNumberOfBatches - 1), // This will provide the data 'totalNumberOfBatches' times
+                new ByteArrayInputStream(new byte[]{(byte) 0x83, 'b', 'a', 'r'}) // The string "bar"
+            )
+        );
+
+        IonReader reader = IonReaderBuilder.standard().build(inputStream);
+        assertEquals(IonType.SEXP, reader.next());
+        reader.stepIn();
+        assertEquals(IonType.LIST, reader.next());
+        assertNull(reader.next());
+        reader.stepOut();
+        assertEquals(IonType.STRING, reader.next());
+        assertEquals("bar", reader.stringValue());
+        assertNull(reader.next());
+    }
+
+    @Test
+    public void readLargeAnnotatedContainer() throws Exception {
+        final Timestamp timestamp = Timestamp.forDay(2000, 1, 1);
+        byte[] raw = testData(timestamp);
+        ByteArrayOutputStream dataBuilder = new ByteArrayOutputStream();
+        dataBuilder.write(0x85); // Field name. Conveniently use SID 5 ("version"), which is in the system symbol table.
+        dataBuilder.write(0xBE); // List with length subfield.
+        IonBinary.writeVarUInt(dataBuilder, raw.length);
+        dataBuilder.write(raw);
+        byte[] data = dataBuilder.toByteArray();
+
+        final int totalNumberOfBatches = (Integer.MAX_VALUE / data.length) + 100000; // 100000 makes the value exceed Integer.MAX_VALUE by an arbitrary amount.
+        ByteArrayOutputStream header = new ByteArrayOutputStream();
+        header.write(BINARY_VERSION_MARKER_1_0);
+        long containerLength = (long) data.length * totalNumberOfBatches;
+        header.write(0xEE); // Annotation wrapper with length subfield.
+        IonBinary.writeVarUInt(header, containerLength + 3 + IonBinary.lenVarUInt(containerLength));
+        header.write(0x81); // One byte of annotations.
+        header.write(0x84); // Conveniently use SID 4 ("name"), which is in the system symbol table.
+        header.write(0xDE); // Struct with length subfield.
+        IonBinary.writeVarUInt(header, containerLength); // Length
+        InputStream inputStream = new SequenceInputStream(
+            new ByteArrayInputStream(header.toByteArray()),
+            new RepeatInputStream(data, totalNumberOfBatches - 1) // This will provide the data 'totalNumberOfBatches' times
+        );
+        IonReader reader = IonReaderBuilder.standard().build(inputStream);
+        assertEquals(IonType.STRUCT, reader.next());
+        String[] annotations = reader.getTypeAnnotations();
+        assertEquals(1, annotations.length);
+        assertEquals("name", annotations[0]);
+        reader.stepIn();
+        int batchesRead = 0;
+        while (reader.next() != null) {
+            assertEquals(IonType.LIST, reader.getType());
+            // Materializing on every iteration makes the tests take too long. Do it on every 100.
+            boolean materializeValues = (batchesRead % 100) == 0;
+            if (materializeValues) {
+                assertEquals("version", reader.getFieldName());
+                reader.stepIn();
+                assertEquals(IonType.STRING, reader.next());
+                assertEquals("foo", reader.stringValue());
+                assertEquals(IonType.DECIMAL, reader.next());
+                assertEquals(BigDecimal.TEN, reader.decimalValue());
+                assertEquals(IonType.TIMESTAMP, reader.next());
+                assertEquals(timestamp, reader.timestampValue());
+                assertNull(reader.next());
+                reader.stepOut();
+            }
+            batchesRead++;
+        }
+        assertNull(reader.next());
+        reader.stepOut();
+        assertNull(reader.next());
+        assertEquals(totalNumberOfBatches, batchesRead);
+    }
+
+    @Test
+    public void skipLargeAnnotatedContainer() throws Exception {
+        final Timestamp timestamp = Timestamp.forDay(2000, 1, 1);
+        byte[] raw = testData(timestamp);
+        ByteArrayOutputStream dataBuilder = new ByteArrayOutputStream();
+        dataBuilder.write(0xEE); // Annotation wrapper with length subfield.
+        IonBinary.writeVarUInt(dataBuilder, 3 + IonBinary.lenVarUInt(raw.length) + raw.length);
+        dataBuilder.write(0x81); // One byte of annotations.
+        dataBuilder.write(0x85); // Annotation. Conveniently use SID 5 ("version"), which is in the system symbol table.
+        dataBuilder.write(0xCE); // S-exp with length subfield.
+        IonBinary.writeVarUInt(dataBuilder, raw.length);
+        dataBuilder.write(raw);
+        byte[] data = dataBuilder.toByteArray();
+
+        final int totalNumberOfBatches = (Integer.MAX_VALUE / data.length) + 1000000; // 1000000 makes the value exceed Integer.MAX_VALUE by an arbitrary amount.
+        ByteArrayOutputStream header = new ByteArrayOutputStream();
+        header.write(BINARY_VERSION_MARKER_1_0);
+        long containerLength = (long) data.length * totalNumberOfBatches;
+        header.write(0xEE); // Annotation wrapper with length subfield.
+        IonBinary.writeVarUInt(header, containerLength + 3 + IonBinary.lenVarUInt(containerLength));
+        header.write(0x81); // One byte of annotations.
+        header.write(0x84); // Conveniently use SID 4 ("name"), which is in the system symbol table.
+        header.write(0xBE); // List with length subfield.
+        IonBinary.writeVarUInt(header, containerLength); // Length
+        InputStream inputStream = new SequenceInputStream(
+            new ByteArrayInputStream(header.toByteArray()),
+            new RepeatInputStream(data, totalNumberOfBatches - 1) // This will provide the data 'totalNumberOfBatches' times
+        );
+        IonReader reader = IonReaderBuilder.standard().build(inputStream);
+        assertEquals(IonType.LIST, reader.next());
+        String[] annotations = reader.getTypeAnnotations();
+        assertEquals(1, annotations.length);
+        assertEquals("name", annotations[0]);
+        assertNull(reader.next());
+    }
+
+    // Note: the objective of the following tests is not to assert that large scalars *should* fail, but rather that
+    // when they *do* fail due to limitations of the current implementation, they fail by throwing an IonException
+    // and not something unexpected and ugly.
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private void cleanlyFailsOnLargeScalar(IonReaderBuilder readerBuilder) throws Exception {
+        byte[] data = "foobarbaz".getBytes("UTF-8");
+        final int totalNumberOfBatches = (Integer.MAX_VALUE / data.length) + 123; // 123 makes the value exceed Integer.MAX_VALUE by an arbitrary amount.
+        ByteArrayOutputStream header = new ByteArrayOutputStream();
+        header.write(BINARY_VERSION_MARKER_1_0);
+        header.write(0x8E); // String with length subfield.
+        IonBinary.writeVarUInt(header, (long) totalNumberOfBatches * data.length);
+        InputStream inputStream = new SequenceInputStream(
+            new ByteArrayInputStream(header.toByteArray()),
+            new RepeatInputStream(data, totalNumberOfBatches - 1) // This will provide the data 'totalNumberOfBatches' times
+        );
+        IonReader reader = readerBuilder.build(inputStream);
+        // If support for large scalars is added, the following line will be deleted and the rest of the test
+        // completed to assert the correctness of the value.
+        thrown.expect(IonException.class);
+        reader.next();
+    }
+
+    @Test
+    public void cleanlyFailsOnLargeScalarNonIncremental() throws Exception {
+        cleanlyFailsOnLargeScalar(IonReaderBuilder.standard());
+    }
+
+    @Test
+    public void cleanlyFailsOnLargeScalarIncremental() throws Exception {
+        cleanlyFailsOnLargeScalar(IonReaderBuilder.standard().withIncrementalReadingEnabled(true));
+    }
+
+    private void cleanlyFailsOnLargeAnnotatedScalar(IonReaderBuilder readerBuilder) throws Exception {
+        byte[] data = "foobarbaz".getBytes("UTF-8");
+        final int totalNumberOfBatches = (Integer.MAX_VALUE / data.length) + 9999; // 9999 makes the value exceed Integer.MAX_VALUE by an arbitrary amount.
+        final long stringLength = (long) totalNumberOfBatches * data.length;
+        ByteArrayOutputStream header = new ByteArrayOutputStream();
+        header.write(BINARY_VERSION_MARKER_1_0);
+        header.write(0xEE); // Annotation wrapper with length subfield.
+        IonBinary.writeVarUInt(header, 3 + IonBinary.lenVarUInt(stringLength) + stringLength);
+        header.write(0x81); // One byte of annotations.
+        header.write(0x84); // Conveniently use SID 4 ("name"), which is in the system symbol table.
+        header.write(0x8E); // String with length subfield.
+        IonBinary.writeVarUInt(header, stringLength);
+        InputStream inputStream = new SequenceInputStream(
+            new ByteArrayInputStream(header.toByteArray()),
+            new RepeatInputStream(data, totalNumberOfBatches - 1) // This will provide the data 'totalNumberOfBatches' times
+        );
+        IonReader reader = readerBuilder.build(inputStream);
+        // If support for large scalars is added, the following line will be deleted and the rest of the test
+        // completed to assert the correctness of the value.
+        thrown.expect(IonException.class);
+        reader.next();
+    }
+
+    @Test
+    public void cleanlyFailsOnLargeAnnotatedScalarNonIncremental() throws Exception {
+        cleanlyFailsOnLargeAnnotatedScalar(IonReaderBuilder.standard());
+    }
+
+    @Test
+    public void cleanlyFailsOnLargeAnnotatedScalarIncremental() throws Exception {
+        cleanlyFailsOnLargeAnnotatedScalar(IonReaderBuilder.standard().withIncrementalReadingEnabled(true));
+    }
+
+    @Test
+    public void cleanlyFailsOnLargeContainerIncremental() throws Exception {
+        final Timestamp timestamp = Timestamp.forDay(2000, 1, 1);
+
+        byte[] data = testData(timestamp);
+
+        final int totalNumberOfBatches = (Integer.MAX_VALUE / data.length) + 42; // 42 makes the value exceed Integer.MAX_VALUE by an arbitrary amount.
+        ByteArrayOutputStream header = new ByteArrayOutputStream();
+        header.write(BINARY_VERSION_MARKER_1_0);
+        header.write(0xCE); // S-exp with length subfield.
+        IonBinary.writeVarUInt(header, (long) data.length * totalNumberOfBatches); // Length
+        InputStream inputStream = new SequenceInputStream(
+            new ByteArrayInputStream(header.toByteArray()),
+            new RepeatInputStream(data, totalNumberOfBatches - 1) // This will provide the data 'totalNumberOfBatches' times
+        );
+
+        IonReader reader = IonReaderBuilder.standard().withIncrementalReadingEnabled(true).build(inputStream);
+        thrown.expect(IonException.class);
+        reader.next();
+    }
+
 }

--- a/test/com/amazon/ion/util/RepeatInputStream.java
+++ b/test/com/amazon/ion/util/RepeatInputStream.java
@@ -77,7 +77,7 @@ public final class RepeatInputStream
             return -1;
         }
 
-        int rem = len - off;
+        int rem = len;
         int consumed = 0;
         while (rem > 0 && !isDone())
         {


### PR DESCRIPTION
*Issue #, if available:*
#170 (for containers, not scalars)

*Description of changes:*
The non-incremental reader does not need to fully buffer container values, so the inability to index into a byte array using an `int` is not a limitation for container values like it currently is for scalars.

This PR allows containers, when read by the non-incremental reader, to require up to 7 bytes of a `long` to represent their lengths. If my math is correct that's 72PB, which will probably be sufficient for a while. If it's not, that's impressive.

There are instances in this diff where a `long` is cast to an `int`. This is done only when it is known that the value being cast must fit in an `int`, either because the value represents the length of a scalar after validation of the limit, or because it was calculated by subtracting a positive `int` from another positive `int`.

The changes in IonReaderLookaheadBuffer (which is used by the incremental reader) are necessary to cleanly fail (by throwing `IonException`) when the limit is passed. This implementation's limit applies to both containers and scalars, as every top-level value will be held in a contiguous `byte[]`.

The bug fixed in `RepeatInputStream` was uncovered due to more robust coverage added in the `IonReaderBinaryRawLargeStreamTest` tests, where for the first time `off` may exceed `len`.

`RepeatInputStream` is used heavily by these tests to avoid having to actually hold multi-GB Ion streams in memory or on disk. We create large streams by repeatedly providing the same data to the reader until a target stream size has been reached. I haven't added a test that verifies that container lengths up to the limit work, as it would take too long. Longer-running tests would be better suited to a CI/CD workflow that runs before new versions are released.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
