### PR TITLE
Update ion-java-regression-detection workflow.

### DIFF
--- a/.github/workflows/ion-java-performance-regression-detector.yml
+++ b/.github/workflows/ion-java-performance-regression-detector.yml
@@ -20,12 +20,11 @@ jobs:
       - name: Checkout ion-java from the new commit.
         uses: actions/checkout@v2
         with:
-          fetch-depth: 2
-          submodules: recursive
-          path: ion-java
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: ion-java-new
 
       - name: Build ion-java from the new commit
-        run: cd ion-java && mvn clean install
+        run: cd ion-java-new && git submodule init && git submodule update && mvn clean install
 
       - name: Checkout ion-java-benchmark-cli
         uses: actions/checkout@v2
@@ -70,8 +69,15 @@ jobs:
       - name: Clean maven dependencies repository
         run : rm -r /home/runner/.m2
 
+      - name: Checkout the current commit
+        uses: actions/checkout@v2
+        with:
+          repository: amzn/ion-java
+          ref: master
+          path: ion-java
+
       - name: Build ion-java from the previous commit
-        run: cd ion-java && git checkout HEAD^ && git submodule update --recursive && mvn clean install
+        run: cd ion-java && git submodule init && git submodule update && mvn clean install
 
       - name: Build ion-java-benchmark-cli
         run: cd ion-java-benchmark-cli && mvn clean install


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amzn/ion-java/issues/448
*Description of changes:*
The purpose of having `ion-java-performance-regression-detection` workflow is to detect if the incoming commit has performance regression comparing to the existing commit on the top of `master` branch. Before updating the workflow, the workflow didn’t checkout the `pull_request` branch to fetch the incoming commit and compared the performance between the wrong commits. This PR fixes the issue by updating the `checkout` repository steps.
- Step: Checkout ion-java from the new commit.
When `checkout` the repository, refer to the `pull_request` branch to get the `HEAD` commit.
- Step: Build ion-java from the new commit
Add `git submodule init` and `git submodule update` to initialize the submodule to avoid test failure when building `ion-java`.
- Step: Checkout the current commit.
This step is added to fetch the current `HEAD` commit of the `amzn/ion-java: master` repository.

Here is the example, when open a `pull_request`, the commits that have been fetched by this workflow are:
<img width="566" alt="new" src="https://user-images.githubusercontent.com/84819822/190212908-e7b3d617-c694-48a1-abd5-3ec756bd637d.png">
<img width="591" alt="current" src="https://user-images.githubusercontent.com/84819822/190212948-50df5971-17a4-4969-ad3f-07e2b55b28bc.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
