### PR TITLE
Adds missing validation for the length of symbol table child values.

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderBinaryIncremental.java
+++ b/src/com/amazon/ion/impl/IonReaderBinaryIncremental.java
@@ -962,6 +962,9 @@ class IonReaderBinaryIncremental implements IonReader, _Private_ReaderWriter, _P
             }
             peekIndex = currentValueEndPosition;
         }
+        if (peekIndex > marker.endIndex) {
+            throw new IonException("Malformed symbol table. Child values exceeded the length declared in the header.");
+        }
         if (!hasSeenImports) {
             resetSymbolTable();
             resetImports();

--- a/test/com/amazon/ion/impl/IonReaderBinaryIncrementalTest.java
+++ b/test/com/amazon/ion/impl/IonReaderBinaryIncrementalTest.java
@@ -3388,4 +3388,22 @@ public class IonReaderBinaryIncrementalTest {
     public void annotationIteratorReuseDisabled() throws Exception {
         annotationIteratorReuse(false);
     }
+
+    @Test
+    public void failsOnMalformedSymbolTable() {
+        byte[] data = bytes(
+            0xE0, 0x01, 0x00, 0xEA, // Binary IVM
+            0xE6, // 6-byte annotation wrapper
+            0x81, // 1 byte of annotation SIDs
+            0x83, // SID 3 ($ion_symbol_table)
+            0xD3, // 3-byte struct
+            0x84, // Field name SID 4 (name)
+            0xE7, // 7-byte annotation wrapper (error: there should only be two bytes remaining).
+            0x81, // Junk byte to fill the 6 bytes of the annotation wrapper and 3 bytes of the struct.
+            0x20  // Next top-level value (int 0).
+        );
+        IonReader reader = newBoundedIncrementalReader(data, 1024);
+        thrown.expect(IonException.class);
+        reader.next();
+    }
 }


### PR DESCRIPTION
*Description of changes:*
Adds missing validation of symbol table lengths to the incremental reader. The data in the test contains a symbol table that ends when the outer header says it will, but contains child value headers that declare lengths that exceed the declared length of the outer header. This is invalid Ion and should raise an error. I will open an issue in ion-tests to add this data as a `bad` vector.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
