### PR TITLE
Updates ion-java-performance-regression-detector workflow.

### DIFF
--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -43,9 +43,9 @@ jobs:
       - name: Generate test Ion Data
         run: |
           mkdir -p testData
-          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/benchmark/testStruct.isl testData/testStruct.10n
-          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/benchmark/testList.isl testData/testList.10n
-          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/benchmark/testNestedStruct.isl testData/testNestedStruct.10n
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/workflow/nestedStruct.isl testData/testStruct.10n
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/workflow/nestedList.isl testData/testList.10n
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/workflow/Sexpression.isl testData/testS-expression.10n
 
       - name: Upload test Ion Data to artifacts
         uses: actions/upload-artifact@v2
@@ -106,9 +106,9 @@ jobs:
         id: regression_result
         run: |
           result=true
-          cd benchmarkResults && for FILE in *; do message=$(java -jar /home/runner/work/ion-java/ion-java/ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar compare --benchmark-result-previous $FILE/previous.ion --benchmark-result-new $FILE/new.ion $FILE/report.ion | tee /dev/stderr) && if [ "$message" != "" ]; then result=false; fi; done
+          cd benchmarkResults && for FILE in *; do message=$(java -jar /home/runner/work/ion-java/ion-java/ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar compare --benchmark-result-previous $FILE/previous.ion --benchmark-result-new $FILE/new.ion $FILE/report.ion | tee /dev/stderr) && if [ "$message" != "no regression detected" ]; then result=false; fi; done
           echo "::set-output name=regression-result::$result"
-          echo $result
+          if [ "$result" = "true" ]; then echo "No regression detected!" >> $GITHUB_STEP_SUMMARY; fi
 
       - name: Upload comparison reports to the benchmark results directory
         uses: actions/upload-artifact@v2
@@ -120,4 +120,6 @@ jobs:
         env:
           regression_detect: ${{steps.regression_result.outputs.regression-result}}
         if: ${{ env.regression_detect == 'false' }}
-        run: exit 1
+        run: |
+          cd benchmarkResults && echo "| Benchmark command | GC Allocation Rate | Heap Usage | Speed |" >> $GITHUB_STEP_SUMMARY && echo "| ----------- | ----------- |----------- | ----------- |" >> $GITHUB_STEP_SUMMARY && for FILE in *; do regressionDetection=$(java -jar /home/runner/work/ion-java/ion-java/ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar compare --benchmark-result-previous $FILE/previous.ion --benchmark-result-new $FILE/new.ion $FILE/report.ion) && if [ "$regressionDetection" != "no regression detected" ]; then command=$(echo $FILE | sed "s/_/ /g") && read gc heapUsage speed <<< $( echo ${regressionDetection} | awk -F", " '{print $1" "$2" "$3}' ) && echo "|$command|$gc|$heapUsage|$speed|" >> $GITHUB_STEP_SUMMARY; fi; done
+          exit 1

--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -43,9 +43,9 @@ jobs:
       - name: Generate test Ion Data
         run: |
           mkdir -p testData
-          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/workflow/nestedStruct.isl testData/testStruct.10n
-          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/workflow/nestedList.isl testData/testList.10n
-          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/workflow/Sexpression.isl testData/testS-expression.10n
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/workflow/nestedStruct.isl testData/testStructs.10n
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/workflow/nestedList.isl testData/testLists.10n
+          java -jar ion-java-benchmark-cli/target/ion-java-benchmark-cli-0.0.1-SNAPSHOT-jar-with-dependencies.jar  generate -S 50000 --input-ion-schema ion-java-benchmark-cli/tst/com/amazon/ion/workflow/sexp.isl testData/testSexps.10n
 
       - name: Upload test Ion Data to artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*

This PR updates the test data of benchmarking process in order to provide more varieties of test data, and also improves the visualization of the results of the workflow, here are some explanations of these changes:

**Test data:**

Updates the ion schema files which are used for generating test ion data. After updating the schema, the workflow is able to use the data with more complicated structures to benchmark the performance of IonJava.
Here are the schema files:
- [Sexpression.isl](https://github.com/linlin-s/ion-java-benchmark-cli/blob/08cd9acefc94ce0afa9a9a0c44ca3c23e77b100f/tst/com/amazon/ion/workflow/Sexpression.isl)
- [nestedList.isl](https://github.com/linlin-s/ion-java-benchmark-cli/blob/08cd9acefc94ce0afa9a9a0c44ca3c23e77b100f/tst/com/amazon/ion/workflow/nestedList.isl)
- [nestedStruct.isl](https://github.com/linlin-s/ion-java-benchmark-cli/blob/08cd9acefc94ce0afa9a9a0c44ca3c23e77b100f/tst/com/amazon/ion/workflow/nestedStruct.isl)

**Visualization improvements:**

- Before updating:
After running ion-java-performance-regression-detection workflow, if there is no regression detected, no information will be displayed when we select the summary session. 
<img width="1291" alt="Screen Shot 2022-08-02 at 8 23 08 AM" src="https://user-images.githubusercontent.com/84819822/182411990-c2092578-da4e-48ff-aa0f-ec05baab8476.png">
     If the regression detected, users need to go back to the workflow to check which benchmark process has performance regression.
  <img width="1419" alt="Screen Shot 2022-08-02 at 8 39 23 AM" src="https://user-images.githubusercontent.com/84819822/182415411-46d87543-316c-4ab2-8562-0a55fef58284.png">

![regression-before](https://user-images.githubusercontent.com/84819822/182415504-0273b651-1e04-4424-afd0-181e9137fd3a.png)

- After updating:
If there is no regression detected, after clicking summary, the following information will be display.
<img width="1417" alt="Screen Shot 2022-08-02 at 8 31 40 AM" src="https://user-images.githubusercontent.com/84819822/182413887-9175b4de-3705-438b-ae89-55b3ef3f729f.png">
If there is regression detected, we are able to get the regression information directly from the job summary session. This table represents which benchmark process has regression and its relative regression scores.
<img width="1168" alt="Screen Shot 2022-08-02 at 9 10 00 AM" src="https://user-images.githubusercontent.com/84819822/182422001-2ff11d92-9441-4261-b8a0-6db82db6b4bd.png">

**Test:**

- Performance regression detected test:
This [commit](https://github.com/linlin-s/ion-java/actions/runs/2813292495) deletes the UTF8 String encoders to cause writing performance regression of IonJava.

- Performance regression not detected test:
This [commit](https://github.com/linlin-s/ion-java/actions/runs/2819542204) only updates the workflow file which will not influence the performance of IonJava.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
