### PR TITLE
Adds Software BOM to releases

### DIFF
--- a/.github/workflows/publish-release-artifacts.yml
+++ b/.github/workflows/publish-release-artifacts.yml
@@ -48,7 +48,7 @@ jobs:
           submodules: recursive
       - uses: gradle/gradle-build-action@v2
         with:
-          arguments: build
+          arguments: build cyclonedxBom
       - name: Upload Jar to GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -58,4 +58,5 @@ jobs:
         # It may also need to be able to upload more than one file.
         run: |
           gh release upload "v$(<project.version)" "build/libs/ion-java-$(<project.version).jar"
+          gh release upload "v$(<project.version)" "build/reports/bom.json"
   # TODO: Add `publish-to-maven-central` job

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     `maven-publish`
     jacoco
     signing
+    id("org.cyclonedx.bom") version "1.7.2"
     // TODO: static analysis. E.g.:
     // id("com.diffplug.spotless") version "6.11.0"
     // id("com.github.spotbugs") version "4.8.0"
@@ -106,6 +107,11 @@ tasks {
 
     withType<Sign> {
         setOnlyIf { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
+    }
+
+    cyclonedxBom {
+        setIncludeConfigs(listOf("runtimeClasspath"))
+        setSkipConfigs(listOf("compileClasspath", "testCompileClasspath"))
     }
 }
 


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Adds [Gradle plugin](https://github.com/CycloneDX/cyclonedx-gradle-plugin) for [CycloneDX](https://cyclonedx.org/) so that we can automatically generate a Software Bill of Materials (SBOM) that meets the National Telecommunications and Information Administration (NTIA) requirements.
* Updates the release workflow to generate and upload the BOM to the GitHub release.
  * I looked around for how to distribute the SBOM, but as far as I can tell, the NTIA doesn't have any specific guidance for that. The [executive order](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/) says we should "[provide] a purchaser a Software Bill of Materials (SBOM) for each product directly or [publish] it on a public website", so unless/until there is more specific guidance, I think that uploading the SBOM to the GitHub release is a good first step.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
