### PR TITLE
Fixes a bug in header compaction for empty containers.

### DIFF
--- a/src/com/amazon/ion/impl/bin/WriteBuffer.java
+++ b/src/com/amazon/ion/impl/bin/WriteBuffer.java
@@ -180,7 +180,7 @@ import java.util.List;
      * @param shiftBy   The number of bytes to the left that we'll be shifting.
      */
     public void shiftBytesLeft(int length, int shiftBy) {
-        if (length == 0 || shiftBy == 0) {
+        if (shiftBy == 0) {
             // Nothing to do.
             return;
         }

--- a/test/AllTests.java
+++ b/test/AllTests.java
@@ -77,6 +77,7 @@ import com.amazon.ion.impl.LocalSymbolTableTest;
 import com.amazon.ion.impl.SharedSymbolTableTest;
 import com.amazon.ion.impl.SymbolTableTest;
 import com.amazon.ion.impl.TreeReaderTest;
+import com.amazon.ion.impl.bin.IonManagedBinaryWriterGoodTest;
 import com.amazon.ion.impl.bin.IonManagedBinaryWriterTest;
 import com.amazon.ion.impl.bin.IonRawBinaryWriterTest;
 import com.amazon.ion.impl.bin.PooledBlockAllocatorProviderTest;
@@ -217,11 +218,12 @@ import org.junit.runners.Suite;
     ResizingPipedInputStreamTest.class,
     IonReaderLookaheadBufferTest.class,
 
-    // experimental binary writer tests
+    // binary writer tests
     PooledBlockAllocatorProviderTest.class,
     WriteBufferTest.class,
     IonRawBinaryWriterTest.class,
     IonManagedBinaryWriterTest.class,
+    IonManagedBinaryWriterGoodTest.class,
 
     // Hash code tests
     HashCodeCorrectnessTest.class,

--- a/test/com/amazon/ion/impl/bin/IonManagedBinaryWriterGoodTest.java
+++ b/test/com/amazon/ion/impl/bin/IonManagedBinaryWriterGoodTest.java
@@ -1,0 +1,56 @@
+package com.amazon.ion.impl.bin;
+
+import com.amazon.ion.IonException;
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.impl._Private_Utils;
+import com.amazon.ion.junit.Injected;
+import com.amazon.ion.system.IonReaderBuilder;
+import org.junit.Test;
+
+import java.io.File;
+
+import static com.amazon.ion.TestUtils.GLOBAL_SKIP_LIST;
+import static com.amazon.ion.TestUtils.GOOD_IONTESTS_FILES;
+import static com.amazon.ion.TestUtils.hexDump;
+import static com.amazon.ion.TestUtils.testdataFiles;
+
+/**
+ * Re-writes and verifies all "good" ion-tests files using all combinations of IonManagedBinaryWriter options.
+ */
+public class IonManagedBinaryWriterGoodTest extends IonManagedBinaryWriterTestCase {
+
+    @Injected.Inject("testFile")
+    public static final File[] FILES =
+        testdataFiles(GLOBAL_SKIP_LIST,
+            GOOD_IONTESTS_FILES);
+
+
+    private File myTestFile;
+
+    public void setTestFile(File file)
+    {
+        myTestFile = file;
+    }
+
+    @Test
+    public void allGoodFiles() throws Exception {
+        byte[] testData = _Private_Utils.loadFileBytes(myTestFile);
+        IonReader reader = IonReaderBuilder.standard().build(testData);
+        writer.writeValues(reader);
+        reader.close();
+
+        writer.finish();
+        final byte[] data = writer.getBytes();
+        final IonValue actual;
+        try {
+            actual = system().getLoader().load(data);
+        } catch (final Exception e) {
+            throw new IonException("Bad generated data:\n" + hexDump(data), e);
+        }
+        final IonValue expected = system().getLoader().load(testData);
+        assertEquals(expected, actual);
+
+        additionalValueAssertions(actual);
+    }
+}

--- a/test/com/amazon/ion/impl/bin/IonManagedBinaryWriterTest.java
+++ b/test/com/amazon/ion/impl/bin/IonManagedBinaryWriterTest.java
@@ -15,165 +15,21 @@
 
 package com.amazon.ion.impl.bin;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableMap;
-
-import com.amazon.ion.IonContainer;
 import com.amazon.ion.IonDatagram;
 import com.amazon.ion.IonInt;
-import com.amazon.ion.IonMutableCatalog;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonSymbol;
 import com.amazon.ion.IonType;
-import com.amazon.ion.IonValue;
 import com.amazon.ion.IonWriter;
-import com.amazon.ion.SymbolTable;
-import com.amazon.ion.SymbolToken;
-import com.amazon.ion.SystemSymbols;
-import com.amazon.ion.impl.bin.IonManagedBinaryWriter.ImportedSymbolResolverMode;
-import com.amazon.ion.impl.bin._Private_IonManagedBinaryWriterBuilder.AllocatorMode;
-import com.amazon.ion.junit.Injected.Inject;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import org.junit.Test;
 
 @SuppressWarnings("deprecation")
-public class IonManagedBinaryWriterTest extends IonRawBinaryWriterTest
+public class IonManagedBinaryWriterTest extends IonManagedBinaryWriterTestCase
 {
-    @SuppressWarnings("unchecked")
-    private static final List<List<String>> SHARED_SYMBOLS = unmodifiableList(asList(
-        unmodifiableList(asList(
-            "a",
-            "b",
-            "c"
-        )),
-        unmodifiableList(asList(
-            "d",
-            "e"
-        ))
-    ));
-
-    private static final Map<String, Integer> SHARED_SYMBOL_LOCAL_SIDS ;
-    static
-    {
-        final Map<String, Integer> sidMap = new HashMap<String, Integer>();
-
-        for (final SymbolToken token : Symbols.systemSymbols())
-        {
-            sidMap.put(token.getText(), token.getSid());
-        }
-        int sid = SystemSymbols.ION_1_0_MAX_ID + 1;
-        for (final List<String> symbolList : SHARED_SYMBOLS)
-        {
-            for (final String symbol : symbolList) {
-                sidMap.put(symbol, sid);
-                sid++;
-            }
-        }
-        SHARED_SYMBOL_LOCAL_SIDS = unmodifiableMap(sidMap);
-    }
-
-    private enum LSTAppendMode
-    {
-        LST_APPEND_DISABLED,
-        LST_APPEND_ENABLED;
-        public boolean isEnabled() { return this == LST_APPEND_ENABLED; }
-    }
-
-    @Inject("lstAppendMode")
-    public static final LSTAppendMode[] LST_APPEND_ENABLED_DIMENSIONS = LSTAppendMode.values();
-    private LSTAppendMode lstAppendMode;
-    public void setLstAppendMode(final LSTAppendMode mode)
-    {
-        this.lstAppendMode = mode;
-    }
-
-    private void checkSymbolTokenAgainstImport(final SymbolToken token)
-    {
-        final Integer sid = SHARED_SYMBOL_LOCAL_SIDS.get(token.getText());
-        if (sid != null)
-        {
-            assertEquals(sid.intValue(), token.getSid());
-        }
-    }
-
-    @Override
-    protected void additionalValueAssertions(final IonValue value)
-    {
-        for (final SymbolToken token : value.getTypeAnnotationSymbols()) {
-            checkSymbolTokenAgainstImport(token);
-        }
-        final IonType type = value.getType();
-        if (type == IonType.SYMBOL && !value.isNullValue())
-        {
-            checkSymbolTokenAgainstImport(((IonSymbol) value).symbolValue());
-        }
-        else if (IonType.isContainer(type))
-        {
-            for (final IonValue child : ((IonContainer) value))
-            {
-                additionalValueAssertions(child);
-            }
-        }
-    }
-
-    @Override
-    public int ivmLength() {
-        return 4;
-    }
-
-
-    @Inject("importedSymbolResolverMode")
-    public static final ImportedSymbolResolverMode[] RESOLVER_DIMENSIONS = ImportedSymbolResolverMode.values();
-
-    private ImportedSymbolResolverMode importedSymbolResolverMode;
-
-    public void setImportedSymbolResolverMode(final ImportedSymbolResolverMode mode)
-    {
-        importedSymbolResolverMode = mode;
-    }
-
-    @Override
-    protected IonWriter createWriter(final OutputStream out) throws IOException
-    {
-        final IonMutableCatalog catalog = ((IonMutableCatalog) system().getCatalog());
-
-        final List<SymbolTable> symbolTables = new ArrayList<SymbolTable>();
-        int i = 1;
-        for (final List<String> symbols : SHARED_SYMBOLS) {
-            final SymbolTable table = system().newSharedSymbolTable("test_" + (i++), 1, symbols.iterator());
-            symbolTables.add(table);
-            catalog.putTable(table);
-        }
-
-        final _Private_IonManagedBinaryWriterBuilder builder = _Private_IonManagedBinaryWriterBuilder
-            .create(AllocatorMode.POOLED)
-            .withImports(importedSymbolResolverMode, symbolTables)
-            .withPreallocationMode(preallocationMode)
-            .withFloatBinary32Enabled();
-
-        if (lstAppendMode.isEnabled()) {
-            builder.withLocalSymbolTableAppendEnabled();
-        } else {
-            builder.withLocalSymbolTableAppendDisabled();
-        }
-
-        final IonWriter writer = builder.newWriter(out);
-
-        final SymbolTable locals = writer.getSymbolTable();
-        assertEquals(14, locals.getImportedMaxId());
-
-        return writer;
-    }
 
     @Test
     public void testSetStringAnnotations() throws Exception
@@ -373,5 +229,28 @@ public class IonManagedBinaryWriterTest extends IonRawBinaryWriterTest
         // SymbolTable expected = system().newSharedSymbolTable("version", )
         bos.toByteArray();
 
+    }
+
+    @Test
+    public void testNestedEmptyContainer() throws Exception
+    {
+        writer.stepIn(IonType.STRUCT);
+        writer.setFieldName("bar");
+        writer.stepIn(IonType.LIST);
+        writer.stepOut();
+        writer.stepOut();
+        assertValue("{bar: []}");
+    }
+
+    @Test
+    public void testNestedEmptyAnnotatedContainer() throws Exception
+    {
+        writer.stepIn(IonType.STRUCT);
+        writer.setFieldName("bar");
+        writer.addTypeAnnotation("foo");
+        writer.stepIn(IonType.LIST);
+        writer.stepOut();
+        writer.stepOut();
+        assertValue("{bar: foo::[]}");
     }
 }

--- a/test/com/amazon/ion/impl/bin/IonManagedBinaryWriterTestCase.java
+++ b/test/com/amazon/ion/impl/bin/IonManagedBinaryWriterTestCase.java
@@ -1,0 +1,152 @@
+package com.amazon.ion.impl.bin;
+
+import com.amazon.ion.IonContainer;
+import com.amazon.ion.IonMutableCatalog;
+import com.amazon.ion.IonSymbol;
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.SymbolTable;
+import com.amazon.ion.SymbolToken;
+import com.amazon.ion.SystemSymbols;
+import com.amazon.ion.junit.Injected;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+
+public class IonManagedBinaryWriterTestCase extends IonRawBinaryWriterTest {
+
+    @SuppressWarnings("unchecked")
+    private static final List<List<String>> SHARED_SYMBOLS = unmodifiableList(asList(
+        unmodifiableList(asList(
+            "a",
+            "b",
+            "c"
+        )),
+        unmodifiableList(asList(
+            "d",
+            "e"
+        ))
+    ));
+
+    private static final Map<String, Integer> SHARED_SYMBOL_LOCAL_SIDS ;
+    static
+    {
+        final Map<String, Integer> sidMap = new HashMap<String, Integer>();
+
+        for (final SymbolToken token : Symbols.systemSymbols())
+        {
+            sidMap.put(token.getText(), token.getSid());
+        }
+        int sid = SystemSymbols.ION_1_0_MAX_ID + 1;
+        for (final List<String> symbolList : SHARED_SYMBOLS)
+        {
+            for (final String symbol : symbolList) {
+                sidMap.put(symbol, sid);
+                sid++;
+            }
+        }
+        SHARED_SYMBOL_LOCAL_SIDS = unmodifiableMap(sidMap);
+    }
+
+    protected enum LSTAppendMode
+    {
+        LST_APPEND_DISABLED,
+        LST_APPEND_ENABLED;
+        public boolean isEnabled() { return this == LST_APPEND_ENABLED; }
+    }
+
+    @Injected.Inject("lstAppendMode")
+    public static final LSTAppendMode[] LST_APPEND_ENABLED_DIMENSIONS = LSTAppendMode.values();
+    protected LSTAppendMode lstAppendMode;
+    public void setLstAppendMode(final LSTAppendMode mode)
+    {
+        this.lstAppendMode = mode;
+    }
+
+    private void checkSymbolTokenAgainstImport(final SymbolToken token)
+    {
+        final Integer sid = SHARED_SYMBOL_LOCAL_SIDS.get(token.getText());
+        if (sid != null)
+        {
+            assertEquals(sid.intValue(), token.getSid());
+        }
+    }
+
+    @Override
+    protected void additionalValueAssertions(final IonValue value)
+    {
+        for (final SymbolToken token : value.getTypeAnnotationSymbols()) {
+            checkSymbolTokenAgainstImport(token);
+        }
+        final IonType type = value.getType();
+        if (type == IonType.SYMBOL && !value.isNullValue())
+        {
+            checkSymbolTokenAgainstImport(((IonSymbol) value).symbolValue());
+        }
+        else if (IonType.isContainer(type))
+        {
+            for (final IonValue child : ((IonContainer) value))
+            {
+                additionalValueAssertions(child);
+            }
+        }
+    }
+
+    @Override
+    public int ivmLength() {
+        return 4;
+    }
+
+
+    @Injected.Inject("importedSymbolResolverMode")
+    public static final IonManagedBinaryWriter.ImportedSymbolResolverMode[] RESOLVER_DIMENSIONS = IonManagedBinaryWriter.ImportedSymbolResolverMode.values();
+
+    private IonManagedBinaryWriter.ImportedSymbolResolverMode importedSymbolResolverMode;
+
+    public void setImportedSymbolResolverMode(final IonManagedBinaryWriter.ImportedSymbolResolverMode mode)
+    {
+        importedSymbolResolverMode = mode;
+    }
+
+    @Override
+    protected IonWriter createWriter(final OutputStream out) throws IOException
+    {
+        final IonMutableCatalog catalog = ((IonMutableCatalog) system().getCatalog());
+
+        final List<SymbolTable> symbolTables = new ArrayList<SymbolTable>();
+        int i = 1;
+        for (final List<String> symbols : SHARED_SYMBOLS) {
+            final SymbolTable table = system().newSharedSymbolTable("test_" + (i++), 1, symbols.iterator());
+            symbolTables.add(table);
+            catalog.putTable(table);
+        }
+
+        final _Private_IonManagedBinaryWriterBuilder builder = _Private_IonManagedBinaryWriterBuilder
+            .create(_Private_IonManagedBinaryWriterBuilder.AllocatorMode.POOLED)
+            .withImports(importedSymbolResolverMode, symbolTables)
+            .withPreallocationMode(preallocationMode)
+            .withFloatBinary32Enabled();
+
+        if (lstAppendMode.isEnabled()) {
+            builder.withLocalSymbolTableAppendEnabled();
+        } else {
+            builder.withLocalSymbolTableAppendDisabled();
+        }
+
+        final IonWriter writer = builder.newWriter(out);
+
+        final SymbolTable locals = writer.getSymbolTable();
+        assertEquals(14, locals.getImportedMaxId());
+
+        return writer;
+    }
+}

--- a/test/com/amazon/ion/impl/bin/WriteBufferTest.java
+++ b/test/com/amazon/ion/impl/bin/WriteBufferTest.java
@@ -1073,4 +1073,24 @@ public class WriteBufferTest
         buf.shiftBytesLeft(1, 6);
         assertBuffer("ABCDE01234B".getBytes());
     }
+
+    @Test
+    public void shiftBytesLeftWithLengthZero() {
+        assertEquals(11, ALLOCATOR.getBlockSize());
+        buf.writeBytes("012345".getBytes());
+        // Shift left by two, retaining zero bytes (i.e. truncate).
+        // In Ion, this situation occurs when a length bytes are preallocated for containers that end up being empty.
+        buf.shiftBytesLeft(0, 2);
+        assertBuffer("0123".getBytes());
+    }
+
+    @Test
+    public void shiftBytesLeftWithLengthZeroAcrossBlocks() {
+        assertEquals(11, ALLOCATOR.getBlockSize());
+        buf.writeBytes("0123456789|0".getBytes());
+        // Shift left by two, retaining zero bytes (i.e. truncate).
+        // In Ion, this situation occurs when a length bytes are preallocated for containers that end up being empty.
+        buf.shiftBytesLeft(0, 2);
+        assertBuffer("0123456789".getBytes());
+    }
 }


### PR DESCRIPTION
*Description of changes:*
Fixes a bug in header compaction for empty containers. Also adds testing for all writer option combinations over all good ion-tests files.

Containers that end up being empty have preallocated lengths when preallocation is enabled. Such containers end up calling `WriteBuffer.shiftBytesLeft` with `length=0`. The pre-fix behavior of short-circuiting resulted in the preallocated bytes remaining in the buffer. However, the other compaction logic still changed the type ID byte to reflect the actual length of the container (0), causing errors to be raised when the reader encountered the still-present overpadded length bytes. Simply removing the short-circuit condition allows `WriteBuffer.shiftBytesLeft(0, ...)` to correctly behave as a truncation.

The new `IonManagedBinaryWriterGoodTest` re-writes  and verifies every `good` ion-tests file using all of the parameterized write options in `IonManagedBinaryWriterTestCase` and `IonRawBinaryWriterTest`. This includes LST append enabled/disabled, imported symbol table resolver modes, and container length preallocation. This results in about 80k new tests, of which 160 failed without the bugfix proposed in this PR.

The red stuff in IonManagedBinaryWriterTest is the green stuff in IonManagedBinaryWriterTestCase.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
