### PR TITLE
Jar info changes

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,3 @@
+build.version=${pom.version}
+build.time=${timestamp}
+build.name=${pom.name}

--- a/build.properties
+++ b/build.properties
@@ -1,3 +1,0 @@
-build.version=${pom.version}
-build.time=${timestamp}
-build.name=${pom.name}

--- a/pom.xml
+++ b/pom.xml
@@ -148,9 +148,6 @@
             </Export-Package>
             <!-- This can be used to retrieve the compiled JarInfo. -->
             <Main-Class>com.amazon.ion.impl._Private_CommandLine</Main-Class>
-            <!-- Add these properties to the manifest so they may be retrieved at runtime. -->
-            <Ion-Java-Build-Time>${build.time}</Ion-Java-Build-Time>
-            <Ion-Java-Project-Version>${project.version}</Ion-Java-Project-Version>
             <Automatic-Module-Name>com.amazon.ion</Automatic-Module-Name>
           </instructions>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,13 @@
       <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.hamcrest/hamcrest -->
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>pl.pragmatists</groupId>
       <artifactId>JUnitParams</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,17 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
     <build.year>${maven.build.timestamp}</build.year>
-    <jdkVersion>1.6</jdkVersion>
+    <!-- As of 2022 we still need to use a parallel property to actually get formatting
+      Don't be fooled if removing the .format line below looks to have no effect- try changing it.
+      See: https://issues.apache.org/jira/browse/MRESOURCES-99
+      -->
+    <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssXXX</maven.build.timestamp.format>
+    <build.time>${maven.build.timestamp}</build.time>
+    <!-- Can't target 6 from 8
+      https://stackoverflow.com/questions/48146930/is-it-possible-to-compile-project-on-java-8-for-target-java-6
+    -->
+    <jdk.source.version>6</jdk.source.version>
+    <jdk.target.version>6</jdk.target.version>
   </properties>
 
   <dependencies>
@@ -85,43 +95,29 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <!-- src/main/resources is the default resources directory but it looks like we need to list it explicitly in
+             order to set filtering=true, which does the interpolation in properties files
+             -->
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <sourceDirectory>src</sourceDirectory>
     <testSourceDirectory>test</testSourceDirectory>
     <plugins>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>${jdkVersion}</source>
-          <target>${jdkVersion}</target>
+          <source>${jdk.source.version}</source>
+          <target>${jdk.target.version}</target>
         </configuration>
       </plugin>
-      <plugin>
-        <!--
-        Since the format of maven.build.timestamp cannot be changed
-        during the build, define the build.time property here.
-        -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.8</version>
-        <executions>
-          <execution>
-            <phase>initialize</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <exportAntProperties>true</exportAntProperties>
-              <target>
-                <tstamp>
-                  <format property="build.time" pattern="yyyy-MM-dd'T'HH:mm:ssXXX"/>
-                </tstamp>
-              </target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+
       <plugin>
         <!-- Run the unit tests. -->
         <groupId>org.apache.maven.plugins</groupId>
@@ -134,6 +130,7 @@
           <argLine>-ea -Xmx3000M ${argLine}</argLine>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -152,6 +149,7 @@
           </instructions>
         </configuration>
       </plugin>
+
       <!-- Code Coverage -->
       <plugin>
         <groupId>org.jacoco</groupId>
@@ -268,11 +266,9 @@
   <profiles>
     <profile>
       <id>release</id>
-      <properties>
-        <jdkVersion>1.5</jdkVersion>
-      </properties>
       <build>
         <plugins>
+
           <plugin>
             <!-- Package the source jar. -->
             <groupId>org.apache.maven.plugins</groupId>
@@ -287,6 +283,7 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
             <!-- Package the javadoc jar. -->
             <groupId>org.apache.maven.plugins</groupId>
@@ -315,6 +312,7 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
             <!-- GPG signing. -->
             <groupId>org.apache.maven.plugins</groupId>
@@ -330,6 +328,7 @@
               </execution>
             </executions>
           </plugin>
+
           <plugin>
             <!-- Publish the artifacts. -->
             <groupId>org.sonatype.plugins</groupId>
@@ -342,6 +341,7 @@
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>
+
         </plugins>
       </build>
     </profile>

--- a/src/com/amazon/ion/util/JarInfo.java
+++ b/src/com/amazon/ion/util/JarInfo.java
@@ -86,7 +86,7 @@ public final class JarInfo
     private void loadBuildProperties()
             throws IonException
     {
-        String file = getClass().getSimpleName() + ".properties";
+        String file = "/build.properties";
         try
         {
             Properties props = new Properties();

--- a/src/main/resources/build.properties
+++ b/src/main/resources/build.properties
@@ -1,0 +1,4 @@
+# These values are defined in pom.xml
+build.version=${pom.version}
+build.time=${build.time}
+build.name=${pom.name}

--- a/test/com/amazon/ion/util/JarInfoTest.java
+++ b/test/com/amazon/ion/util/JarInfoTest.java
@@ -15,95 +15,17 @@
 
 package com.amazon.ion.util;
 
-import com.amazon.ion.IonException;
-import com.amazon.ion.Timestamp;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.jar.Manifest;
-
-import static org.junit.Assert.*;
 
 public class JarInfoTest
 {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
-    private static String getAttributes(String manifestVersion)
-    {
-        return "Manifest-Version: " + manifestVersion + "\n";
-    }
-
-    private static String getIonJavaAttributes(String buildTime, String version)
-    {
-        return getAttributes("1.0")
-                + "Ion-Java-Build-Time: " + buildTime + "\n"
-                + "Ion-Java-Project-Version: " + version + "\n";
-    }
-
-    private static Manifest getManifest(String attributes) throws IOException
-    {
-        return new Manifest(new ByteArrayInputStream(attributes.getBytes("UTF-8")));
-    }
-
     @Test
-    public void testSingleManifest() throws Exception
+    public void testConstruction()
     {
-        String expectedBuildTime = "1984T";
-        String expectedVersion = "42.0";
-
-        Manifest manifest = getManifest(getIonJavaAttributes(expectedBuildTime, expectedVersion));
-        JarInfo info = new JarInfo(Collections.singletonList(manifest));
-
-        assertEquals(expectedVersion, info.getProjectVersion());
-        assertEquals(Timestamp.valueOf(expectedBuildTime), info.getBuildTime());
-    }
-
-    @Test
-    public void testMultipleManifests() throws Exception
-    {
-        String expectedBuildTime = "1984T";
-        String expectedVersion = "42.0";
-
-        List<Manifest> manifests = new ArrayList<Manifest>();
-        manifests.add(getManifest(getAttributes("1.0")));
-        manifests.add(getManifest(getIonJavaAttributes(expectedBuildTime, expectedVersion)));
-        manifests.add(getManifest(getAttributes("2.0")));
-
-        JarInfo info = new JarInfo(manifests);
-
-        assertEquals(expectedVersion, info.getProjectVersion());
-        assertEquals(Timestamp.valueOf(expectedBuildTime), info.getBuildTime());
-    }
-
-    @Test
-    public void testNoMatchingManifests() throws Exception
-    {
-        List<Manifest> manifests = new ArrayList<Manifest>();
-        manifests.add(getManifest(getAttributes("1.0")));
-        manifests.add(getManifest(getAttributes("2.0")));
-        manifests.add(getManifest(getAttributes("3.0")));
-
-        thrown.expect(IonException.class);
-        new JarInfo(manifests);
-    }
-
-    @Test
-    public void testConflictingManifests() throws Exception
-    {
-        List<Manifest> manifests = new ArrayList<Manifest>();
-        manifests.add(getManifest(getIonJavaAttributes("1984T", "42.0")));
-        manifests.add(getManifest(getAttributes("1.0")));
-        manifests.add(getManifest(getIonJavaAttributes("1985T", "43.0")));
-
-        thrown.expect(IonException.class);
-        new JarInfo(manifests);
+        // This attempts to load the properties file, but within IDE its
+        // not on the classpath.  At least we'll make sure the constructor
+        // doesn't die when the file is missing.
+        JarInfo info = new JarInfo();
     }
 
 }

--- a/test/com/amazon/ion/util/JarInfoTest.java
+++ b/test/com/amazon/ion/util/JarInfoTest.java
@@ -15,17 +15,31 @@
 
 package com.amazon.ion.util;
 
+import com.amazon.ion.Timestamp;
 import org.junit.Test;
 
-public class JarInfoTest
-{
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.matchesPattern;
+
+public class JarInfoTest {
     @Test
-    public void testConstruction()
-    {
-        // This attempts to load the properties file, but within IDE its
-        // not on the classpath.  At least we'll make sure the constructor
-        // doesn't die when the file is missing.
+    public void getBuildTime() {
         JarInfo info = new JarInfo();
+        Timestamp timestamp = info.getBuildTime();
+        // This test was written at the timestamp below, the loaded time should always be greater
+        Timestamp original = Timestamp.valueOf("2022-05-10T22:56:48Z");
+        assertThat(timestamp, greaterThan(original));
+    }
+
+    @Test
+    public void getProjectVersion() {
+        JarInfo info = new JarInfo();
+        String projectVersion = info.getProjectVersion();
+        // Semantic version MAJOR.MINOR.PATCH with optional -SNAPSHOT suffix
+        // Should always match our project version
+        String projectVersionPattern = "\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?";
+        assertThat(projectVersion, matchesPattern(projectVersionPattern));
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:* #432

*Description of changes:* Uses a `build.properties` file interpolated from Maven variables at build time to make project version and build time information available through `JarInfo`. This approach does not fail when multiple instances of `ion-java` are available on the classpath. 

For testing I built two different versions of `ion-java` with each with this patch applied (in `props`) or not (in `manifest`).
```plain
❯ ls props
ion-java-1.9.5-SNAPSHOT.jar  ion-java-1.9.99-SNAPSHOT.jar

❯ ls manifest
ion-java-1.9.5-SNAPSHOT.jar  ion-java-1.9.99-SNAPSHOT.jar
```

I created a test project `Hello.java` as so:
```java
import com.amazon.ion.util.JarInfo;

public class Hello {
  public static void main(String... a) {
    JarInfo info = new JarInfo();
    System.out.println("ion-java project version is: " +info.getProjectVersion());
  }
}
```

I checked all four permutations of property/manifest version mixing:
```plain
❯ mv manifest/ion-java-1.9.5-SNAPSHOT.jar props/ion-java-1.9.99-SNAPSHOT.jar mixed/

❯ mv props/ion-java-1.9.5-SNAPSHOT.jar manifest/ion-java-1.9.99-SNAPSHOT.jar backmixed/
```

```plain
❯ for i in manifest props mixed backmixed; do; printf "%10s: " "$i"; java -cp ./$i/*:. Hello; echo; done;
  manifest: Exception in thread "main" com.amazon.ion.IonException: Found multiple manifests with ion-java version info on the classpath.
	at com.amazon.ion.util.JarInfo.loadBuildProperties(JarInfo.java:114)
	at com.amazon.ion.util.JarInfo.<init>(JarInfo.java:73)
	at Hello.main(Hello.java:5)

     props: ion-java project version is: 1.9.5-SNAPSHOT

     mixed: ion-java project version is: 1.9.5-SNAPSHOT

 backmixed: ion-java project version is: 1.9.5-SNAPSHOT
```

Two manifest-using versions of `ion-java` was the only mutually incompatible solution, and in each of the other cases the first (alphabetically-listed) version of the jar won out. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
