### PR TITLE
Fixes a bug in the incremental reader that caused certain Decimal, BigDecimal, and BigInteger values to be read incorrectly in multi-reader contexts.

### DIFF
--- a/src/com/amazon/ion/impl/IonReaderBinaryIncremental.java
+++ b/src/com/amazon/ion/impl/IonReaderBinaryIncremental.java
@@ -1374,7 +1374,7 @@ class IonReaderBinaryIncremental implements IonReader, _Private_ReaderWriter, _P
     }
 
     // Scratch space for various byte sizes. Only for use while computing a single value.
-    private static final byte[][] SCRATCH_FOR_SIZE = new byte[][] {
+    private final byte[][] scratchForSize = new byte[][] {
         new byte[0],
         new byte[1],
         new byte[2],
@@ -1400,8 +1400,8 @@ class IonReaderBinaryIncremental implements IonReader, _Private_ReaderWriter, _P
         // Note: using reusable scratch buffers makes reading ints and decimals 1-5% faster and causes much less
         // GC churn.
         byte[] bytes = null;
-        if (length < SCRATCH_FOR_SIZE.length) {
-            bytes = SCRATCH_FOR_SIZE[length];
+        if (length < scratchForSize.length) {
+            bytes = scratchForSize[length];
         }
         if (bytes == null) {
             bytes = new byte[length];


### PR DESCRIPTION
*Description of changes:*

The incremental reader's implementation of `decimalValue`, `bigDecimalValue`, and `bigIntegerValue` use scratch space ([example](https://github.com/amzn/ion-java/blob/master/src/com/amazon/ion/impl/IonReaderBinaryIncremental.java#L1698)). `decimalValue` and `bigIntegerValue` use this scratch space for all values, while `bigDecimalValue` only use it for values with coefficients that consume at least 8 bytes.

The scratch space is [incorrectly declared static](https://github.com/amzn/ion-java/blob/master/src/com/amazon/ion/impl/IonReaderBinaryIncremental.java#L1377), which causes the same space to be used by multiple readers when they are accessed concurrently.

The fix for the bug is simply to make the scratch space non-static; the fact that it is static at all appears to have been a simple mistake and is not an essential aspect of the design.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
