### PR TITLE
Adds workflows to create ion-java prerelease on GitHub.

### DIFF
--- a/.github/workflows/create-gitHub-prerelease-after-fast-forward-check.yml
+++ b/.github/workflows/create-gitHub-prerelease-after-fast-forward-check.yml
@@ -51,7 +51,7 @@ jobs:
           cd current_release/target
           echo "path=$(readlink -f $(ls *.jar))" >> $GITHUB_ENV
           echo "file_name=$(ls *.jar)" >> $GITHUB_ENV
-          echo "version_number=$(echo $(ls *.jar) | cut -d'-' -f3)" >> $GITHUB_ENV
+          cd .. && echo "version_number=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
 
       - name: Create new release
         id: create_new_release

--- a/.github/workflows/create-gitHub-prerelease-after-fast-forward-check.yml
+++ b/.github/workflows/create-gitHub-prerelease-after-fast-forward-check.yml
@@ -1,11 +1,39 @@
 name: Create GitHub prerelease after fast-forward check
-on: workflow_dispatch
+on:
+  pull_request:
+    types:
+      - closed
 
 jobs:
+  check-version-change:
+    if: github.event.pull_request.merged == true
+    name: check-version-change
+    runs-on: ubuntu-latest
+    outputs:
+      output1: ${{ steps.check-version-change.outputs.result }}
+    steps:
+      - name: Checkout the current repository master branch
+        uses: actions/checkout@v3
+        with:
+          repository: amzn/ion-java
+          ref: master
+          fetch-depth: 2
+          path: ion-java-current
+
+      - name: Check whether the pull request contains version number bump
+        id: check-version-change
+        run: |
+          cd ion-java-current
+          versionNew=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          git reset --hard HEAD^
+          versionPrevious=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          if [[ $versionNew != $versionPrevious ]]; then echo "::set-output name=result::pass"; else echo "::set-output name=result::failed"; fi
+
   prerelease:
     name: prerelease
+    needs: check-version-change
+    if: ${{ needs.check-version-change.outputs.output1 == 'pass' }}
     runs-on: ubuntu-latest
-
     steps:
       - name: Access to the incoming release
         uses: actions/checkout@v3
@@ -16,9 +44,7 @@ jobs:
       - name: Build ion-java
         run: |
           cd current_release
-          git submodule init
-          git submodule update
-          mvn clean install
+          mvn clean install -DskipTests
 
       - name: Get the parameters of executable jar
         run: |

--- a/.github/workflows/create-gitHub-prerelease-after-fast-forward-check.yml
+++ b/.github/workflows/create-gitHub-prerelease-after-fast-forward-check.yml
@@ -1,0 +1,48 @@
+name: Create GitHub prerelease after fast-forward check
+on: workflow_dispatch
+
+jobs:
+  prerelease:
+    name: prerelease
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Access to the incoming release
+        uses: actions/checkout@v3
+        with:
+          repository: amzn/ion-java
+          path: current_release
+
+      - name: Build ion-java
+        run: |
+          cd current_release
+          git submodule init
+          git submodule update
+          mvn clean install
+
+      - name: Get the parameters of executable jar
+        run: |
+          cd current_release/target
+          echo "path=$(readlink -f $(ls *.jar))" >> $GITHUB_ENV
+          echo "file_name=$(ls *.jar)" >> $GITHUB_ENV
+          echo "version_number=$(echo $(ls *.jar) | cut -d'-' -f3)" >> $GITHUB_ENV
+
+      - name: Create new release
+        id: create_new_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ env.version_number }}
+          release_name: v${{ env.version_number }}
+          prerelease: true
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_new_release.outputs.upload_url }}
+          asset_path: ${{ env.path }}
+          asset_name: ${{ env.file_name }}
+          asset_content_type: application/zip

--- a/.github/workflows/version-bump-and-fast-forward-check.yml
+++ b/.github/workflows/version-bump-and-fast-forward-check.yml
@@ -75,7 +75,7 @@ jobs:
           if git merge-base --is-ancestor ${{env.last_release_commit_id}} ${{env.current_release_commit_id}}; then echo "Trigger github release"; else exit 1; fi
 
       - name: comment
-        if: steps.build.outputs.exit_code == 0
+        if: ${{ success() }}
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -83,7 +83,7 @@ jobs:
             This PR passes version bump check and fast-forward check, please double check the version number and merge this PR. After merging this PR, "Create gitHub prerelease after fast-forward check" workflow will be automatically triggered to create prerelease.
 
       - name: comment
-        if: steps.build.outputs.exit_code == 1
+        if: ${{ failure() }}
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/version-bump-and-fast-forward-check.yml
+++ b/.github/workflows/version-bump-and-fast-forward-check.yml
@@ -5,6 +5,8 @@ jobs:
   check-version-bump:
     name: check-version-bump
     runs-on: ubuntu-latest
+    outputs:
+      output1: ${{ steps.check-version-change.outputs.result }}
     steps:
       - name: Switch to the branch of the pull request
         uses: actions/checkout@v3
@@ -20,31 +22,19 @@ jobs:
           path: ion-java-current
 
       - name: Check whether the pull request contains version number bump
+        id: check-version-change
         run: |
           cd /home/runner/work/ion-java/ion-java/ion-java-new
           versionNew=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
           commitID=$(git rev-parse HEAD)
           cd /home/runner/work/ion-java/ion-java/ion-java-current
           versionCurrent=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          if [[ $versionNew != $versionCurrent ]]; then echo "version bump check pass"; else exit 1; fi 
-
-  comment-when-version-number-check-failed:
-    needs: check-version-bump
-    if: ${{ failure() }}
-    runs-on: ubuntu-latest
-    name: comment-when-version-number-check-failed
-    steps:
-      - name: Create comment
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            This PR doesn't contain version number bump and will not trigger the ion-java GitHub prerelease process.
+          if [[ $versionNew != $versionCurrent ]]; then echo "::set-output name=result::pass"; else echo "::set-output name=result::failed"; fi
 
   fast-forward-check:
     needs: check-version-bump
     name: fast-forward-check
-    if: ${{ success() }}
+    if: ${{ needs.check-version-bump.outputs.output1 == 'pass' }}
     runs-on: ubuntu-latest
     steps:
       - name: Access to the last release
@@ -82,7 +72,7 @@ jobs:
       - name: Check whether the incoming release is fast-forward compared to the last release
         run: |
           cd ion-java-new 
-          if git merge-base --is-ancestor ${{env.current_release_commit_id}} ${{env.current_release_commit_id}}; then echo "Trigger github release"; else exit 1; fi 
+          if git merge-base --is-ancestor ${{env.last_release_commit_id}} ${{env.current_release_commit_id}}; then echo "Trigger github release"; else exit 1; fi
 
       - name: comment
         if: steps.build.outputs.exit_code == 0
@@ -90,7 +80,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            This PR passes version bump check and fast-forward check, please double check the version number and merge this PR. After merging this PR, please trigger "Create gitHub prerelease after fast-forward check" workflow manually to create prerelease.
+            This PR passes version bump check and fast-forward check, please double check the version number and merge this PR. After merging this PR, "Create gitHub prerelease after fast-forward check" workflow will be automatically triggered to create prerelease.
 
       - name: comment
         if: steps.build.outputs.exit_code == 1

--- a/.github/workflows/version-bump-and-fast-forward-check.yml
+++ b/.github/workflows/version-bump-and-fast-forward-check.yml
@@ -1,0 +1,101 @@
+name: Version-bump-and-fast-forward-check
+on: [pull_request]
+
+jobs:
+  check-version-bump:
+    name: check-version-bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Switch to the branch of the pull request
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: ion-java-new
+
+      - name: Checkout the current repository master branch
+        uses: actions/checkout@v3
+        with:
+          repository: amzn/ion-java
+          ref: master
+          path: ion-java-current
+
+      - name: Check whether the pull request contains version number bump
+        run: |
+          cd /home/runner/work/ion-java/ion-java/ion-java-new
+          versionNew=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          commitID=$(git rev-parse HEAD)
+          cd /home/runner/work/ion-java/ion-java/ion-java-current
+          versionCurrent=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          if [[ $versionNew != $versionCurrent ]]; then echo "version bump check pass"; else exit 1; fi 
+
+  comment-when-version-number-check-failed:
+    needs: check-version-bump
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    name: comment-when-version-number-check-failed
+    steps:
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            This PR doesn't contain version number bump and will not trigger the ion-java GitHub prerelease process.
+
+  fast-forward-check:
+    needs: check-version-bump
+    name: fast-forward-check
+    if: ${{ success() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Access to the last release
+        uses: oprypin/find-latest-tag@v1
+        id: check_last_release
+        with:
+          repository: amzn/ion-java
+          releases-only: true
+
+      - name: Checkout the last release
+        uses: actions/checkout@v3
+        with:
+          repository: amzn/ion-java
+          ref: ${{ steps.check_last_release.outputs.tag }}
+          path: last-release
+
+      - name: Get the commit id of the last release
+        run: |
+          cd last-release
+          echo "last_release_commit_id=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Access to the incoming release
+        uses: actions/checkout@v3
+        with:
+          repository: amzn/ion-java
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: ion-java-new
+
+      - name: Get the commit id of the incoming release
+        run: |
+          cd ion-java-new
+          echo "current_release_commit_id=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo $(git rev-parse HEAD)
+
+      - name: Check whether the incoming release is fast-forward compared to the last release
+        run: |
+          cd ion-java-new 
+          if git merge-base --is-ancestor ${{env.current_release_commit_id}} ${{env.current_release_commit_id}}; then echo "Trigger github release"; else exit 1; fi 
+
+      - name: comment
+        if: steps.build.outputs.exit_code == 0
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            This PR passes version bump check and fast-forward check, please double check the version number and merge this PR. After merging this PR, please trigger "Create gitHub prerelease after fast-forward check" workflow manually to create prerelease.
+
+      - name: comment
+        if: steps.build.outputs.exit_code == 1
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            This PR is not fast-forward compared to the last release, please check.


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
This PR adds two workflows to create ion-java GitHub pre-release. In the workflow, there are some steps to help check version number bump and also check whether the new release is fast-forward compared to the last release. Here are some explanation and examples about how these workflows work.

- Version-bump-and-fast-forward-check:
This workflow will be triggered when there is a PR created. The first part of this workflow is to check whether this new PR contains version number change. If there is no version number bump included in this PR, the workflow will be executed successfully without executing the steps of checking fast-forward. Here is the example: https://github.com/linlin-s/ion-java/pull/23
<img width="1109" alt="image" src="https://user-images.githubusercontent.com/84819822/196347618-0730405f-959d-4947-b381-5cfbdfe74387.png">

- If there is version number bump in this PR, the workflow will trigger the job of fast-forward check. If the commit id of the last release  is ancestor of the incoming PR commit id, the fast-forward check will be passed. When both version number bump check and fast-forward check pass, the workflow will throw a comment on this PR:
https://github.com/linlin-s/ion-java/pull/24
<img width="943" alt="image" src="https://user-images.githubusercontent.com/84819822/196351554-300e75a4-98ff-437b-a613-c4a9ecb9d9e7.png">

Here is an example of when version bump check passes but the fast-forward check doesn't: 
https://github.com/linlin-s/ion-java/pull/24

<img width="958" alt="image" src="https://user-images.githubusercontent.com/84819822/196351904-c5bae8e9-b4b1-4885-8cc0-5b5c6365da57.png">

- Create GitHub prerelease after fast-forward check:
This workflow contains two jobs, and it will be triggered whenever there is a PR get merged. The first job is to check the version number bump. If there is no version number change, the next job -- create prerelease will be skipped and the workflow will be executed successfully. Here is an example:
[](https://github.com/linlin-s/ion-java/actions/runs/3270949287)
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/84819822/196348373-b666ae48-dcaf-4a6f-b3cf-2479a12d7067.png">
If the version bump check passed, the prerelease of the new version of ion-java will be created. It will build the new version of ion-java then upload the executable jar file to the prerelease assets. Then developers can keep editing the release note and publish the release, Here is an example of prerelease generated by triggering this workflow. 

https://github.com/linlin-s/ion-java/actions/runs/3271080245
<img width="910" alt="image" src="https://user-images.githubusercontent.com/84819822/196353286-f49f57ac-c17a-491d-a729-d749ee59ba98.png">
https://github.com/linlin-s/ion-java/releases/tag/v1.9.8
<img width="1284" alt="image" src="https://user-images.githubusercontent.com/84819822/196353209-967311c9-52b0-432b-9ef0-1cc77d0b08dc.png">



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
