### PR TITLE
Fixes a bug that prevented the incremental reader from recovering from an oversized value that occurred mid-stream.

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderLookaheadBuffer.java
+++ b/src/com/amazon/ion/impl/IonReaderLookaheadBuffer.java
@@ -516,6 +516,7 @@ public final class IonReaderLookaheadBuffer extends ReaderLookaheadBufferBase {
         peekIndex = Math.max(peekIndex - shiftAmount, 0);
         valuePreHeaderIndex -= shiftAmount;
         valuePostHeaderIndex -= shiftAmount;
+        valueStartWriteIndex -= shiftAmount;
         for (Marker symbolTableMarker : symbolTableMarkers) {
             if (symbolTableMarker.startIndex > afterIndex) {
                 symbolTableMarker.startIndex -= shiftAmount;


### PR DESCRIPTION
*Description of changes:*
The existing tests failed to cover the case where an oversized value occurs mid-stream. Tests in a consuming package uncovered this issue. Before this fix, a `BufferOverflowException` would be raised in this situation because the buffer's write index was not shifted left to make room for more data when an oversized value was skipped. After this fix, oversized values are able to be skipped properly, allowing processing of the rest of the values in the stream to proceed normally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
